### PR TITLE
Ensure generateClassList doesn't try to do string operations on undefined

### DIFF
--- a/packages/core/__tests__/classes.spec.ts
+++ b/packages/core/__tests__/classes.spec.ts
@@ -4,7 +4,9 @@ import { generateClassList } from '../src/classes'
 describe('class list generation', () => {
   it('returns null if generateClassList() is called without a user supplied class list', () => {
     const node = createNode()
-    expect(generateClassList(node, 'outer', {'formkit-outer': true, 'mb-5': true})).toBe('formkit-outer mb-5')
+    expect(
+      generateClassList(node, 'outer', { 'formkit-outer': true, 'mb-5': true })
+    ).toBe('formkit-outer mb-5')
     expect(generateClassList(node, 'label')).toBe(null)
   })
 })

--- a/packages/core/src/classes.ts
+++ b/packages/core/src/classes.ts
@@ -51,16 +51,14 @@ export function generateClassList(
   property: string,
   ...args: Record<string, boolean>[]
 ): string | null {
-  let combinedClassList:Record<string, boolean> = {}
-  if (args && args.length) {
-    combinedClassList = args.reduce((finalClassList, currentClassList) => {
-      const { $reset, ...classList } = currentClassList
-      if ($reset) {
-        return classList
-      }
-      return Object.assign(finalClassList, classList)
-    }, {})
-  }
+  const combinedClassList = args.reduce((finalClassList, currentClassList) => {
+    if (!currentClassList) return finalClassList
+    const { $reset, ...classList } = currentClassList
+    if ($reset) {
+      return classList
+    }
+    return Object.assign(finalClassList, classList)
+  }, {})
 
   return (
     Object.keys(


### PR DESCRIPTION
This should prevent issues with arguments passed to `generateClassList()` trying to do string operations on undefined. I've separately updated the Tailwind example in the docs content.

Could use some guidance on getting proper test coverage for this change. I've added a test to make sure `generateClassList()` returns a string or null, but I'm not sure how to best author a test that proves it gracefully handles `undefined` as a value for `...args`.