### PR TITLE
Feature/GitHub packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"

--- a/packages/inputs/package.json
+++ b/packages/inputs/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"

--- a/packages/observer/package.json
+++ b/packages/observer/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -10,7 +10,8 @@
   "author": "Justin Schroeder <justin@wearebraid.com>",
   "license": "UNLICENSED",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "registry":"https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Relevant docs here: 
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#publishing-multiple-packages-to-the-same-repository

Gist is:
1. i've logged into `npm` on the command line using `npm login --scope=@formkit --registry=https://npm.pkg.github.com`. it'll prompt you for the following: Username: `GITHUB USERNAME`, Password: `GITHUB PERSONAL ACCESS TOKEN` (this token needs `package:read`, `package:write`, and `package:delete` permissions in our case), Email: `PUBLIC-EMAIL-ADDRESS`
2. I've added `repository` and `publishConfig:registry` fields to each package's `package.json`.
3. When we publish now, the values in the `package.json` files should take effect and prevent accidental publishing to NPM.

