### PR TITLE
Release/beta.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 FormKit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
-<p align="center"><a href="https://www.formkit.com" target="_blank" rel="noopener noreferrer"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo.png" alt="FormKit Logo"></a></p>
+![FormKit Logo](https://cdn.formk.it/brand-assets/formkit-logo.png#gh-light-mode-only)
+![FormKit Logo](https://cdn.formk.it/brand-assets/formkit-logo-white.png#gh-dark-mode-only)
 
-<p align="center">
-  <a href="https://circleci.com/gh/formkit/formkit/tree/master"><img title="CircleCI" alt="CI build status" src="https://circleci.com/gh/formkit/formkit/tree/master.svg?style=shield&circle-token=d6f469a71ef441701050fb5634ace5088111e0d1"></a>
-</p>
+<a href="https://circleci.com/gh/formkit/formkit/tree/master"><img title="CircleCI" alt="CI build status" src="https://circleci.com/gh/formkit/formkit/tree/master.svg?style=shield&circle-token=d6f469a71ef441701050fb5634ace5088111e0d1"></a>
 
-<p align="center">
-  <a href="https://formkit.com">Documentation website</a>
-</p>
+<a href="https://formkit.com">Documentation website</a>
 
 # FormKit (Beta)
 <h2>Industry-leading form development. 10x faster. For <img width="20" style="vertical-align:middle;" src="https://cdn.formk.it/vendor-logos/vue-logo.png"> Vue 3.</h2>
 
 FormKit is a form authoring framework for Vue developers that makes building high quality production-ready forms 10x faster. It is easy-to-learn and ships with production-ready scaffolding like inputs, validation rules, and error handling. To learn more check out the documentation website at: [formkit.com](https://www.formkit.com).
 
-<p align="center"><a href="https://formkit.com"><img width="190" src="https://cdn.formk.it/brand-assets/fk-read-docs.png" /></a></p>
+<a href="https://formkit.com"><img width="190" src="https://cdn.formk.it/brand-assets/fk-read-docs.png" /></a>
 
 <table style="width: 100%;">
 	<tr>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![FormKit Logo](https://cdn.formk.it/brand-assets/formkit-logo.png#gh-light-mode-only)
-![FormKit Logo](https://cdn.formk.it/brand-assets/formkit-logo-white.png#gh-dark-mode-only)
+![FormKit Logo](https://cdn.formk.it/brand-assets/formkit-logo.png#gh-light-mode-only)![FormKit Logo](https://cdn.formk.it/brand-assets/formkit-logo-white.png#gh-dark-mode-only)
 
 <a href="https://circleci.com/gh/formkit/formkit/tree/master"><img title="CircleCI" alt="CI build status" src="https://circleci.com/gh/formkit/formkit/tree/master.svg?style=shield&circle-token=d6f469a71ef441701050fb5634ace5088111e0d1"></a>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://www.formkit.com" target="_blank" rel="noopener noreferrer"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo.png" alt="FormKit Logo"></a></p>
+<p align="center"><a href="https://www.formkit.com" target="_blank" rel="noopener noreferrer"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo.png#gh-light-mode-only" alt="FormKit Logo"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo-white.png#gh-dark-mode-only" alt="FormKit Logo"></a></p>
 
 <p align="center">
   <a href="https://circleci.com/gh/formkit/formkit/tree/master"><img title="CircleCI" alt="CI build status" src="https://circleci.com/gh/formkit/formkit/tree/master.svg?style=shield&circle-token=d6f469a71ef441701050fb5634ace5088111e0d1"></a>
@@ -8,7 +8,7 @@
   <a href="https://formkit.com">Documentation website</a>
 </p>
 
-# FormKit (private Beta)
+# FormKit (Beta)
 <h2>Industry-leading form development. 10x faster. For <img width="20" style="vertical-align:middle;" src="https://cdn.formk.it/vendor-logos/vue-logo.png"> Vue 3.</h2>
 
 FormKit is a form authoring framework for Vue developers that makes building high quality production-ready forms 10x faster. It is easy-to-learn and ships with production-ready scaffolding like inputs, validation rules, and error handling. To learn more check out the documentation website at: [formkit.com](https://www.formkit.com).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
-![FormKit Logo](https://cdn.formk.it/brand-assets/formkit-logo.png#gh-light-mode-only)![FormKit Logo](https://cdn.formk.it/brand-assets/formkit-logo-white.png#gh-dark-mode-only)
+<p align="center">
+  <a href="https://www.formkit.com#gh-light-mode-only" target="_blank" rel="noopener noreferrer"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo.png" alt="FormKit Logo"></a>
+  <a href="https://www.formkit.com#gh-dark-mode-only" target="_blank" rel="noopener noreferrer"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo-white.png" alt="FormKit Logo"></a>
+</p>
 
-<a href="https://circleci.com/gh/formkit/formkit/tree/master"><img title="CircleCI" alt="CI build status" src="https://circleci.com/gh/formkit/formkit/tree/master.svg?style=shield&circle-token=d6f469a71ef441701050fb5634ace5088111e0d1"></a>
+<p align="center">
+  <a href="https://circleci.com/gh/formkit/formkit/tree/master"><img title="CircleCI" alt="CI build status" src="https://circleci.com/gh/formkit/formkit/tree/master.svg?style=shield&circle-token=d6f469a71ef441701050fb5634ace5088111e0d1"></a>
+</p>
 
-<a href="https://formkit.com">Documentation website</a>
+<p align="center">
+  <a href="https://formkit.com">Documentation website</a>
+</p>
 
 # FormKit (Beta)
 <h2>Industry-leading form development. 10x faster. For <img width="20" style="vertical-align:middle;" src="https://cdn.formk.it/vendor-logos/vue-logo.png"> Vue 3.</h2>
 
 FormKit is a form authoring framework for Vue developers that makes building high quality production-ready forms 10x faster. It is easy-to-learn and ships with production-ready scaffolding like inputs, validation rules, and error handling. To learn more check out the documentation website at: [formkit.com](https://www.formkit.com).
 
-<a href="https://formkit.com"><img width="190" src="https://cdn.formk.it/brand-assets/fk-read-docs.png" /></a>
+<p align="center"><a href="https://formkit.com"><img width="190" src="https://cdn.formk.it/brand-assets/fk-read-docs.png" /></a></p>
 
 <table style="width: 100%;">
 	<tr>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://www.formkit.com" target="_blank" rel="noopener noreferrer"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo.png#gh-light-mode-only" alt="FormKit Logo"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo-white.png#gh-dark-mode-only" alt="FormKit Logo"></a></p>
+<p align="center"><a href="https://www.formkit.com" target="_blank" rel="noopener noreferrer"><img width="200" src="https://cdn.formk.it/brand-assets/formkit-logo.png" alt="FormKit Logo"></a></p>
 
 <p align="center">
   <a href="https://circleci.com/gh/formkit/formkit/tree/master"><img title="CircleCI" alt="CI build status" src="https://circleci.com/gh/formkit/formkit/tree/master.svg?style=shield&circle-token=d6f469a71ef441701050fb5634ace5088111e0d1"></a>

--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -1,8 +1,8 @@
 import { createApp } from 'vue'
 import { plugin, defaultConfig, createInput } from '@formkit/vue'
-import { createRouter, createWebHashHistory } from 'vue-router'
 import { de, fr } from '@formkit/i18n'
-import '@formkit/themes/dist/genesis/theme.css'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import '@formkit/themes/genesis'
 import './assets/styles/main.scss'
 import App from './vue/App.vue'
 import BasicForm from './vue/examples/BasicForm.vue'
@@ -31,6 +31,10 @@ app.use(plugin, config)
 const router = createRouter({
   history: createWebHashHistory(),
   routes: [
+    {
+      path: '/',
+      component: BasicForm,
+    },
     {
       path: '/basic-form',
       component: BasicForm,

--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -11,6 +11,7 @@ import CurrencyInput from './vue/examples/custom-input/CurrencyInput.vue'
 import FileUpload from './vue/examples/FileUpload.vue'
 import GroupInput from './vue/examples/Group.vue'
 import TSXExample from './vue/examples/TSXExample.tsx'
+import ModifySchema from './vue/examples/ModifySchema.vue'
 
 const myInput = createInput(CurrencyInput)
 
@@ -54,6 +55,10 @@ const router = createRouter({
     {
       path: '/tsx',
       component: TSXExample,
+    },
+    {
+      path: '/plugin-schema',
+      component: ModifySchema,
     },
   ],
 })

--- a/examples/src/vue/Navigation.vue
+++ b/examples/src/vue/Navigation.vue
@@ -26,6 +26,11 @@
           TSX Example
         </router-link>
       </li>
+      <li>
+        <router-link to="/plugin-schema">
+          Modify schema with plugin
+        </router-link>
+      </li>
     </ul>
   </nav>
 </template>

--- a/examples/src/vue/examples/BasicForm.vue
+++ b/examples/src/vue/examples/BasicForm.vue
@@ -19,6 +19,7 @@
       name="fruit"
       type="select"
       label="Favorite pie"
+      placeholder="Select some pie"
       :options="{
         apple: 'Apple pie',
         pumpkin: 'Pumpkin pie',

--- a/examples/src/vue/examples/FileUpload.vue
+++ b/examples/src/vue/examples/FileUpload.vue
@@ -17,6 +17,7 @@
       name="single_file"
       label="Single file"
       help="You can only select one file"
+      @change="changed"
     />
     <FormKit
       type="file"
@@ -34,4 +35,8 @@ import { ref } from 'vue'
 const values = ref({
   another_file: [ { name: 'pizza.jpg' } ]
 })
+
+function changed () {
+  alert('@change event fired')
+}
 </script>

--- a/examples/src/vue/examples/ModifySchema.vue
+++ b/examples/src/vue/examples/ModifySchema.vue
@@ -1,0 +1,59 @@
+<template>
+  <h2>Tell us a little about yourself</h2>
+  <FormKit
+    type="form"
+    :plugins="[pluginRemoveInnerWrapper]"
+  >
+    <FormKit
+      label="I like sports"
+      type="checkbox"
+    />
+    <FormKit
+      label="I like music"
+      type="checkbox"
+    />
+    <FormKit
+      label="Your Email"
+      type="email"
+    />
+  </FormKit>
+</template>
+
+<script lang="ts" setup>
+import { FormKitPlugin, FormKitExtendableSchemaRoot } from '@formkit/core'
+
+const pluginRemoveInnerWrapper: FormKitPlugin = (inputNode) => {
+  inputNode.on('created', ({ payload: node }) => {
+    // Ensure we only tap into checkboxes:
+    if (
+      node.props?.type === 'checkbox' &&
+      typeof node.props.definition.schema === 'function'
+    ) {
+      // Lets retain our own copy of this definition to prevent deep object referencing
+      const definition = { ...node.props.definition }
+      // Store the original schema
+      const schema = definition.schema
+
+      // We replace the schema with our own higher-order-function
+      const newSchema: FormKitExtendableSchemaRoot = function (extensions = {}) {
+        if (!extensions.inner) {
+          extensions.inner = {
+            attrs: {
+              style: {
+                backgroundColor: 'red'
+              }
+            }
+          }
+        }
+        // Finally we call the original schema, with our extensions applied
+        return schema(extensions)
+      }
+      // Now replace the schema
+      definition.schema = newSchema
+
+      // Now we replace the input definition
+      node.props.definition = definition
+    }
+  })
+}
+</script>

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "@aws-sdk/client-cloudfront": "^3.45.0",
     "@aws-sdk/client-s3": "^3.45.0",
     "@microsoft/api-extractor": "^7.18.4",
-    "@nuxt/kit": "^0.8.1-edge",
-    "@nuxt/kit-edge": "^3.0.0-27398533.8edd481",
+    "@nuxt/kit": "npm:@nuxt/kit-edge@latest",
     "@nuxt/module-builder": "^0.1.7",
     "@nuxtjs/eslint-config-typescript": "^8.0.0",
     "@rollup/plugin-node-resolve": "^13.0.5",
@@ -33,7 +32,7 @@
     "fs-extra": "^10.0.0",
     "glob": "^7.2.0",
     "jest": "^27.0.3",
-    "nuxt3": "^3.0.0-27396610.ed4f4f5",
+    "nuxt3": "^3.0.0-27415326.3c563fa",
     "ora": "^5.4.1",
     "postcss": "^8.3.11",
     "postcss-import": "^14.0.2",
@@ -61,7 +60,9 @@
     "local": "node scripts/cli.mjs --script local",
     "cli": "node scripts/cli.mjs",
     "dev": "vite --config ./examples/vite.config.ts",
-    "deploy": "node scripts/cli.mjs --script=deploy"
+    "deploy": "node scripts/cli.mjs --script=deploy",
+    "nuxt-pack": "nuxt-module-build packages/nuxt",
+    "nuxt-dev": "nuxi dev packages/nuxt/playground"
   },
   "dependencies": {},
   "size-limit": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ts-jest": "27.0.3",
     "typescript": "4.4.3",
     "vite": "^2.4.4",
-    "vue": "3.2.29"
+    "vue": "^3.0.0"
   },
   "license": "UNLICENSED",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,29 @@
 {
   "name": "@formkit/core",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "The framework agnostic core of FormKit",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/core"
+  },
   "types": "dist/index.d.ts",
   "contributors": [
     "Justin Schroeder <justin@formkit.com>"
@@ -13,7 +32,6 @@
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {
     "@formkit/utils": "1.0.0-beta.2"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,7 +27,7 @@ export {
 export {
   FormKitLedger,
   FormKitCounterCondition,
-  FormKitCounter
+  FormKitCounter,
 } from './ledger'
 
 /**
@@ -104,3 +104,8 @@ export * from './registry'
  * The root configuration creator.
  */
 export { createConfig } from './config'
+
+/**
+ * Sets error store messages on inputs.
+ */
+export { setErrors } from './setErrors'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,3 +109,8 @@ export { createConfig } from './config'
  * Sets error store messages on inputs.
  */
 export { setErrors } from './setErrors'
+
+/**
+ * Programmatically submits a form by the id.
+ */
+export { submitForm } from './submitForm'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,11 @@ export {
 /**
  * The FormKit ledger.
  */
-export { FormKitLedger } from './ledger'
+export {
+  FormKitLedger,
+  FormKitCounterCondition,
+  FormKitCounter
+} from './ledger'
 
 /**
  * Export dispatcher typings.
@@ -68,6 +72,7 @@ export {
   FormKitSchemaDOMNode,
   FormKitSchemaFormKit,
   FormKitSchemaNode,
+  FormKitSchemaProps,
   FormKitSchemaTextNode,
   isComponent,
   isConditional,

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -398,6 +398,16 @@ export interface FormKitFrameworkContext {
      */
     dirty: boolean
     /**
+     * If the input has explicit errors placed on it, or in the case of a group,
+     * list, or form, this is true if any children have errors on them.
+     */
+    errors: boolean
+    /**
+     * True when the input has validation rules. Has nothing to do with the
+     * state of those validation rules.
+     */
+    rules: boolean
+    /**
      * If the form has been submitted.
      */
     submitted: boolean
@@ -407,11 +417,6 @@ export interface FormKitFrameworkContext {
      * of all its children.
      */
     valid: boolean
-    /**
-     * If the input has explicit errors placed on it, or in the case of a group,
-     * list, or form, this is true if any children have errors on them.
-     */
-    errors: boolean
     /**
      * If the validation-visibility has been satisfied and any validation
      * messages should be displayed.

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -403,7 +403,7 @@ export interface FormKitFrameworkContext {
      * Or:
      * - The input has no validation rules
      * - The input has no errors
-     * - The input is dirty
+     * - The input is dirty and has a value
      *
      * This is not intended to be used on forms/groups/lists but instead on
      * individual inputs. Imagine placing a green checkbox next to each input

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1688,8 +1688,9 @@ function nodeInit(node: FormKitNode, options: FormKitOptions): FormKitNode {
   // Register the node globally if someone explicitly gave it an id
   if (options.props?.id) register(node)
   // Our node is finally ready, emit it to the world
+  node.emit('created', node)
   node.isCreated = true
-  return node.emit('created', node)
+  return node
 }
 
 /**

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -331,28 +331,102 @@ export interface FormKitContext {
  */
 export interface FormKitFrameworkContext {
   [index: string]: unknown
+  /**
+   * The current "live" value of the input. Not debounced.
+   */
   _value: any
+  /**
+   * An object of attributes that (generally) should be applied to the root
+   * <input> element.
+   */
   attrs: Record<string, any>
+  /**
+   * Classes to apply on the various sections.
+   */
   classes: Record<string, string>
+  /**
+   * Event handlers.
+   */
   handlers: {
     blur: () => void
     touch: () => void
     DOMInput: (e: Event) => void
   } & Record<string, (...args: any[]) => void>
+  /**
+   * Utility functions, generally for use in the input’s schema.
+   */
   fns: Record<string, (...args: any[]) => any>
+  /**
+   * The help text of the input.
+   */
   help?: string
+  /**
+   * The unique id of the input. Should also be applied as the id attribute.
+   * This is generally required for accessibility reasons.
+   */
   id: string
+  /**
+   * The label of the input.
+   */
   label?: string
+  /**
+   * A list of messages to be displayed on the input. Often these are validation
+   * messages and error messages, but other `visible` core node messages do also
+   * apply here. This object is only populated when the validation should be
+   * actually displayed.
+   */
   messages: Record<string, FormKitMessage>
+  /**
+   * The core node of this input.
+   */
   node: FormKitNode
+  /**
+   * If this input type accepts options (like select lists and checkboxes) then
+   * this will be populated with a properly structured list of options.
+   */
   options?: Array<Record<string, any> & { label: string; value: any }>
+  /**
+   * A collection of state trackers/details about the input.
+   */
   state: Record<string, boolean | undefined> & {
+    /**
+     * If the input has been blurred.
+     */
     blurred: boolean
+    /**
+     * If the input has had a value typed into it or a change made to it.
+     */
     dirty: boolean
+    /**
+     * If the form has been submitted.
+     */
     submitted: boolean
+    /**
+     * If the input (or group/form/list) is passing all validation rules. In
+     * the case of groups, forms, and lists this includes the validation state
+     * of all its children.
+     */
     valid: boolean
+    /**
+     * If the input has explicit errors placed on it, or in the case of a group,
+     * list, or form, this is true if any children have errors on them.
+     */
+    errors: boolean
+    /**
+     * If the validation-visibility has been satisfied and any validation
+     * messages should be displayed.
+     */
+    validationVisible: boolean
   }
+  /**
+   * The type of input "text" or "select" (retrieved from node.props.type). This
+   * is not the core node type (input, group, or list).
+   */
   type: string
+  /**
+   * The current committed value of the input. This is the value that should be
+   * used for most use cases.
+   */
   value: any
 }
 
@@ -690,14 +764,14 @@ function trap(
  */
 function createHooks(): FormKitHooks {
   const hooks: Map<string, FormKitDispatcher<unknown>> = new Map()
-  return (new Proxy(hooks, {
+  return new Proxy(hooks, {
     get(_, property: string) {
       if (!hooks.has(property)) {
         hooks.set(property, createDispatcher())
       }
       return hooks.get(property)
     },
-  }) as unknown) as FormKitHooks
+  }) as unknown as FormKitHooks
 }
 
 /**
@@ -725,9 +799,7 @@ export function resetCount(): void {
  * @param children -
  * @public
  */
-export function names(
-  children: FormKitNode[]
-): {
+export function names(children: FormKitNode[]): {
   [index: string]: FormKitNode
 } {
   return children.reduce(
@@ -791,12 +863,12 @@ function input(
   if (context.isSettled) node.disturb()
   if (async) {
     if (context._tmo) clearTimeout(context._tmo)
-    context._tmo = (setTimeout(
+    context._tmo = setTimeout(
       commit,
       node.props.delay,
       node,
       context
-    ) as unknown) as number
+    ) as unknown as number
   } else {
     commit(node, context)
   }
@@ -851,9 +923,9 @@ function partial(
   // In this case we know for sure we're dealing with a group, TS doesn't
   // know that however, so we use some unpleasant casting here
   if (value !== valueRemoved) {
-    ;((context._value as unknown) as FormKitGroupValue)[name as string] = value
+    ;(context._value as unknown as FormKitGroupValue)[name as string] = value
   } else {
-    delete ((context._value as unknown) as FormKitGroupValue)[name as string]
+    delete (context._value as unknown as FormKitGroupValue)[name as string]
   }
 }
 
@@ -1612,7 +1684,7 @@ export function createNode(options?: FormKitOptions): FormKitNode {
   // Note: The typing for the proxy object cannot be fully modeled, thus we are
   // force-typing to a FormKitNode. See:
   // https://github.com/microsoft/TypeScript/issues/28067
-  const node = (new Proxy(context, {
+  const node = new Proxy(context, {
     get(...args) {
       const [, property] = args
       if (property === '__FKNode__') return true
@@ -1626,7 +1698,7 @@ export function createNode(options?: FormKitOptions): FormKitNode {
       if (trap && trap.set) return trap.set(node, context, property, value)
       return Reflect.set(...args)
     },
-  }) as unknown) as FormKitNode
+  }) as unknown as FormKitNode
 
   return nodeInit(node, ops)
 }

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -394,6 +394,23 @@ export interface FormKitFrameworkContext {
      */
     blurred: boolean
     /**
+     * True when these conditions are met:
+     *
+     * Either:
+     * - The input has validation rules
+     * - The validation rules are all passing
+     * - There are no errors on the input
+     * Or:
+     * - The input has no validation rules
+     * - The input has no errors
+     * - The input is dirty
+     *
+     * This is not intended to be used on forms/groups/lists but instead on
+     * individual inputs. Imagine placing a green checkbox next to each input
+     * when the user filled it out correctly — thats what these are for.
+     */
+    complete: boolean
+    /**
      * If the input has had a value typed into it or a change made to it.
      */
     dirty: boolean

--- a/packages/core/src/setErrors.ts
+++ b/packages/core/src/setErrors.ts
@@ -1,10 +1,7 @@
-import {
-  getNode,
-  createMessage,
-  FormKitMessage,
-  FormKitNode,
-  warn,
-} from '@formkit/core'
+import { FormKitNode } from './node'
+import { FormKitMessage, createMessage } from './store'
+import { getNode } from './registry'
+import { warn } from './errors'
 
 /**
  * Creates an array of message arrays from strings.
@@ -51,7 +48,7 @@ function createMessages(
  * @param childErrors - (optional) The errors to set on the form or the form’s inputs
  * @public
  */
-export default function setErrors(
+export function setErrors(
   id: string,
   localErrors: string[] | Record<string, string | string[]>,
   childErrors?: string[] | Record<string, string | string[]>

--- a/packages/core/src/setErrors.ts
+++ b/packages/core/src/setErrors.ts
@@ -1,45 +1,6 @@
-import { FormKitNode } from './node'
-import { FormKitMessage, createMessage } from './store'
 import { getNode } from './registry'
+import { ErrorMessages } from './store'
 import { warn } from './errors'
-
-/**
- * Creates an array of message arrays from strings.
- * @param errors - Arrays or objects of form errors or input errors
- * @returns
- */
-function createMessages(
-  node: FormKitNode,
-  ...errors: Array<string[] | Record<string, string | string[]> | undefined>
-): Array<FormKitMessage[] | Record<string, FormKitMessage[]>> {
-  return errors
-    .filter((m) => !!m)
-    .map((errorSet): FormKitMessage[] | Record<string, FormKitMessage[]> => {
-      const sourceKey = `${node.name}-set`
-      const make = (error: string) =>
-        createMessage({
-          key: error,
-          type: 'error',
-          value: error,
-          meta: { source: sourceKey },
-        })
-      if (Array.isArray(errorSet)) {
-        return errorSet.map((error) => make(error))
-      } else {
-        const errors: Record<string, FormKitMessage[]> = {}
-        for (const key in errorSet) {
-          if (Array.isArray(errorSet[key])) {
-            errors[key] = (errorSet[key] as string[]).map((error) =>
-              make(error)
-            )
-          } else {
-            errors[key] = [make(errorSet[key] as string)]
-          }
-        }
-        return errors
-      }
-    })
-}
 
 /**
  * Sets errors on a form, group, or input.
@@ -50,15 +11,12 @@ function createMessages(
  */
 export function setErrors(
   id: string,
-  localErrors: string[] | Record<string, string | string[]>,
-  childErrors?: string[] | Record<string, string | string[]>
+  localErrors: ErrorMessages,
+  childErrors?: ErrorMessages
 ): void {
   const node = getNode(id)
   if (node) {
-    const sourceKey = `${node.name}-set`
-    createMessages(node, localErrors, childErrors).forEach((errors) => {
-      node.store.apply(errors, (message) => message.meta.source === sourceKey)
-    })
+    node.setErrors(localErrors, childErrors)
   } else {
     warn(651, id)
   }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -369,6 +369,51 @@ export function applyMessages(
 }
 
 /**
+ * Error messages.
+ * @internal
+ */
+export type ErrorMessages = string[] | Record<string, string | string[]>
+
+/**
+ * Creates an array of message arrays from strings.
+ * @param errors - Arrays or objects of form errors or input errors
+ * @returns
+ * @internal
+ */
+export function createMessages(
+  node: FormKitNode,
+  ...errors: Array<ErrorMessages | undefined>
+): Array<FormKitMessage[] | Record<string, FormKitMessage[]>> {
+  return errors
+    .filter((m) => !!m)
+    .map((errorSet): FormKitMessage[] | Record<string, FormKitMessage[]> => {
+      const sourceKey = `${node.name}-set`
+      const make = (error: string) =>
+        createMessage({
+          key: error,
+          type: 'error',
+          value: error,
+          meta: { source: sourceKey },
+        })
+      if (Array.isArray(errorSet)) {
+        return errorSet.map((error) => make(error))
+      } else {
+        const errors: Record<string, FormKitMessage[]> = {}
+        for (const key in errorSet) {
+          if (Array.isArray(errorSet[key])) {
+            errors[key] = (errorSet[key] as string[]).map((error) =>
+              make(error)
+            )
+          } else {
+            errors[key] = [make(errorSet[key] as string)]
+          }
+        }
+        return errors
+      }
+    })
+}
+
+/**
  *
  * @param store - The store to apply this missed applications.
  * @param address - The address that was missed (a node path that didn't yet exist)

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -372,7 +372,10 @@ export function applyMessages(
  * Error messages.
  * @internal
  */
-export type ErrorMessages = string[] | Record<string, string | string[]>
+export type ErrorMessages =
+  | string
+  | string[]
+  | Record<string, string | string[]>
 
 /**
  * Creates an array of message arrays from strings.
@@ -384,17 +387,18 @@ export function createMessages(
   node: FormKitNode,
   ...errors: Array<ErrorMessages | undefined>
 ): Array<FormKitMessage[] | Record<string, FormKitMessage[]>> {
+  const sourceKey = `${node.name}-set`
+  const make = (error: string) =>
+    createMessage({
+      key: error,
+      type: 'error',
+      value: error,
+      meta: { source: sourceKey },
+    })
   return errors
     .filter((m) => !!m)
     .map((errorSet): FormKitMessage[] | Record<string, FormKitMessage[]> => {
-      const sourceKey = `${node.name}-set`
-      const make = (error: string) =>
-        createMessage({
-          key: error,
-          type: 'error',
-          value: error,
-          meta: { source: sourceKey },
-        })
+      if (typeof errorSet === 'string') errorSet = [errorSet]
       if (Array.isArray(errorSet)) {
         return errorSet.map((error) => make(error))
       } else {

--- a/packages/core/src/submitForm.ts
+++ b/packages/core/src/submitForm.ts
@@ -1,0 +1,16 @@
+import { warn } from './errors'
+
+/**
+ * Submits a FormKit form programmatically.
+ * @param id - The id of the form
+ * @public
+ */
+export function submitForm(id: string): void {
+  const formElement = document.getElementById(id)
+  if (formElement instanceof HTMLFormElement) {
+    const event = new Event('submit', { cancelable: true, bubbles: true })
+    formElement.dispatchEvent(event)
+    return
+  }
+  warn(151, id)
+}

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -1,11 +1,30 @@
 {
   "name": "@formkit/dev",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "Development tools for FormKit.",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/dev"
+  },
   "contributors": [
     "Justin Schroeder <justin@formkit.com>"
   ],
@@ -13,7 +32,6 @@
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {
     "@formkit/core": "1.0.0-beta.2",
     "@formkit/utils": "1.0.0-beta.2"

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/dev/src/index.ts
+++ b/packages/dev/src/index.ts
@@ -33,6 +33,7 @@ const errors: Record<
   104: ({ data: [operator, expression] }) =>
     `Schema expressions cannot end with an operator (${operator} in "${expression}")`,
   105: ({ data: expression }) => `Invalid schema expression: ${expression}`,
+  106: ({ data: name }) => `Cannot submit because (${name}) is not in a form.`,
   /**
    * FormKit vue errors:
    */
@@ -59,6 +60,7 @@ const warnings: Record<
    */
   150: ({ data: fn }: { data: string }) =>
     `Schema function "${fn}()" is not a valid function.`,
+  151: ({ data: id }: { data: string }) => `No form element with id: ${id}`,
   /**
    * Input specific warnings:
    */

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,19 +1,38 @@
 {
   "name": "@formkit/i18n",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "Internationalization layer for FormKit.",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/i18n"
+  },
   "contributors": [
-    "Justin Schroeder <justin@formkit.com>"
+    "Justin Schroeder <justin@formkit.com>",
+    "Andrew Boyd <andrew@formkit.com>"
   ],
   "license": "MIT",
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {
     "@formkit/core": "1.0.0-beta.2",
     "@formkit/utils": "1.0.0-beta.2",

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,6 +1,7 @@
 import * as de from './locales/de'
 import * as en from './locales/en'
 import * as fa from './locales/fa'
+import * as fi from './locales/fi'
 import * as fr from './locales/fr'
 import * as he from './locales/he'
 import * as tr from './locales/tr'
@@ -23,6 +24,7 @@ export const locales = {
   de,
   en,
   fa,
+  fi,
   fr,
   he,
   hr,
@@ -36,7 +38,7 @@ export const locales = {
 /**
  * Export each locale individually for people who want to cherry pick.
  */
-export { de, en, fa, fr, he, hr, nl, pt, ru, tr, zh }
+export { de, en, fa, fi, fr, he, hr, nl, pt, ru, tr, zh }
 
 /**
  * Export all formatter functions.

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -2,6 +2,7 @@ import * as de from './locales/de'
 import * as en from './locales/en'
 import * as fr from './locales/fr'
 import * as he from './locales/he'
+import * as tr from './locales/tr'
 import * as hr from './locales/hr'
 import * as nl from './locales/nl'
 import * as pt from './locales/pt'
@@ -26,13 +27,14 @@ export const locales = {
   nl,
   pt,
   ru,
+  tr,
   zh,
 }
 
 /**
  * Export each locale individually for people who want to cherry pick.
  */
-export { de, en, fr, he, hr, nl, pt, ru, zh }
+export { de, en, fr, he, hr, nl, pt, ru, tr, zh }
 
 /**
  * Export all formatter functions.

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,5 +1,6 @@
 import * as de from './locales/de'
 import * as en from './locales/en'
+import * as fa from './locales/fa'
 import * as fr from './locales/fr'
 import * as he from './locales/he'
 import * as tr from './locales/tr'
@@ -21,6 +22,7 @@ export * from './i18n'
 export const locales = {
   de,
   en,
+  fa,
   fr,
   he,
   hr,
@@ -34,7 +36,7 @@ export const locales = {
 /**
  * Export each locale individually for people who want to cherry pick.
  */
-export { de, en, fr, he, hr, nl, pt, ru, tr, zh }
+export { de, en, fa, fr, he, hr, nl, pt, ru, tr, zh }
 
 /**
  * Export all formatter functions.

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,9 +1,10 @@
 import * as de from './locales/de'
 import * as en from './locales/en'
-import * as nl from './locales/nl'
 import * as fr from './locales/fr'
 import * as he from './locales/he'
 import * as hr from './locales/hr'
+import * as nl from './locales/nl'
+import * as pt from './locales/pt'
 import * as ru from './locales/ru'
 import * as zh from './locales/zh'
 
@@ -23,6 +24,7 @@ export const locales = {
   he,
   hr,
   nl,
+  pt,
   ru,
   zh,
 }
@@ -30,7 +32,7 @@ export const locales = {
 /**
  * Export each locale individually for people who want to cherry pick.
  */
-export { de, en, fr, he, hr, nl, ru, zh }
+export { de, en, fr, he, hr, nl, pt, ru, zh }
 
 /**
  * Export all formatter functions.

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,14 +1,15 @@
 import * as de from './locales/de'
 import * as en from './locales/en'
+import * as es from './locales/es'
 import * as fa from './locales/fa'
 import * as fi from './locales/fi'
 import * as fr from './locales/fr'
 import * as he from './locales/he'
-import * as tr from './locales/tr'
 import * as hr from './locales/hr'
 import * as nl from './locales/nl'
 import * as pt from './locales/pt'
 import * as ru from './locales/ru'
+import * as tr from './locales/tr'
 import * as zh from './locales/zh'
 
 /**
@@ -23,6 +24,7 @@ export * from './i18n'
 export const locales = {
   de,
   en,
+  es,
   fa,
   fi,
   fr,
@@ -38,7 +40,7 @@ export const locales = {
 /**
  * Export each locale individually for people who want to cherry pick.
  */
-export { de, en, fa, fi, fr, he, hr, nl, pt, ru, tr, zh }
+export { de, en, es, fa, fi, fr, he, hr, nl, pt, ru, tr, zh }
 
 /**
  * Export all formatter functions.

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1,0 +1,313 @@
+import { FormKitValidationMessages } from '@formkit/validation'
+
+/**
+ * Here we can import additional helper functions to assist in formatting our
+ * language. Feel free to add additional helper methods to libs/formats if it
+ * assists in creating good validation messages for your locale.
+ */
+import { sentence as s, list, date, order } from '../formatters'
+import { FormKitLocaleMessages } from '../i18n'
+
+/**
+ * Standard language for interface features.
+ * @public
+ */
+export const ui: FormKitLocaleMessages = {
+  /**
+   * Shown when a button to remove items is visible.
+   */
+  remove: 'Quitar',
+  /**
+   * Shown when there are multiple items to remove at the same time.
+   */
+  removeAll: 'Quitar todos',
+  /**
+   * Shown when all fields are not filled out correctly.
+   */
+  incomplete: 'Discúlpe, los campos no fueron completados correctamente.',
+  /**
+   * Shown in a button inside a form to submit the form.
+   */
+  submit: 'Enviar',
+  /**
+   * Shown when no files are selected.
+   */
+  noFiles: 'Archivo no seleccionado',
+}
+
+/**
+ * These are all the possible strings that pertain to validation messages.
+ * @public
+ */
+export const validation: FormKitValidationMessages = {
+  /**
+   * The value is not an accepted value.
+   * @see {@link https://docs.formkit.com/essentials/validation#accepted}
+   */
+  accepted({ name }): string {
+    /* <i18n case="Shown when the user-provided value is not a valid 'accepted' value."> */
+    return `Acepte el ${name} por favor.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not after
+   * @see {@link https://docs.formkit.com/essentials/validation#date-after}
+   */
+  date_after({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not after the date supplied to the rule."> */
+      return `${s(name)} debe ser posterior a ${date(args[0])}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not after today's date, since no date was supplied to the rule."> */
+    return `${s(name)} debe ser una fecha futura.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a letter.
+   * @see {@link https://docs.formkit.com/essentials/validation#alpha}
+   */
+  alpha({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphabetical characters."> */
+    return `${s(name)} debe contener solo caractéres alfabéticos.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not alphanumeric
+   * @see {@link https://docs.formkit.com/essentials/validation#alphanumeric}
+   */
+  alphanumeric({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphanumeric characters."> */
+    return `${s(name)} debe ser alfanumérico.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not before
+   * @see {@link https://docs.formkit.com/essentials/validation#date-before}
+   */
+  date_before({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not before the date supplied to the rule."> */
+      return `${s(name)} debe ser anterior a ${date(args[0])}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not before today's date, since no date was supplied to the rule."> */
+    return `${s(name)} debe ser una fecha pasada.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not between two numbers
+   * @see {@link https://docs.formkit.com/essentials/validation#between}
+   */
+  between({ name, args }) {
+    if (isNaN(args[0]) || isNaN(args[1])) {
+      /* <i18n case="Shown when any of the arguments supplied to the rule were not a number."> */
+      return `El campo no fue completado correctamente y no puede ser enviado.`
+      /* </i18n> */
+    }
+    const [a, b] = order(args[0], args[1])
+    /* <i18n case="Shown when the user-provided value is not between two numbers."> */
+    return `${s(name)} debe estar entre ${a} y ${b}.`
+    /* </i18n> */
+  },
+
+  /**
+   * The confirmation field does not match
+   * @see {@link https://docs.formkit.com/essentials/validation#confirm}
+   */
+  confirm({ name }) {
+    /* <i18n case="Shown when the user-provided value does not equal the value of the matched input."> */
+    return `${s(name)} no coincide.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a valid date
+   * @see {@link https://docs.formkit.com/essentials/validation#date-format}
+   */
+  date_format({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date does not satisfy the date format supplied to the rule."> */
+      return `${s(name)} no es una fecha válida, por favor utilice el formato ${
+        args[0]
+      }`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when no date argument was supplied to the rule."> */
+    return 'El campo no fue completado correctamente y no puede ser enviado.'
+    /* </i18n> */
+  },
+
+  /**
+   * Is not within expected date range
+   * @see {@link https://docs.formkit.com/essentials/validation#date-between}
+   */
+  date_between({ name, args }) {
+    /* <i18n case="Shown when the user-provided date is not between the start and end dates supplied to the rule. "> */
+    return `${s(name)} debe estar entre ${date(args[0])} y ${date(args[1])}`
+    /* </i18n> */
+  },
+
+  /**
+   * Shown when the user-provided value is not a valid email address.
+   * @see {@link https://docs.formkit.com/essentials/validation#email}
+   */
+  email: 'Ingrese una dirección de correo electrónico válida por favor.',
+
+  /**
+   * Does not end with the specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#ends-with}
+   */
+  ends_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not end with the substring supplied to the rule."> */
+    return `${s(name)} no termina con ${list(args)}.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#is}
+   */
+  is({ name }) {
+    /* <i18n case="Shown when the user-provided value is not one of the values supplied to the rule."> */
+    return `${s(name)} no es un valor permitido.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not match specified length
+   * @see {@link https://docs.formkit.com/essentials/validation#length}
+   */
+  length({ name, args: [first = 0, second = Infinity] }) {
+    const min = Number(first) <= Number(second) ? first : second
+    const max = Number(second) >= Number(first) ? second : first
+    if (min == 1 && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
+      return `${s(name)} debe tener al menos una letra.`
+      /* </i18n> */
+    }
+    if (min == 0 && max) {
+      /* <i18n case="Shown when first argument supplied to the rule is 0, and the user-provided value is longer than the max (the 2nd argument) supplied to the rule."> */
+      return `${s(name)} debe tener como máximo ${max} caractéres.`
+      /* </i18n> */
+    }
+    if (min && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is less than the minimum supplied to the rule and there is no maximum supplied to the rule."> */
+      return `${s(name)} debe tener como mínimo ${min} caractéres.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the length of the user-provided value is between the two lengths supplied to the rule."> */
+    return `${s(name)} debe tener entre ${min} y ${max} caractéres.`
+    /* </i18n> */
+  },
+
+  /**
+   * Value is not a match
+   * @see {@link https://docs.formkit.com/essentials/validation#matches}
+   */
+  matches({ name }) {
+    /* <i18n case="Shown when the user-provided value does not match any of the values or RegExp patterns supplied to the rule. "> */
+    return `${s(name)} no es un valor permitido.`
+    /* </i18n> */
+  },
+
+  /**
+   * Exceeds maximum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#max}
+   */
+  max({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is longer than the max supplied to the rule."> */
+      return `Cannot have more than ${args[0]} ${name}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is greater than the maximum number supplied to the rule."> */
+    return `${s(name)} debe ser menor o igual a ${args[0]}.`
+    /* </i18n> */
+  },
+
+  /**
+   * The (field-level) value does not match specified mime type
+   * @see {@link https://docs.formkit.com/essentials/validation#mime}
+   */
+  mime({ name, args }) {
+    if (!args[0]) {
+      /* <i18n case="Shown when no file formats were supplied to the rule."> */
+      return 'No existen formatos de archivos permitidos.'
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the mime type of user-provided file does not match any mime types supplied to the rule."> */
+    return `${s(name)} debe ser del tipo: ${args[0]}`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not fulfill minimum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#min}
+   */
+  min({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is shorter than the min supplied to the rule."> */
+      return `Cannot have less than ${args[0]} ${name}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is less than the minimum number supplied to the rule."> */
+    return `${s(name)} debe ser de al menos ${args[0]}.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#not}
+   */
+  not({ name, node: { value } }) {
+    /* <i18n case="Shown when the user-provided value matches one of the values supplied to (and thus disallowed by) the rule."> */
+    return `“${value}” no es un valor permitido de ${name}.`
+    /* </i18n> */
+  },
+
+  /**
+   *  Is not a number
+   * @see {@link https://docs.formkit.com/essentials/validation#number}
+   */
+  number({ name }) {
+    /* <i18n case="Shown when the user-provided value is not a number."> */
+    return `${s(name)} debe ser un número.`
+    /* </i18n> */
+  },
+
+  /**
+   * Required field.
+   * @see {@link https://docs.formkit.com/essentials/validation#required}
+   */
+  required({ name }) {
+    /* <i18n case="Shown when a user does not provide a value to a required input."> */
+    return `${s(name)} es requerido.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not start with specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#starts-with}
+   */
+  starts_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not start with the substring supplied to the rule."> */
+    return `${s(name)} debe comenzar con ${list(args)}.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not a url
+   * @see {@link https://docs.formkit.com/essentials/validation#url}
+   */
+  url() {
+    /* <i18n case="Shown when the user-provided value is not a valid url."> */
+    return `Proporcione una URL válida por favor.`
+    /* </i18n> */
+  },
+}

--- a/packages/i18n/src/locales/fa.ts
+++ b/packages/i18n/src/locales/fa.ts
@@ -1,0 +1,314 @@
+import { FormKitValidationMessages } from '@formkit/validation'
+
+/**
+ * Here we can import additional helper functions to assist in formatting our
+ * language. Feel free to add additional helper methods to libs/formats if it
+ * assists in creating good validation messages for your locale.
+ */
+import { sentence as s, list, date } from '../formatters'
+import { FormKitLocaleMessages } from '../i18n'
+
+/**
+ * Standard language for interface features.
+ * @public
+ */
+export const ui: FormKitLocaleMessages = {
+  /**
+   * Shown when a button to remove items is visible.
+   */
+  remove: 'حذف',
+  /**
+   * Shown when there are multiple items to remove at the same time.
+   */
+  removeAll: 'همه را حذف کنید',
+  /**
+   * Shown when all fields are not filled out correctly.
+   */
+  incomplete: 'همه فیلدها به‌درستی پر نشده‌اند',
+  /**
+   * Shown in a button inside a form to submit the form.
+   */
+  submit: 'ثبت',
+  /**
+   * Shown when no files are selected.
+   */
+  noFiles: 'هیچ فایلی انتخاب نشده است',
+}
+
+/**
+ * These are all the possible strings that pertain to validation messages.
+ * @public
+ */
+export const validation: FormKitValidationMessages = {
+  /**
+   * The value is not an accepted value.
+   * @see {@link https://docs.formkit.com/essentials/validation#accepted}
+   */
+  accepted({ name }): string {
+    /* <i18n case="Shown when the user-provided value is not a valid 'accepted' value."> */
+    return `لطفاً ${name} را بپذیرید.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not after
+   * @see {@link https://docs.formkit.com/essentials/validation#date-after}
+   */
+  date_after({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not after the date supplied to the rule."> */
+      return `${s(name)} باید بعد از تاریخ ${date(args[0])} باشد.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not after today's date, since no date was supplied to the rule."> */
+    return `${s(name)} باید مربوط به آینده باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a letter.
+   * @see {@link https://docs.formkit.com/essentials/validation#alpha}
+   */
+  alpha({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphabetical characters."> */
+    return `${s(name)} فقط میتواند شامل حروف الفبا باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not alphanumeric
+   * @see {@link https://docs.formkit.com/essentials/validation#alphanumeric}
+   */
+  alphanumeric({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphanumeric characters."> */
+    return `${s(name)} فقط میتواند شامل حروف و اعداد باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not before
+   * @see {@link https://docs.formkit.com/essentials/validation#date-before}
+   */
+  date_before({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not before the date supplied to the rule."> */
+      return `${s(name)} باید قبل از تاریخ ${date(args[0])} باشد.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not before today's date, since no date was supplied to the rule."> */
+    return `${s(name)} باید مربوط به گذشته باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not between two numbers
+   * @see {@link https://docs.formkit.com/essentials/validation#between}
+   */
+  between({ name, args }) {
+    if (isNaN(args[0]) || isNaN(args[1])) {
+      /* <i18n case="Shown when any of the arguments supplied to the rule were not a number."> */
+      return `این فیلد به اشتباه پیکربندی شده است و قابل ارسال نیست`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is not between two numbers."> */
+    return `${s(name)} باید بین ${args[0]} و ${args[1]} باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * The confirmation field does not match
+   * @see {@link https://docs.formkit.com/essentials/validation#confirm}
+   */
+  confirm({ name }) {
+    /* <i18n case="Shown when the user-provided value does not equal the value of the matched input."> */
+    return `${s(name)} مطابقت ندارد.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a valid date
+   * @see {@link https://docs.formkit.com/essentials/validation#date-format}
+   */
+  date_format({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date does not satisfy the date format supplied to the rule."> */
+      return `${s(name)} تاریخ معتبری نیست، لطفاً از قالب ${
+        args[0]
+      } استفاده کنید
+`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when no date argument was supplied to the rule."> */
+    return 'این فیلد به اشتباه پیکربندی شده است و قابل ارسال نیست'
+    /* </i18n> */
+  },
+
+  /**
+   * Is not within expected date range
+   * @see {@link https://docs.formkit.com/essentials/validation#date-between}
+   */
+  date_between({ name, args }) {
+    /* <i18n case="Shown when the user-provided date is not between the start and end dates supplied to the rule. "> */
+    return `${s(name)} باید بین ${date(args[0])} و ${date(args[1])} باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * Shown when the user-provided value is not a valid email address.
+   * @see {@link https://docs.formkit.com/essentials/validation#email}
+   */
+  email: 'لطفا آدرس ایمیل معتبر وارد کنید.',
+
+  /**
+   * Does not end with the specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#ends-with}
+   */
+  ends_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not end with the substring supplied to the rule."> */
+    return `${s(name)} باید به ${list(args)} ختم شود.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#is}
+   */
+  is({ name }) {
+    /* <i18n case="Shown when the user-provided value is not one of the values supplied to the rule."> */
+    return `${s(name)} مجاز نیست.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not match specified length
+   * @see {@link https://docs.formkit.com/essentials/validation#length}
+   */
+  length({ name, args: [first = 0, second = Infinity] }) {
+    const min = first <= second ? first : second
+    const max = second >= first ? second : first
+    if (min == 1 && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
+      return `${s(name)} باید حداقل یک کاراکتر باشد.`
+      /* </i18n> */
+    }
+    if (min == 0 && max) {
+      /* <i18n case="Shown when first argument supplied to the rule is 0, and the user-provided value is longer than the max (the 2nd argument) supplied to the rule."> */
+      return `${s(name)} باید کمتر یا برابر با ${max} کاراکتر باشد.`
+      /* </i18n> */
+    }
+    if (min && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is less than the minimum supplied to the rule and there is no maximum supplied to the rule."> */
+      return `${s(name)} باید بزرگتر یا برابر با ${min} کاراکتر باشد.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the length of the user-provided value is between the two lengths supplied to the rule."> */
+    return `${s(name)} باید بین ${min} و ${max} کاراکتر باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * Value is not a match
+   * @see {@link https://docs.formkit.com/essentials/validation#matches}
+   */
+  matches({ name }) {
+    /* <i18n case="Shown when the user-provided value does not match any of the values or RegExp patterns supplied to the rule. "> */
+    return `${s(name)} مجاز نیست.`
+    /* </i18n> */
+  },
+
+  /**
+   * Exceeds maximum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#max}
+   */
+  max({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is longer than the max supplied to the rule."> */
+      return `${name} نمی تواند بیش از ${args[0]} باشد.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is greater than the maximum number supplied to the rule."> */
+    return `${s(name)} باید کمتر یا برابر با ${args[0]} باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * The (field-level) value does not match specified mime type
+   * @see {@link https://docs.formkit.com/essentials/validation#mime}
+   */
+  mime({ name, args }) {
+    if (!args[0]) {
+      /* <i18n case="Shown when no file formats were supplied to the rule."> */
+      return 'فرمت فایل مجاز نیست.'
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the mime type of user-provided file does not match any mime types supplied to the rule."> */
+    return `${s(name)} باید از این نوع باشد: ${args[0]}`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not fulfill minimum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#min}
+   */
+  min({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is shorter than the min supplied to the rule."> */
+      return `${name} نمی تواند کمتر از ${args[0]} باشد.
+`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is less than the minimum number supplied to the rule."> */
+    return `${s(name)} باید حداقل ${args[0]} باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#not}
+   */
+  not({ name, node: { value } }) {
+    /* <i18n case="Shown when the user-provided value matches one of the values supplied to (and thus disallowed by) the rule."> */
+    return `"${value}" یک ${name} مجاز نیست.`
+    /* </i18n> */
+  },
+
+  /**
+   *  Is not a number
+   * @see {@link https://docs.formkit.com/essentials/validation#number}
+   */
+  number({ name }) {
+    /* <i18n case="Shown when the user-provided value is not a number."> */
+    return `${s(name)} باید عدد باشد.`
+    /* </i18n> */
+  },
+
+  /**
+   * Required field.
+   * @see {@link https://docs.formkit.com/essentials/validation#required}
+   */
+  required({ name }) {
+    /* <i18n case="Shown when a user does not provide a value to a required input."> */
+    return `پر کردن ${s(name)} اجباری است.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not start with specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#starts-with}
+   */
+  starts_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not start with the substring supplied to the rule."> */
+    return `${s(name)} باید با ${list(args)} شروع شود.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not a url
+   * @see {@link https://docs.formkit.com/essentials/validation#url}
+   */
+  url() {
+    /* <i18n case="Shown when the user-provided value is not a valid url."> */
+    return `لطفاً آدرس اینترنتی معتبر وارد کنید.`
+    /* </i18n> */
+  },
+}

--- a/packages/i18n/src/locales/fi.ts
+++ b/packages/i18n/src/locales/fi.ts
@@ -1,0 +1,313 @@
+import { FormKitValidationMessages } from '@formkit/validation'
+
+/**
+ * Here we can import additional helper functions to assist in formatting our
+ * language. Feel free to add additional helper methods to libs/formats if it
+ * assists in creating good validation messages for your locale.
+ */
+import { sentence as s, list, date, order } from '../formatters'
+import { FormKitLocaleMessages } from '../i18n'
+
+/**
+ * Standard language for interface features.
+ * @public
+ */
+export const ui: FormKitLocaleMessages = {
+  /**
+   * Shown when a button to remove items is visible.
+   */
+  remove: 'Poista',
+  /**
+   * Shown when there are multiple items to remove at the same time.
+   */
+  removeAll: 'Poista kaikki',
+  /**
+   * Shown when all fields are not filled out correctly.
+   */
+  incomplete: 'Kaikkia kenttiä ei ole täytetty oikein.',
+  /**
+   * Shown in a button inside a form to submit the form.
+   */
+  submit: 'Tallenna',
+  /**
+   * Shown when no files are selected.
+   */
+  noFiles: 'Ei valittuja tiedostoja',
+}
+
+/**
+ * These are all the possible strings that pertain to validation messages.
+ * @public
+ */
+export const validation: FormKitValidationMessages = {
+  /**
+   * The value is not an accepted value.
+   * @see {@link https://docs.formkit.com/essentials/validation#accepted}
+   */
+  accepted({ name }): string {
+    /* <i18n case="Shown when the user-provided value is not a valid 'accepted' value."> */
+    return `Ole hyvä ja hyväksy ${name}`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not after
+   * @see {@link https://docs.formkit.com/essentials/validation#date-after}
+   */
+  date_after({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not after the date supplied to the rule."> */
+      return `${s(name)} tulee olla ${date(args[0])} jälkeen.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not after today's date, since no date was supplied to the rule."> */
+    return `${s(name)} on oltava tulevaisuudessa.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a letter.
+   * @see {@link https://docs.formkit.com/essentials/validation#alpha}
+   */
+  alpha({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphabetical characters."> */
+    return `${s(name)} saa sisältää vain kirjaimia.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not alphanumeric
+   * @see {@link https://docs.formkit.com/essentials/validation#alphanumeric}
+   */
+  alphanumeric({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphanumeric characters."> */
+    return `${s(name)} saa sisältää vain kirjaimia ja numeroita.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not before
+   * @see {@link https://docs.formkit.com/essentials/validation#date-before}
+   */
+  date_before({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not before the date supplied to the rule."> */
+      return `${s(name)} tulee olla ennen: ${date(args[0])}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not before today's date, since no date was supplied to the rule."> */
+    return `${s(name)} on oltava menneisyydessä.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not between two numbers
+   * @see {@link https://docs.formkit.com/essentials/validation#between}
+   */
+  between({ name, args }) {
+    if (isNaN(args[0]) || isNaN(args[1])) {
+      /* <i18n case="Shown when any of the arguments supplied to the rule were not a number."> */
+      return `Tämä kenttä on täytetty virheellisesti joten sitä ei voitu lähettää.`
+      /* </i18n> */
+    }
+    const [a, b] = order(args[0], args[1])
+    /* <i18n case="Shown when the user-provided value is not between two numbers."> */
+    return `${s(name)} on oltava välillä ${a} - ${b} `
+    /* </i18n> */
+  },
+
+  /**
+   * The confirmation field does not match
+   * @see {@link https://docs.formkit.com/essentials/validation#confirm}
+   */
+  confirm({ name }) {
+    /* <i18n case="Shown when the user-provided value does not equal the value of the matched input."> */
+    return `${s(name)} ei täsmää.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a valid date
+   * @see {@link https://docs.formkit.com/essentials/validation#date-format}
+   */
+  date_format({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date does not satisfy the date format supplied to the rule."> */
+      return `${s(
+        name
+      )} ei ole validi päivämäärä, ole hyvä ja syötä muodossa: ${args[0]}`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when no date argument was supplied to the rule."> */
+    return 'Tämä kenttä on täytetty virheellisesti joten sitä ei voitu lähettää.'
+    /* </i18n> */
+  },
+
+  /**
+   * Is not within expected date range
+   * @see {@link https://docs.formkit.com/essentials/validation#date-between}
+   */
+  date_between({ name, args }) {
+    /* <i18n case="Shown when the user-provided date is not between the start and end dates supplied to the rule. "> */
+    return `${s(name)} on oltava välillä ${date(args[0])} - ${date(args[1])}`
+    /* </i18n> */
+  },
+
+  /**
+   * Shown when the user-provided value is not a valid email address.
+   * @see {@link https://docs.formkit.com/essentials/validation#email}
+   */
+  email: 'Syötä validi sähköpostiosoite.',
+
+  /**
+   * Does not end with the specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#ends-with}
+   */
+  ends_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not end with the substring supplied to the rule."> */
+    return `${s(name)} tulee päättyä ${list(args)}.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#is}
+   */
+  is({ name }) {
+    /* <i18n case="Shown when the user-provided value is not one of the values supplied to the rule."> */
+    return `${s(name)} ei ole sallittu vaihtoehto.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not match specified length
+   * @see {@link https://docs.formkit.com/essentials/validation#length}
+   */
+  length({ name, args: [first = 0, second = Infinity] }) {
+    const min = Number(first) <= Number(second) ? first : second
+    const max = Number(second) >= Number(first) ? second : first
+    if (min == 1 && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
+      return `${s(name)} on oltava vähintään yksi merkki.`
+      /* </i18n> */
+    }
+    if (min == 0 && max) {
+      /* <i18n case="Shown when first argument supplied to the rule is 0, and the user-provided value is longer than the max (the 2nd argument) supplied to the rule."> */
+      return `${s(name)} on oltava ${max} tai alle merkkiä.`
+      /* </i18n> */
+    }
+    if (min && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is less than the minimum supplied to the rule and there is no maximum supplied to the rule."> */
+      return `${s(name)} on oltava vähintään ${min} merkkiä.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the length of the user-provided value is between the two lengths supplied to the rule."> */
+    return `${s(name)} on oltava vähintään ${min}, enintään ${max} merkkiä.`
+    /* </i18n> */
+  },
+
+  /**
+   * Value is not a match
+   * @see {@link https://docs.formkit.com/essentials/validation#matches}
+   */
+  matches({ name }) {
+    /* <i18n case="Shown when the user-provided value does not match any of the values or RegExp patterns supplied to the rule. "> */
+    return `${s(name)} ei ole sallittu arvo.`
+    /* </i18n> */
+  },
+
+  /**
+   * Exceeds maximum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#max}
+   */
+  max({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is longer than the max supplied to the rule."> */
+      return `Valitse enintään ${args[0]} ${name} vaihtoehtoa.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is greater than the maximum number supplied to the rule."> */
+    return `${s(name)} on oltava ${args[0]} tai alle.`
+    /* </i18n> */
+  },
+
+  /**
+   * The (field-level) value does not match specified mime type
+   * @see {@link https://docs.formkit.com/essentials/validation#mime}
+   */
+  mime({ name, args }) {
+    if (!args[0]) {
+      /* <i18n case="Shown when no file formats were supplied to the rule."> */
+      return 'Tiedostoja ei sallita.'
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the mime type of user-provided file does not match any mime types supplied to the rule."> */
+    return `${s(name)} tulee olla ${args[0]}-tiedostotyyppiä.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not fulfill minimum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#min}
+   */
+  min({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is shorter than the min supplied to the rule."> */
+      return `Valitse vähintään ${args[0]} ${name} vaihtoehtoa.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is less than the minimum number supplied to the rule."> */
+    return `${s(name)} tulee olla ${args[0]} tai suurempi.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#not}
+   */
+  not({ name, node: { value } }) {
+    /* <i18n case="Shown when the user-provided value matches one of the values supplied to (and thus disallowed by) the rule."> */
+    return `“${value}” ei ole sallittu ${name}.`
+    /* </i18n> */
+  },
+
+  /**
+   *  Is not a number
+   * @see {@link https://docs.formkit.com/essentials/validation#number}
+   */
+  number({ name }) {
+    /* <i18n case="Shown when the user-provided value is not a number."> */
+    return `Kentän ${s(name)} tulee olla numero.`
+    /* </i18n> */
+  },
+
+  /**
+   * Required field.
+   * @see {@link https://docs.formkit.com/essentials/validation#required}
+   */
+  required({ name }) {
+    /* <i18n case="Shown when a user does not provide a value to a required input."> */
+    return `${s(name)} vaaditaan.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not start with specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#starts-with}
+   */
+  starts_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not start with the substring supplied to the rule."> */
+    return `${s(name)} on alettava ${list(args)}.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not a url
+   * @see {@link https://docs.formkit.com/essentials/validation#url}
+   */
+  url() {
+    /* <i18n case="Shown when the user-provided value is not a valid url."> */
+    return `Syötä validi url-osoite.`
+    /* </i18n> */
+  },
+}

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1,0 +1,312 @@
+import { FormKitValidationMessages } from '@formkit/validation'
+
+/**
+ * Here we can import additional helper functions to assist in formatting our
+ * language. Feel free to add additional helper methods to libs/formats if it
+ * assists in creating good validation messages for your locale.
+ */
+import { sentence as s, list, date } from '../formatters'
+import { FormKitLocaleMessages } from '../i18n'
+
+/**
+ * Standard language for interface features.
+ * @public
+ */
+export const ui: FormKitLocaleMessages = {
+  /**
+   * Shown when a button to remove items is visible.
+   */
+  remove: 'Remover',
+  /**
+   * Shown when there are multiple items to remove at the same time.
+   */
+  removeAll: 'Deletar tudo',
+  /**
+   * Shown when all fields are not filled out correctly.
+   */
+  incomplete: 'Desculpe, nem todos os campos foram preenchidos corretamente.',
+  /**
+   * Shown in a button inside a form to submit the form.
+   */
+  submit: 'Enviar',
+  /**
+   * Shown when no files are selected.
+   */
+  noFiles: 'Nenhum arquivo',
+}
+
+/**
+ * These are all the possible strings that pertain to validation messages.
+ * @public
+ */
+export const validation: FormKitValidationMessages = {
+  /**
+   * The value is not an accepted value.
+   * @see {@link https://docs.formkit.com/essentials/validation#accepted}
+   */
+  accepted({ name }): string {
+    /* <i18n case="Shown when the user-provided value is not a valid 'accepted' value."> */
+    return `Por favor aceite o ${name}.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not after
+   * @see {@link https://docs.formkit.com/essentials/validation#date-after}
+   */
+  date_after({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not after the date supplied to the rule."> */
+      return `${s(name)} deve ser posterior a ${date(args[0])}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not after today's date, since no date was supplied to the rule."> */
+    return `${s(name)} deve ser no futuro.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a letter.
+   * @see {@link https://docs.formkit.com/essentials/validation#alpha}
+   */
+  alpha({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphabetical characters."> */
+    return `${s(name)} só pode conter caracteres do alfabeto.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not alphanumeric
+   * @see {@link https://docs.formkit.com/essentials/validation#alphanumeric}
+   */
+  alphanumeric({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphanumeric characters."> */
+    return `${s(name)} só pode ter letras e números.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not before
+   * @see {@link https://docs.formkit.com/essentials/validation#date-before}
+   */
+  date_before({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not before the date supplied to the rule."> */
+      return `${s(name)} deve ser anterior a ${date(args[0])}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not before today's date, since no date was supplied to the rule."> */
+    return `${s(name)} deve ser anterior a data atual.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not between two numbers
+   * @see {@link https://docs.formkit.com/essentials/validation#between}
+   */
+  between({ name, args }) {
+    if (isNaN(args[0]) || isNaN(args[1])) {
+      /* <i18n case="Shown when any of the arguments supplied to the rule were not a number."> */
+      return `O campo foi configurado incorretamente e não pode ser enviado.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is not between two numbers."> */
+    return `${s(name)} deve estar entre ${args[0]} e ${args[1]}.`
+    /* </i18n> */
+  },
+
+  /**
+   * The confirmation field does not match
+   * @see {@link https://docs.formkit.com/essentials/validation#confirm}
+   */
+  confirm({ name }) {
+    /* <i18n case="Shown when the user-provided value does not equal the value of the matched input."> */
+    return `${s(name)} não confere.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a valid date
+   * @see {@link https://docs.formkit.com/essentials/validation#date-format}
+   */
+  date_format({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date does not satisfy the date format supplied to the rule."> */
+      return `${s(name)} não é uma data válida, por favor use o formato ${
+        args[0]
+      }`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when no date argument was supplied to the rule."> */
+    return 'O campo foi configurado incorretamente e não pode ser enviado.'
+    /* </i18n> */
+  },
+
+  /**
+   * Is not within expected date range
+   * @see {@link https://docs.formkit.com/essentials/validation#date-between}
+   */
+  date_between({ name, args }) {
+    /* <i18n case="Shown when the user-provided date is not between the start and end dates supplied to the rule. "> */
+    return `${s(name)} deve ser entre ${date(args[0])} e ${date(args[1])}`
+    /* </i18n> */
+  },
+
+  /**
+   * Shown when the user-provided value is not a valid email address.
+   * @see {@link https://docs.formkit.com/essentials/validation#email}
+   */
+  email: 'Por favor informe um e-mail válido.',
+
+  /**
+   * Does not end with the specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#ends-with}
+   */
+  ends_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not end with the substring supplied to the rule."> */
+    return `${s(name)} não termina com ${list(args)}.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#is}
+   */
+  is({ name }) {
+    /* <i18n case="Shown when the user-provided value is not one of the values supplied to the rule."> */
+    return `${s(name)} não é um valor permitido.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not match specified length
+   * @see {@link https://docs.formkit.com/essentials/validation#length}
+   */
+  length({ name, args: [first = 0, second = Infinity] }) {
+    const min = first <= second ? first : second
+    const max = second >= first ? second : first
+    if (min == 1 && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
+      return `${s(name)} deve ter ao menos um caractere.`
+      /* </i18n> */
+    }
+    if (min == 0 && max) {
+      /* <i18n case="Shown when first argument supplied to the rule is 0, and the user-provided value is longer than the max (the 2nd argument) supplied to the rule."> */
+      return `${s(name)} não pode ter mais que ${max} caracteres.`
+      /* </i18n> */
+    }
+    if (min && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is less than the minimum supplied to the rule and there is no maximum supplied to the rule."> */
+      return `${s(name)} deve ter no mínimo ${min} caracteres.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the length of the user-provided value is between the two lengths supplied to the rule."> */
+    return `${s(name)} deve ter entre ${min} e ${max} caracteres.`
+    /* </i18n> */
+  },
+
+  /**
+   * Value is not a match
+   * @see {@link https://docs.formkit.com/essentials/validation#matches}
+   */
+  matches({ name }) {
+    /* <i18n case="Shown when the user-provided value does not match any of the values or RegExp patterns supplied to the rule. "> */
+    return `${s(name)} não é um valor permitido.`
+    /* </i18n> */
+  },
+
+  /**
+   * Exceeds maximum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#max}
+   */
+  max({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is longer than the max supplied to the rule."> */
+      return `Não pode ter mais que ${args[0]} ${name}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is greater than the maximum number supplied to the rule."> */
+    return `${s(name)} deve ser igual ou menor que ${args[0]}.`
+    /* </i18n> */
+  },
+
+  /**
+   * The (field-level) value does not match specified mime type
+   * @see {@link https://docs.formkit.com/essentials/validation#mime}
+   */
+  mime({ name, args }) {
+    if (!args[0]) {
+      /* <i18n case="Shown when no file formats were supplied to the rule."> */
+      return 'Nenhum formato de arquivo permitido.'
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the mime type of user-provided file does not match any mime types supplied to the rule."> */
+    return `${s(name)} deve ser do tipo: ${args[0]}`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not fulfill minimum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#min}
+   */
+  min({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is shorter than the min supplied to the rule."> */
+      return `Não pode ter menos que ${args[0]} ${name}.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is less than the minimum number supplied to the rule."> */
+    return `${s(name)} deve ter pelo menos ${args[0]}.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#not}
+   */
+  not({ name, node: { value } }) {
+    /* <i18n case="Shown when the user-provided value matches one of the values supplied to (and thus disallowed by) the rule."> */
+    return `“${value}” não permite ${name}.`
+    /* </i18n> */
+  },
+
+  /**
+   *  Is not a number
+   * @see {@link https://docs.formkit.com/essentials/validation#number}
+   */
+  number({ name }) {
+    /* <i18n case="Shown when the user-provided value is not a number."> */
+    return `${s(name)} deve ser um número.`
+    /* </i18n> */
+  },
+
+  /**
+   * Required field.
+   * @see {@link https://docs.formkit.com/essentials/validation#required}
+   */
+  required({ name }) {
+    /* <i18n case="Shown when a user does not provide a value to a required input."> */
+    return `${s(name)} é obrigatório.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not start with specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#starts-with}
+   */
+  starts_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not start with the substring supplied to the rule."> */
+    return `${s(name)} não começa com ${list(args)}.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not a url
+   * @see {@link https://docs.formkit.com/essentials/validation#url}
+   */
+  url() {
+    /* <i18n case="Shown when the user-provided value is not a valid url."> */
+    return `Por favor informe um url válido.`
+    /* </i18n> */
+  },
+}

--- a/packages/i18n/src/locales/tr.ts
+++ b/packages/i18n/src/locales/tr.ts
@@ -1,0 +1,312 @@
+import { FormKitValidationMessages } from '@formkit/validation'
+
+/**
+ * Here we can import additional helper functions to assist in formatting our
+ * language. Feel free to add additional helper methods to libs/formats if it
+ * assists in creating good validation messages for your locale.
+ */
+import { sentence as s, list, date } from '../formatters'
+import { FormKitLocaleMessages } from '../i18n'
+
+/**
+ * Standard language for interface features.
+ * @public
+ */
+export const ui: FormKitLocaleMessages = {
+  /**
+   * Shown when a button to remove items is visible.
+   */
+  remove: 'Kaldır',
+  /**
+   * Shown when there are multiple items to remove at the same time.
+   */
+  removeAll: 'Hepsini kaldır',
+  /**
+   * Shown when all fields are not filled out correctly.
+   */
+  incomplete: 'Maalesef, tüm alanlar doğru doldurulmadı.',
+  /**
+   * Shown in a button inside a form to submit the form.
+   */
+  submit: 'Gönder',
+  /**
+   * Shown when no files are selected.
+   */
+  noFiles: 'Dosya yok',
+}
+
+/**
+ * These are all the possible strings that pertain to validation messages.
+ * @public
+ */
+export const validation: FormKitValidationMessages = {
+  /**
+   * The value is not an accepted value.
+   * @see {@link https://docs.formkit.com/essentials/validation#accepted}
+   */
+  accepted({ name }): string {
+    /* <i18n case="Shown when the user-provided value is not a valid 'accepted' value."> */
+    return `Lütfen ${name}'yi kabul edin.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not after
+   * @see {@link https://docs.formkit.com/essentials/validation#date-after}
+   */
+  date_after({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not after the date supplied to the rule."> */
+      return `${s(name)} ${date(args[0])}'den sonra olmalıdır.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not after today's date, since no date was supplied to the rule."> */
+    return `${s(name)} gelecekte bir zaman olmalıdır.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a letter.
+   * @see {@link https://docs.formkit.com/essentials/validation#alpha}
+   */
+  alpha({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphabetical characters."> */
+    return `${s(name)} sadece alfabetik karakterler içerebilir.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not alphanumeric
+   * @see {@link https://docs.formkit.com/essentials/validation#alphanumeric}
+   */
+  alphanumeric({ name }) {
+    /* <i18n case="Shown when the user-provided value contains non-alphanumeric characters."> */
+    return `${s(name)} sadece alfabetik karakterler ve sayı içerebilir.`
+    /* </i18n> */
+  },
+
+  /**
+   * The date is not before
+   * @see {@link https://docs.formkit.com/essentials/validation#date-before}
+   */
+  date_before({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date is not before the date supplied to the rule."> */
+      return `${s(name)} ${date(args[0])} tarihinden önce olmalı.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided date is not before today's date, since no date was supplied to the rule."> */
+    return `${s(name)} geçmişte olmalı.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not between two numbers
+   * @see {@link https://docs.formkit.com/essentials/validation#between}
+   */
+  between({ name, args }) {
+    if (isNaN(args[0]) || isNaN(args[1])) {
+      /* <i18n case="Shown when any of the arguments supplied to the rule were not a number."> */
+      return `Alan yanlış yapılandırılmış ve gönderilemez.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is not between two numbers."> */
+    return `${s(name)} ${args[0]} ve ${args[1]} aralığında olmalı.`
+    /* </i18n> */
+  },
+
+  /**
+   * The confirmation field does not match
+   * @see {@link https://docs.formkit.com/essentials/validation#confirm}
+   */
+  confirm({ name }) {
+    /* <i18n case="Shown when the user-provided value does not equal the value of the matched input."> */
+    return `${s(name)} eşleşmiyor.`
+    /* </i18n> */
+  },
+
+  /**
+   * The value is not a valid date
+   * @see {@link https://docs.formkit.com/essentials/validation#date-format}
+   */
+  date_format({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      /* <i18n case="Shown when the user-provided date does not satisfy the date format supplied to the rule."> */
+      return `${s(name)} geçerli bir tarih değil, lütfen ${
+        args[0]
+      } biçimini kullanın.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when no date argument was supplied to the rule."> */
+    return 'Alan yanlış yapılandırılmış ve gönderilemez.'
+    /* </i18n> */
+  },
+
+  /**
+   * Is not within expected date range
+   * @see {@link https://docs.formkit.com/essentials/validation#date-between}
+   */
+  date_between({ name, args }) {
+    /* <i18n case="Shown when the user-provided date is not between the start and end dates supplied to the rule. "> */
+    return `${s(name)}, ${date(args[0])} ve ${date(args[1])} aralığında olmalı.`
+    /* </i18n> */
+  },
+
+  /**
+   * Shown when the user-provided value is not a valid email address.
+   * @see {@link https://docs.formkit.com/essentials/validation#email}
+   */
+  email: 'Lütfen geçerli bir e-mail adresi girin.',
+
+  /**
+   * Does not end with the specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#ends-with}
+   */
+  ends_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not end with the substring supplied to the rule."> */
+    return `${s(name)} ${list(args)} ile bitmiyor.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#is}
+   */
+  is({ name }) {
+    /* <i18n case="Shown when the user-provided value is not one of the values supplied to the rule."> */
+    return `${s(name)} izin verilen bir değer değil.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not match specified length
+   * @see {@link https://docs.formkit.com/essentials/validation#length}
+   */
+  length({ name, args: [first = 0, second = Infinity] }) {
+    const min = first <= second ? first : second
+    const max = second >= first ? second : first
+    if (min == 1 && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
+      return `${s(name)} en azından bir karakter uzunluğunda olmalı.`
+      /* </i18n> */
+    }
+    if (min == 0 && max) {
+      /* <i18n case="Shown when first argument supplied to the rule is 0, and the user-provided value is longer than the max (the 2nd argument) supplied to the rule."> */
+      return `${s(name)} ${max}'e eşit veya daha küçük olmalı.`
+      /* </i18n> */
+    }
+    if (min && max === Infinity) {
+      /* <i18n case="Shown when the length of the user-provided value is less than the minimum supplied to the rule and there is no maximum supplied to the rule."> */
+      return `${s(name)} ${min}'e eşit veya daha büyük olmalı.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the length of the user-provided value is between the two lengths supplied to the rule."> */
+    return `${s(name)}, ${min} ve ${max} karakter uzunluğu aralığında olmalı.`
+    /* </i18n> */
+  },
+
+  /**
+   * Value is not a match
+   * @see {@link https://docs.formkit.com/essentials/validation#matches}
+   */
+  matches({ name }) {
+    /* <i18n case="Shown when the user-provided value does not match any of the values or RegExp patterns supplied to the rule. "> */
+    return `${s(name)} izin verilen bir değer değil.`
+    /* </i18n> */
+  },
+
+  /**
+   * Exceeds maximum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#max}
+   */
+  max({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is longer than the max supplied to the rule."> */
+      return `${name}'in uzunluğu ${args[0]}'dan daha uzun olamaz.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is greater than the maximum number supplied to the rule."> */
+    return `${s(name)} en azından ${args[0]} uzunluğunda veya ona eşit olmalı.`
+    /* </i18n> */
+  },
+
+  /**
+   * The (field-level) value does not match specified mime type
+   * @see {@link https://docs.formkit.com/essentials/validation#mime}
+   */
+  mime({ name, args }) {
+    if (!args[0]) {
+      /* <i18n case="Shown when no file formats were supplied to the rule."> */
+      return 'Hiçbir dosya türüne izin verilmez.'
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the mime type of user-provided file does not match any mime types supplied to the rule."> */
+    return `${s(name)} şu tiplerden biri olmalı: ${args[0]}`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not fulfill minimum allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#min}
+   */
+  min({ name, node: { value }, args }) {
+    if (Array.isArray(value)) {
+      /* <i18n case="Shown when the length of the array of user-provided values is shorter than the min supplied to the rule."> */
+      return `${name}'in uzunluğu ${args[0]}'dan daha kısa olamaz.`
+      /* </i18n> */
+    }
+    /* <i18n case="Shown when the user-provided value is less than the minimum number supplied to the rule."> */
+    return `${s(name)} en azından ${args[0]} uzunluğunda olmalı.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not an allowed value
+   * @see {@link https://docs.formkit.com/essentials/validation#not}
+   */
+  not({ name, node: { value } }) {
+    /* <i18n case="Shown when the user-provided value matches one of the values supplied to (and thus disallowed by) the rule."> */
+    return `“${value}” ${name} olamaz.`
+    /* </i18n> */
+  },
+
+  /**
+   *  Is not a number
+   * @see {@link https://docs.formkit.com/essentials/validation#number}
+   */
+  number({ name }) {
+    /* <i18n case="Shown when the user-provided value is not a number."> */
+    return `${s(name)} sayı olmalı.`
+    /* </i18n> */
+  },
+
+  /**
+   * Required field.
+   * @see {@link https://docs.formkit.com/essentials/validation#required}
+   */
+  required({ name }) {
+    /* <i18n case="Shown when a user does not provide a value to a required input."> */
+    return `${s(name)} gerekli.`
+    /* </i18n> */
+  },
+
+  /**
+   * Does not start with specified value
+   * @see {@link https://docs.formkit.com/essentials/validation#starts-with}
+   */
+  starts_with({ name, args }) {
+    /* <i18n case="Shown when the user-provided value does not start with the substring supplied to the rule."> */
+    return `${s(name)} ${list(args)} ile başlamıyor.`
+    /* </i18n> */
+  },
+
+  /**
+   * Is not a url
+   * @see {@link https://docs.formkit.com/essentials/validation#url}
+   */
+  url() {
+    /* <i18n case="Shown when the user-provided value is not a valid url."> */
+    return `Lütfen geçerli bir url dahil edin.`
+    /* </i18n> */
+  },
+}

--- a/packages/inputs/__tests__/compose.spec.ts
+++ b/packages/inputs/__tests__/compose.spec.ts
@@ -1,4 +1,5 @@
 import { composable } from '../src/compose'
+import { FormKitExtendableSchemaRoot } from '@formkit/core'
 
 describe('composable creator', () => {
   it('does not deeply nest objects', () => {
@@ -52,5 +53,89 @@ describe('composable creator', () => {
         },
       ],
     })
+  })
+
+  it('does not allow deeply linked objects', () => {
+    const outer = composable('outer', () => ({
+      $el: 'div',
+    }))
+    const inner = composable('inner', () => ({
+      $el: 'div',
+    }))
+    const input = composable('input', () => ({
+      $el: 'input',
+    }))
+    const text: FormKitExtendableSchemaRoot = (ext) => [
+      outer(ext.outer, [inner(ext.inner, [input(ext.input)])]),
+    ]
+    const modified = () => {
+      return text({ inner: { $el: 'h1' } })
+    }
+    expect(modified()).toStrictEqual([
+      {
+        if: '$slots.outer',
+        then: '$slots.outer',
+        else: [
+          {
+            $el: 'div',
+            children: [
+              {
+                if: '$slots.inner',
+                then: '$slots.inner',
+                else: [
+                  {
+                    $el: 'h1',
+                    children: [
+                      {
+                        if: '$slots.input',
+                        then: '$slots.input',
+                        else: [
+                          {
+                            $el: 'input',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+    expect(text({})).toStrictEqual([
+      {
+        if: '$slots.outer',
+        then: '$slots.outer',
+        else: [
+          {
+            $el: 'div',
+            children: [
+              {
+                if: '$slots.inner',
+                then: '$slots.inner',
+                else: [
+                  {
+                    $el: 'div',
+                    children: [
+                      {
+                        if: '$slots.input',
+                        then: '$slots.input',
+                        else: [
+                          {
+                            $el: 'input',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
   })
 })

--- a/packages/inputs/package.json
+++ b/packages/inputs/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/inputs/package.json
+++ b/packages/inputs/package.json
@@ -1,11 +1,30 @@
 {
   "name": "@formkit/inputs",
-  "repository": "https://github.com/formkit/formkit",
+  "type": "module",
   "version": "1.0.0-beta.2",
   "description": "Commonly shared types for FormKit",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/inputs"
+  },
   "contributors": [
     "Justin Schroeder <justin@formkit.com>"
   ],
@@ -13,7 +32,6 @@
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {
     "@formkit/core": "1.0.0-beta.2"
   },

--- a/packages/inputs/src/composables/form.ts
+++ b/packages/inputs/src/composables/form.ts
@@ -4,6 +4,7 @@ const form = composable('form', () => ({
   $el: 'form',
   bind: '$attrs',
   attrs: {
+    id: '$id',
     class: '$classes.form',
     name: '$node.name',
     onSubmit: '$handlers.submit',

--- a/packages/inputs/src/composables/outer.ts
+++ b/packages/inputs/src/composables/outer.ts
@@ -7,6 +7,7 @@ const outer = composable('outer', () => ({
     'data-type': '$type',
     'data-multiple': '$attrs.multiple',
     'data-disabled': '$disabled || undefined',
+    'data-complete': '$state.complete || undefined',
   },
 }))
 

--- a/packages/inputs/src/composables/outer.ts
+++ b/packages/inputs/src/composables/outer.ts
@@ -10,6 +10,7 @@ const outer = composable('outer', () => ({
     'data-complete': '$state.complete || undefined',
     'data-invalid':
       '$state.valid === false && $state.validationVisible || undefined',
+    'data-errors': '$state.errors || undefined',
   },
 }))
 

--- a/packages/inputs/src/composables/outer.ts
+++ b/packages/inputs/src/composables/outer.ts
@@ -8,6 +8,8 @@ const outer = composable('outer', () => ({
     'data-multiple': '$attrs.multiple',
     'data-disabled': '$disabled || undefined',
     'data-complete': '$state.complete || undefined',
+    'data-invalid':
+      '$state.valid === false && $state.validationVisible || undefined',
   },
 }))
 

--- a/packages/inputs/src/composables/textarea.ts
+++ b/packages/inputs/src/composables/textarea.ts
@@ -12,6 +12,7 @@ const textarea = composable('input', () => ({
     value: '$_value',
     id: '$id',
   },
+  children: '$initialValue',
 }))
 
 export default textarea

--- a/packages/inputs/src/features/files.ts
+++ b/packages/inputs/src/features/files.ts
@@ -83,6 +83,11 @@ export default function (node: FormKitNode): void {
         node.input(files)
       }
       if (node.context) node.context.files = files
+      // Call the original listener if there is one.
+
+      if (typeof node.props.attrs?.onChange === 'function') {
+        node.props.attrs?.onChange(e)
+      }
     }
   })
 }

--- a/packages/inputs/src/features/form.ts
+++ b/packages/inputs/src/features/form.ts
@@ -5,8 +5,8 @@ import { has, clone } from '@formkit/utils'
  * Handle the submit event.
  * @param e - The event
  */
-async function handleSubmit(node: FormKitNode, e: Event) {
-  e.preventDefault()
+async function handleSubmit(node: FormKitNode, submitEvent: Event) {
+  submitEvent.preventDefault()
   await node.settled
   // Set the submitted state on all children
   node.walk((n) => {
@@ -20,7 +20,7 @@ async function handleSubmit(node: FormKitNode, e: Event) {
   })
 
   if (typeof node.props.onSubmitRaw === 'function') {
-    node.props.onSubmitRaw(e)
+    node.props.onSubmitRaw(submitEvent)
   }
 
   if (node.ledger.value('blocking')) {
@@ -64,8 +64,8 @@ async function handleSubmit(node: FormKitNode, e: Event) {
         node.store.remove('loading')
       }
     } else {
-      if (e.target instanceof HTMLFormElement) {
-        e.target.submit()
+      if (submitEvent.target instanceof HTMLFormElement) {
+        submitEvent.target.submit()
       }
     }
   }

--- a/packages/inputs/src/features/form.ts
+++ b/packages/inputs/src/features/form.ts
@@ -45,7 +45,8 @@ async function handleSubmit(node: FormKitNode, submitEvent: Event) {
     if (typeof node.props.onSubmit === 'function') {
       // call onSubmit
       const retVal = node.props.onSubmit(
-        clone(node.value as Record<string, any>)
+        clone(node.value as Record<string, any>),
+        node
       )
       if (retVal instanceof Promise) {
         const autoDisable =

--- a/packages/inputs/src/features/form.ts
+++ b/packages/inputs/src/features/form.ts
@@ -76,6 +76,7 @@ async function handleSubmit(node: FormKitNode, submitEvent: Event) {
  * @param node - A formkit node.
  */
 export default function (node: FormKitNode): void {
+  node.props.isForm = true
   node.on('created', () => {
     if (node.context?.handlers) {
       node.context.handlers.submit = handleSubmit.bind(null, node)

--- a/packages/inputs/src/features/initialValue.ts
+++ b/packages/inputs/src/features/initialValue.ts
@@ -1,0 +1,9 @@
+import { FormKitNode } from '@formkit/core'
+
+export default function initialValue(node: FormKitNode): void {
+  node.on('created', () => {
+    if (node.context) {
+      node.context.initialValue = node.value
+    }
+  })
+}

--- a/packages/inputs/src/features/initialValue.ts
+++ b/packages/inputs/src/features/initialValue.ts
@@ -3,7 +3,7 @@ import { FormKitNode } from '@formkit/core'
 export default function initialValue(node: FormKitNode): void {
   node.on('created', () => {
     if (node.context) {
-      node.context.initialValue = node.value
+      node.context.initialValue = node.value || ''
     }
   })
 }

--- a/packages/inputs/src/features/localize.ts
+++ b/packages/inputs/src/features/localize.ts
@@ -1,10 +1,13 @@
 import { FormKitNode, createMessage } from '@formkit/core'
 
 /**
- * Creates a localization message (type: ui).
+ * Creates a new feature that generates a localization message of type ui
+ * for use on a given component.
+ *
  * @param key - The key of the message
  * @param value - The value of the message
  * @returns
+ * @public
  */
 export default function localize(
   key: string,

--- a/packages/inputs/src/index.ts
+++ b/packages/inputs/src/index.ts
@@ -16,6 +16,11 @@ export * from './inputs'
 export { createLibraryPlugin } from './plugin'
 
 /**
+ * Export the localize.
+ */
+export { default as localize } from './features/localize'
+
+/**
  * Options types.
  */
 export { FormKitOptionsList } from './features/options'

--- a/packages/inputs/src/inputs.ts
+++ b/packages/inputs/src/inputs.ts
@@ -18,6 +18,7 @@ import formHandler from './features/form'
 import localize from './features/localize'
 import files from './features/files'
 import ignore from './features/ignore'
+import initialValue from './features/initialValue'
 
 /**
  * Default classifications that are available.
@@ -118,6 +119,7 @@ export const range = textClassification
 export const textarea: FormKitTypeDefinition = {
   type: 'input',
   schema: textareaSchema,
+  features: [initialValue],
 }
 
 /**

--- a/packages/nuxt/.npmignore
+++ b/packages/nuxt/.npmignore
@@ -3,3 +3,4 @@ api-extractor.json
 __tests__
 playground
 node_modules
+yarn-error.log

--- a/packages/nuxt/LICENSE
+++ b/packages/nuxt/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-present FormKit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -16,10 +16,6 @@
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "prepack": "nuxt-module-build",
     "dev": "nuxi dev playground",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@formkit/nuxt",
   "repository": "https://github.com/formkit/formkit",
+  "description": "The official Nuxt module for FormKit.",
   "version": "1.0.0-beta.2",
   "license": "MIT",
   "type": "module",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -18,10 +18,7 @@
   ],
   "scripts": {
     "prepack": "nuxt-module-build",
-    "dev": "nuxi dev playground",
-    "dev:build": "nuxi build playground",
-    "build": "nuxi build playground && nuxt-module-build",
-    "prepare": "nuxt-module-build --stub && nuxi prepare playground"
+    "dev": "nuxi dev playground"
   },
   "dependencies": {
     "@formkit/vue": "1.0.0-beta.2",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -24,7 +24,7 @@
     "prepare": "nuxt-module-build --stub && nuxi prepare playground"
   },
   "dependencies": {
-    "@nuxt/kit": "npm:@nuxt/kit-edge@latest",
-    "@formkit/vue": "1.0.0-beta.2"
+    "@formkit/vue": "1.0.0-beta.2",
+    "@nuxt/kit": "npm:@nuxt/kit-edge@latest"
   }
 }

--- a/packages/nuxt/playground/.nuxt/tsconfig.json
+++ b/packages/nuxt/playground/.nuxt/tsconfig.json
@@ -73,13 +73,13 @@
         ".nuxt/*"
       ],
       "#config": [
-        "../@nuxt/nitro"
+        "@nuxt/nitro"
       ],
       "#storage": [
-        "../@nuxt/nitro"
+        "@nuxt/nitro"
       ],
       "#assets": [
-        "../@nuxt/nitro"
+        "@nuxt/nitro"
       ]
     }
   },

--- a/packages/nuxt/playground/app.vue
+++ b/packages/nuxt/playground/app.vue
@@ -1,32 +1,44 @@
 <template>
   <div class="my-form">
     <FormKit
-      label="I've got Tailwind classes from rootClasses"
-      placeholder="Look Ma! Tailwind styles."
-      help="I only get the `text` styles because the config has conditional logic"
-    />
-    <FormKit
-      label="I override my label color"
-      placeholder="I don't like to conform"
-      :classes="{
-        label: {
-          'text-gray-600': false,
-          'text-red-600': true
-        }
-      }"
-      help="Gray label text color removed, red added."
-      validation="required"
-      validation-visibility="live"
-    />
-    <FormKit
-      label="How much do you like Tailwind?"
-      type="radio"
-      :options="{
-        little: 'I like it a little',
-        lots: 'I like it a lot'
-      }"
-      help="I only get the `radio` styles because the config has conditional logic"
-    />
+      type="form"
+      :value="{ hydration_test: 'Testing hydration', tailwind: 'lots' }"
+    >
+      <FormKit
+        label="I've got Tailwind classes from rootClasses"
+        placeholder="Look Ma! Tailwind styles."
+        help="I only get the `text` styles because the config has conditional logic"
+      />
+      <FormKit
+        label="I override my label color"
+        placeholder="I don't like to conform"
+        :classes="{
+          label: {
+            'text-gray-600': false,
+            'text-red-600': true
+          }
+        }"
+        help="Gray label text color removed, red added."
+        validation="required"
+        validation-visibility="live"
+        value="This is hydrated"
+      />
+      <FormKit
+        id="hydration_test"
+        type="textarea"
+        name="hydration_test"
+      />
+      <FormKit
+        label="How much do you like Tailwind?"
+        type="radio"
+        name="tailwind"
+        :options="{
+          little: 'I like it a little',
+          lots: 'I like it a lot'
+        }"
+        help="I only get the `radio` styles because the config has conditional logic"
+      />
+    </FormKit>
   </div>
 </template>
 

--- a/packages/nuxt/playground/app.vue
+++ b/packages/nuxt/playground/app.vue
@@ -1,32 +1,42 @@
 <template>
-  <FormKit
-    label="I've got Tailwind classes from rootClasses"
-    placeholder="Look Ma! Tailwind styles."
-    help="I only get the `text` styles because the config has conditional logic"
-  />
-  <FormKit
-    label="I override my label color"
-    placeholder="I don't like to conform"
-    :classes="{
-      label: {
-        'text-gray-600': false,
-        'text-red-600': true
-      }
-    }"
-    help="Gray label text color removed, red added."
-    validation="required"
-    validation-visibility="live"
-  />
-  <FormKit
-    label="How much do you like Tailwind?"
-    type="radio"
-    :options="{
-      little: 'I like it a little',
-      lots: 'I like it a lot'
-    }"
-    help="I only get the `radio` styles because the config has conditional logic"
-  />
+  <div class="my-form">
+    <FormKit
+      label="I've got Tailwind classes from rootClasses"
+      placeholder="Look Ma! Tailwind styles."
+      help="I only get the `text` styles because the config has conditional logic"
+    />
+    <FormKit
+      label="I override my label color"
+      placeholder="I don't like to conform"
+      :classes="{
+        label: {
+          'text-gray-600': false,
+          'text-red-600': true
+        }
+      }"
+      help="Gray label text color removed, red added."
+      validation="required"
+      validation-visibility="live"
+    />
+    <FormKit
+      label="How much do you like Tailwind?"
+      type="radio"
+      :options="{
+        little: 'I like it a little',
+        lots: 'I like it a lot'
+      }"
+      help="I only get the `radio` styles because the config has conditional logic"
+    />
+  </div>
 </template>
 
 <script lang="ts" setup>
 </script>
+
+<style>
+.my-form {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 1em;
+}
+</style>

--- a/packages/nuxt/src/runtime/plugin.mjs
+++ b/packages/nuxt/src/runtime/plugin.mjs
@@ -1,16 +1,7 @@
 import { defineNuxtPlugin } from '#app'
 import { plugin, defaultConfig } from '@formkit/vue'
-<% if (options.configFile) { %>
-import config from '<%= options.configFile %>'
-<% } %>
-
+<%= options.importStatement %>
 
 export default defineNuxtPlugin((nuxtApp) => {
-  <% if (options.defaultConfig) { %>
-  nuxtApp.vueApp.use(plugin, defaultConfig<%= options.configFile ? '(config)' : '' %>)
-  <% } else if (options.configFile) { %>
-  nuxtApp.vueApp.use(plugin, config)
-  <% } else { %>
-  throw new Error('@formkit/nuxt — defaultConfig is set to false but not configFile option is defined.')
-  <% } %>
+  nuxtApp.vueApp.use(plugin, <%= options.config %>)
 })

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -1,3 +1,6 @@
 {
+  "compilerOptions": {
+    "moduleResolution": "node"
+  },
   "extends": "./playground/.nuxt/tsconfig.json"
 }

--- a/packages/observer/package.json
+++ b/packages/observer/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/observer/package.json
+++ b/packages/observer/package.json
@@ -1,11 +1,30 @@
 {
   "name": "@formkit/observer",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "Utility to wrap a FormKitNode in a dependency tracking observer proxy",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/observer"
+  },
   "contributors": [
     "Justin Schroeder <justin@formkit.com>"
   ],
@@ -13,7 +32,6 @@
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {
     "@formkit/core": "1.0.0-beta.2",
     "@formkit/utils": "1.0.0-beta.2"

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,11 +1,30 @@
 {
   "name": "@formkit/rules",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "Validation rules for FormKit",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/rules"
+  },
   "contributors": [
     "Justin Schroeder <justin@formkit.com>"
   ],
@@ -13,7 +32,6 @@
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "devDependencies": {},
   "dependencies": {
     "@formkit/core": "1.0.0-beta.2",

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -11,10 +11,6 @@
     "Andrew Boyd <andrew@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -12,6 +12,7 @@
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
     },
+    "./genesis": "./dist/genesis/theme.css",
     "./*": "./dist/*"
   },
   "keywords": [

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,20 +1,39 @@
 {
   "name": "@formkit/themes",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "FormKit base themes",
   "main": "index.cjs.js",
   "module": "index.esm.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "ui",
+    "styling"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/themes"
+  },
   "contributors": [
     "Justin Schroeder <justin@formkit.com>",
-    "Andrew Boyd <andrew@formkit.com>"
+    "Andrew Boyd <andrew@formkit.com>",
+    "lennartzellmer <2241624+lennartzellmer@users.noreply.github.com>"
   ],
   "license": "MIT",
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {},
   "devDependencies": {}
 }

--- a/packages/themes/src/genesis/inputs/button-and-submit.css
+++ b/packages/themes/src/genesis/inputs/button-and-submit.css
@@ -40,7 +40,7 @@
 
     &:focus-visible,
     &:focus-within {
-      border-color: var(--fk-border-color-focus);
+      border-color: var(--fk-color-border-focus);
     }
   }
 

--- a/packages/themes/src/genesis/old.css
+++ b/packages/themes/src/genesis/old.css
@@ -13,17 +13,17 @@
     }
 
     &[disabled] {
-      background: var(--fk-border-color);
+      background: var(--fk-color-border);
     }
   }
 }
 
 [data-type="button"] {
   & .formkit-input {
-    border: 1px solid var(--fk-border-color);
+    border: 1px solid var(--fk-color-border);
 
     &:hover {
-      background-color: var(--fk-button-hover);
+      background-color: var(--fk-color-button-hover);
     }
   }
 }
@@ -31,7 +31,7 @@
 .formkit-outer[data-disabled] {
   &:not([data-type="checkbox"]):not([data-type="radio"]):not([data-type="range"]) {
     & .formkit-inner {
-      background-color: var(--fk-disabled-color);
+      background-color: var(--fk-color-disabled);
     }
   }
 }
@@ -78,7 +78,7 @@
     }
 
     &:focus-visible {
-      border-color: var(--fk-focus-border-color);
+      border-color: var(--fk-color-border-focus);
     }
   }
 }
@@ -101,4 +101,3 @@
   line-height: 1.33;
   font-family: inherit;
 }
-

--- a/packages/themes/src/genesis/structure.css
+++ b/packages/themes/src/genesis/structure.css
@@ -92,7 +92,16 @@
 
     &[data-placeholder]:not([multiple]) {
       color: var(--fk-color-placeholder);
+
+      & option {
+        color: var(--fk-color-input);
+
+        &[data-is-placeholder] {
+          color: var(--fk-color-placeholder);
+        }
+      }
     }
+
     & option {
       font-size: var(--fk-font-size-option);
     }

--- a/packages/themes/src/genesis/structure.css
+++ b/packages/themes/src/genesis/structure.css
@@ -94,7 +94,7 @@
       color: var(--fk-color-placeholder);
     }
     & option {
-      font-size: var(--fk-option-font-size);
+      font-size: var(--fk-font-size-option);
     }
   }
 

--- a/packages/themes/src/genesis/typography.css
+++ b/packages/themes/src/genesis/typography.css
@@ -49,7 +49,7 @@
 .formkit-messages {
   font-family: var(--fk-font-family-message);
   font-family: var(--fk-font-family);
-  line-height: var(--fk-line-height-messages);
+  line-height: var(--fk-line-height-message);
 }
 
 .formkit-message {

--- a/packages/themes/src/genesis/variables.css
+++ b/packages/themes/src/genesis/variables.css
@@ -81,7 +81,7 @@
   --fk-border-focus: var(--fk-border-width-focus) var(--fk-border-style) var(--fk-color-border-focus);
   --fk-border-decorator: var(--fk-border-width-decorator) var(--fk-border-style) var(--fk-color-border);
   --fk-border-decorator-focus: var(--fk-border-width-focus) var(--fk-border-style) var(--fk-color-border-focus);
-  --fk-border-decorator-focus-visible: var(--fk-border-width-focus-visible) var(--fk-border-style) var(--fk-color-border-focus);
+  --fk-border-decorator-focus-visible: var(--fk-border-width-decorator-focus-visible) var(--fk-border-style) var(--fk-color-border-focus);
   --fk-border-decorator-checked: var(--fk-border-width-checked) var(--fk-border-style) var(--fk-color-border-focus);
   --fk-border-box-shadow: 0 0 0 var(--fk-border-width) var(--fk-color-border);
   --fk-border-box-shadow-focus: 0 0 0 var(--fk-border-width-focus) var(--fk-color-border-focus);

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,11 +1,30 @@
 {
   "name": "@formkit/utils",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "Shared utilities for FormKit packages",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/utils"
+  },
   "contributors": [
     "Justin Schroeder <justin@formkit.com>"
   ],
@@ -13,7 +32,6 @@
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {},
   "devDependencies": {}
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -463,6 +463,18 @@ export function clone<T extends Record<string, unknown> | unknown[] | null>(
 }
 
 /**
+ * Clones anything. If the item is scalar, no worries, it passes it back. if it
+ * is an object, it performs a (fast/loose) clone operation.
+ * @param obj - The object to clone
+ * @public
+ */
+export function cloneAny<T>(obj: T): T {
+  return typeof obj === 'object'
+    ? (clone(obj as Record<string, unknown>) as T)
+    : obj
+}
+
+/**
  * Get a specific value via dot notation.
  * @param obj - An object to fetch data from
  * @param addr - An "address" in dot notation

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,11 +1,30 @@
 {
   "name": "@formkit/validation",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "Validation plugin for FormKit",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/validation"
+  },
   "contributors": [
     "Justin Schroeder <justin@formkit.com>"
   ],
@@ -13,7 +32,6 @@
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {
     "@formkit/core": "1.0.0-beta.2",
     "@formkit/observer": "1.0.0-beta.2"

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -175,19 +175,13 @@ export function createValidationPlugin(baseRules: FormKitValidationRules = {}) {
         removeListeners(observedNode.receipts)
         // Remove all existing messages before re-validating
         node.store.filter(() => false, 'validation')
-        validate(
-          observedNode,
-          parseRules(event.payload.value, availableRules),
-          state
-        )
+        node.props.parsedRules = parseRules(event.payload.value, availableRules)
+        validate(observedNode, node.props.parsedRules, state)
       }
     })
     // Validate the field when this plugin is initialized
-    validate(
-      observedNode,
-      parseRules(node.props.validation, availableRules),
-      state
-    )
+    node.props.parsedRules = parseRules(node.props.validation, availableRules)
+    validate(observedNode, node.props.parsedRules, state)
   }
 }
 
@@ -248,13 +242,13 @@ function run(
     applyListeners(node, diffDeps(validation.deps, newDeps), () => {
       validation.queued = true
       if (state.rerun) clearTimeout(state.rerun)
-      state.rerun = (setTimeout(
+      state.rerun = setTimeout(
         validate,
         0,
         node,
         validations,
         state
-      ) as unknown) as number
+      ) as unknown as number
     })
     validation.deps = newDeps
 
@@ -323,10 +317,10 @@ function runRule(
   after: (result: boolean | Promise<boolean>) => void
 ) {
   if (validation.debounce) {
-    validation.timer = (setTimeout(() => {
+    validation.timer = setTimeout(() => {
       node.observe()
       after(validation.rule(node, ...validation.args))
-    }, validation.debounce) as unknown) as number
+    }, validation.debounce) as unknown as number
   } else {
     node.observe()
     after(validation.rule(node, ...validation.args))

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -3,11 +3,10 @@ import { flushPromises, mount } from '@vue/test-utils'
 import FormKit from '../src/FormKit'
 import { plugin } from '../src/plugin'
 import defaultConfig from '../src/defaultConfig'
-import { FormKitNode } from '@formkit/core'
+import { FormKitNode, setErrors } from '@formkit/core'
 import { token } from '@formkit/utils'
 import { getNode } from '@formkit/core'
 import vuePlugin from '../src/bindings'
-import setErrors from '../src/composables/setErrors'
 
 // Object.assign(defaultConfig.nodeOptions, { validationVisibility: 'live' })
 

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -7,6 +7,7 @@ import { FormKitNode } from '@formkit/core'
 import { token } from '@formkit/utils'
 import { getNode } from '@formkit/core'
 import vuePlugin from '../src/bindings'
+import setErrors from '../src/composables/setErrors'
 
 // Object.assign(defaultConfig.nodeOptions, { validationVisibility: 'live' })
 
@@ -1042,6 +1043,35 @@ describe('state attributes', () => {
     const outer = wrapper.find('.formkit-outer')
     expect(outer.attributes('data-errors')).toBe('true')
     wrapper.setProps({ errors: [] })
+    await nextTick()
+    expect(outer.attributes('data-errors')).toBe(undefined)
+  })
+
+  it('adds data-errors when the input has errors applied via form', async () => {
+    const formId = token()
+    const wrapper = mount(
+      {
+        template: `<FormKit type="form" id="${formId}">
+        <FormKit
+          type="text"
+          name="foo"
+          :delay="0"
+        />
+      </FormKit>`,
+      },
+      {
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+    setErrors(formId, [], {
+      foo: ['this is an error'],
+    })
+    await nextTick()
+    const outer = wrapper.find('.formkit-outer')
+    expect(outer.attributes('data-errors')).toBe('true')
+    setErrors(formId, [], { foo: [] })
     await nextTick()
     expect(outer.attributes('data-errors')).toBe(undefined)
   })

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1082,3 +1082,21 @@ describe('state attributes', () => {
     expect(outer.attributes('data-errors')).toBe(undefined)
   })
 })
+
+describe('exposures', () => {
+  it('exposes the core FormKitNode', () => {
+    const wrapper = mount(
+      {
+        template: '<FormKit type="select" ref="select" />',
+      },
+      {
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+    const node = (wrapper.vm.$refs.select as any).node as FormKitNode
+    expect(node.props.type).toBe('select')
+    expect(node.__FKNode__).toBe(true)
+  })
+})

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -476,6 +476,66 @@ describe('validation', () => {
     await nextTick()
     expect(node?.context?.state.rules).toBe(false)
   })
+
+  it('is complete when the input has validation rules that are passing', async () => {
+    const id = token()
+    const wrapper = mount(FormKit, {
+      props: {
+        id,
+        delay: 0,
+        validation: 'required|length:10',
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    const node = getNode(id)
+    expect(node?.context?.state.complete).toBe(false)
+    wrapper.find('input').element.value = 'its not the end yet'
+    wrapper.find('input').trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(node?.context?.state.complete).toBe(true)
+  })
+
+  it('is complete when it has no validation rules is not dirty', async () => {
+    const id = token()
+    const wrapper = mount(FormKit, {
+      props: {
+        id,
+        delay: 0,
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    const node = getNode(id)
+    expect(node?.context?.state.complete).toBe(false)
+    wrapper.find('input').element.value = 'yes'
+    wrapper.find('input').trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(node?.context?.state.complete).toBe(true)
+  })
+
+  it('is not complete when the input has explicit error messages', async () => {
+    const id = token()
+    const wrapper = mount(FormKit, {
+      props: {
+        id,
+        delay: 0,
+        validation: 'required',
+        errors: ['This is an error'],
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    const node = getNode(id)
+    expect(node?.context?.state.complete).toBe(false)
+    wrapper.find('input').element.value = 'yes'
+    wrapper.find('input').trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(node?.context?.state.complete).toBe(false)
+  })
 })
 
 describe('configuration', () => {

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -608,7 +608,8 @@ describe('classes', () => {
         plugins: [[plugin, defaultConfig]],
       },
     })
-    expect(wrapper.html()).toBe(`<div class="formkit-outer" data-type="text">
+    expect(wrapper.html())
+      .toBe(`<div class="formkit-outer" data-type="text" data-invalid="true">
   <div class="formkit-wrapper"><label for="foobar" class="formkit-label">input label</label>
     <div class="formkit-inner">
       <!----><input type="text" class="formkit-input" name="classTest" id="foobar">
@@ -1016,5 +1017,28 @@ describe('state attributes', () => {
     expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
       'true'
     )
+  })
+
+  it('adds data-invalid when validation is failing and visible', async () => {
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'text',
+        delay: 0,
+        validation: 'required|length:5',
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    const input = wrapper.find('input')
+    const outer = wrapper.find('.formkit-outer')
+    expect(outer.attributes('data-invalid')).toBe(undefined)
+    input.trigger('blur')
+    await nextTick()
+    expect(outer.attributes('data-invalid')).toBe('true')
+    input.element.value = '123456'
+    input.trigger('input')
+    await new Promise((r) => setTimeout(r, 15))
+    expect(outer.attributes('data-invalid')).toBe(undefined)
   })
 })

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -458,6 +458,24 @@ describe('validation', () => {
     })
     expect(wrapper.html()).toContain('Too short')
   })
+
+  it('changes state.rules when the validation prop changes', async () => {
+    const id = token()
+    const wrapper = mount(FormKit, {
+      props: {
+        id,
+        validation: 'required|length:10',
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    const node = getNode(id)
+    expect(node?.context?.state.rules).toBe(true)
+    wrapper.setProps({ validation: '' })
+    await nextTick()
+    expect(node?.context?.state.rules).toBe(false)
+  })
 })
 
 describe('configuration', () => {

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -494,7 +494,7 @@ describe('validation', () => {
     expect(node?.context?.state.complete).toBe(false)
     wrapper.find('input').element.value = 'its not the end yet'
     wrapper.find('input').trigger('input')
-    await new Promise((r) => setTimeout(r, 10))
+    await new Promise((r) => setTimeout(r, 20))
     expect(node?.context?.state.complete).toBe(true)
   })
 

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -945,3 +945,76 @@ describe('prefix and suffix', () => {
     )
   })
 })
+
+describe('state attributes', () => {
+  it('does not initialize with the complete attribute', async () => {
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'text',
+        delay: 0,
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      undefined
+    )
+    wrapper.find('input').element.value = '123'
+    wrapper.find('input').trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      'true'
+    )
+  })
+
+  it('does not initialize with the complete attribute', async () => {
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'text',
+        delay: 0,
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      undefined
+    )
+    wrapper.find('input').element.value = '123'
+    wrapper.find('input').trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      'true'
+    )
+  })
+
+  it('adds the data-complete attribute when it passes validation', async () => {
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'text',
+        delay: 0,
+        validation: 'required|length:5',
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    const input = wrapper.find('input')
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      undefined
+    )
+    input.element.value = '123'
+    input.trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      undefined
+    )
+    input.element.value = '123456'
+    input.trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      'true'
+    )
+  })
+})

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -959,14 +959,21 @@ describe('state attributes', () => {
         plugins: [[plugin, defaultConfig]],
       },
     })
+    const input = wrapper.find('input')
     expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
       undefined
     )
-    wrapper.find('input').element.value = '123'
-    wrapper.find('input').trigger('input')
+    input.element.value = '123'
+    input.trigger('input')
     await new Promise((r) => setTimeout(r, 10))
     expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
       'true'
+    )
+    input.element.value = ''
+    input.trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      undefined
     )
   })
 

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -969,27 +969,6 @@ describe('state attributes', () => {
     )
   })
 
-  it('does not initialize with the complete attribute', async () => {
-    const wrapper = mount(FormKit, {
-      props: {
-        type: 'text',
-        delay: 0,
-      },
-      global: {
-        plugins: [[plugin, defaultConfig]],
-      },
-    })
-    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
-      undefined
-    )
-    wrapper.find('input').element.value = '123'
-    wrapper.find('input').trigger('input')
-    await new Promise((r) => setTimeout(r, 10))
-    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
-      'true'
-    )
-  })
-
   it('adds the data-complete attribute when it passes validation', async () => {
     const wrapper = mount(FormKit, {
       props: {
@@ -1017,6 +996,12 @@ describe('state attributes', () => {
     expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
       'true'
     )
+    input.element.value = '126'
+    input.trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.find('.formkit-outer').attributes('data-complete')).toBe(
+      undefined
+    )
   })
 
   it('adds data-invalid when validation is failing and visible', async () => {
@@ -1040,5 +1025,24 @@ describe('state attributes', () => {
     input.trigger('input')
     await new Promise((r) => setTimeout(r, 15))
     expect(outer.attributes('data-invalid')).toBe(undefined)
+  })
+
+  it('adds data-errors when the input has errors directly applied via prop', async () => {
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'text',
+        delay: 0,
+        validation: 'required|length:5',
+        errors: ['This is an error'],
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    const outer = wrapper.find('.formkit-outer')
+    expect(outer.attributes('data-errors')).toBe('true')
+    wrapper.setProps({ errors: [] })
+    await nextTick()
+    expect(outer.attributes('data-errors')).toBe(undefined)
   })
 })

--- a/packages/vue/__tests__/form.spec.ts
+++ b/packages/vue/__tests__/form.spec.ts
@@ -22,19 +22,24 @@ describe('form structure', () => {
       props: {
         type: 'form',
         name: 'test_form',
+        id: 'foo',
+        submitAttrs: {
+          id: 'button',
+        },
       },
       slots: {
         default: () => h('h1', 'in the form'),
       },
       ...global,
     })
-    expect(wrapper.html()).toEqual(`<form class="formkit-form" name="test_form">
+    expect(wrapper.html())
+      .toEqual(`<form id="foo" class="formkit-form" name="test_form">
   <h1>in the form</h1>
   <!---->
   <div class="formkit-actions">
     <div class="formkit-outer" data-type="submit">
       <!---->
-      <div class="formkit-wrapper"><button type="submit" class="formkit-input" name="submit_1" id="input_1">
+      <div class="formkit-wrapper"><button type="submit" class="formkit-input" name="submit_1" id="button">
           <!---->Submit
           <!---->
         </button></div>
@@ -42,6 +47,18 @@ describe('form structure', () => {
     </div>
   </div>
 </form>`)
+  })
+
+  it('outputs the id of the form', () => {
+    const id = token()
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'form',
+        id,
+      },
+      ...global,
+    })
+    expect(wrapper.find('form').attributes('id')).toBe(id)
   })
 })
 

--- a/packages/vue/__tests__/form.spec.ts
+++ b/packages/vue/__tests__/form.spec.ts
@@ -740,7 +740,7 @@ describe('form submission', () => {
       {
         methods: {
           submitHandler(_data: any, node: FormKitNode) {
-            node.setErrors(['Woops your phone battery is low'])
+            node.setErrors('Woops your phone battery is low')
           },
         },
         template: `<FormKit type="form" @submit="submitHandler">

--- a/packages/vue/__tests__/form.spec.ts
+++ b/packages/vue/__tests__/form.spec.ts
@@ -1,7 +1,7 @@
 import FormKit from '../src/FormKit'
 import { plugin } from '../src/plugin'
 import defaultConfig from '../src/defaultConfig'
-import { getNode, setErrors } from '@formkit/core'
+import { getNode, setErrors, FormKitNode } from '@formkit/core'
 import { de, en } from '@formkit/i18n'
 import { token } from '@formkit/utils'
 import { mount } from '@vue/test-utils'
@@ -733,6 +733,25 @@ describe('form submission', () => {
       }
     )
     expect(wrapper.vm.values).toStrictEqual({ foo: undefined })
+  })
+
+  it('can set errors on the form using the node passed in the submit handler', async () => {
+    const wrapper = mount(
+      {
+        methods: {
+          submitHandler(_data: any, node: FormKitNode) {
+            node.setErrors(['Woops your phone battery is low'])
+          },
+        },
+        template: `<FormKit type="form" @submit="submitHandler">
+        <FormKit type="text" name="name" />
+      </FormKit>`,
+      },
+      global
+    )
+    wrapper.find('form').trigger('submit')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.html()).toContain('Woops your phone battery is low')
   })
 })
 

--- a/packages/vue/__tests__/form.spec.ts
+++ b/packages/vue/__tests__/form.spec.ts
@@ -1,13 +1,12 @@
 import FormKit from '../src/FormKit'
 import { plugin } from '../src/plugin'
 import defaultConfig from '../src/defaultConfig'
-import { getNode } from '@formkit/core'
+import { getNode, setErrors } from '@formkit/core'
 import { de, en } from '@formkit/i18n'
 import { token } from '@formkit/utils'
 import { mount } from '@vue/test-utils'
 import { h, nextTick } from 'vue'
 import { jest } from '@jest/globals'
-import setErrors from '../src/composables/setErrors'
 import { ref, reactive } from 'vue'
 
 const global: Record<string, Record<string, any>> = {

--- a/packages/vue/__tests__/group.spec.ts
+++ b/packages/vue/__tests__/group.spec.ts
@@ -30,6 +30,34 @@ describe('group', () => {
     expect(inputs[2].element.value).toBe('hello')
   })
 
+  it('does not allow mutations to the initial value object. Issue #72', async () => {
+    const wrapper = mount(
+      {
+        data() {
+          return {
+            initial: { foo: 'abc', baz: 'hello' },
+          }
+        },
+        template: `
+        <div>
+          <FormKit type="group" :value="initial">
+            <FormKit name="foo" :delay="0" />
+            <FormKit name="bar" />
+            <FormKit name="baz" />
+          </FormKit>
+        </div>`,
+      },
+      {
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+    wrapper.find('input').setValue('def')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.vm.initial).toStrictEqual({ foo: 'abc', baz: 'hello' })
+  })
+
   it('can use v-model to change input values', async () => {
     const wrapper = mount(
       {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -10,10 +10,6 @@
     "Justin Schroeder <justin@formkit.com>"
   ],
   "license": "MIT",
-  "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,11 +1,30 @@
 {
   "name": "@formkit/vue",
-  "repository": "https://github.com/formkit/formkit",
   "version": "1.0.0-beta.2",
+  "type": "module",
   "description": "Build industry leading Vue forms 10x faster.",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./dist/*"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "inputs",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/formkit.git",
+    "directory": "packages/rules"
+  },
   "contributors": [
     "Justin Schroeder <justin@formkit.com>"
   ],
@@ -13,7 +32,6 @@
   "scripts": {
     "test": "jest"
   },
-  "type": "module",
   "dependencies": {
     "@formkit/core": "1.0.0-beta.2",
     "@formkit/dev": "1.0.0-beta.2",

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -48,6 +48,10 @@ const FormKit = defineComponent({
     const library = node.props.definition.library as
       | Record<string, ConcreteComponent>
       | undefined
+
+    // Expose the FormKitNode to template refs.
+    context.expose({ node })
+
     return () =>
       h(
         FormKitSchema,

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -42,7 +42,7 @@ const FormKit = defineComponent({
     if (!schemaDefinition) error(601, node)
     const schema =
       typeof schemaDefinition === 'function'
-        ? schemaDefinition(props.sectionsSchema)
+        ? schemaDefinition({ ...props.sectionsSchema })
         : schemaDefinition
     context.emit('node', node)
     const library = node.props.definition.library as

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -8,7 +8,7 @@ import {
   generateClassList,
   FormKitTypeDefinition,
 } from '@formkit/core'
-import { eq, has, camel } from '@formkit/utils'
+import { eq, has, camel, empty } from '@formkit/utils'
 import { createObserver } from '@formkit/observer'
 
 /**
@@ -74,7 +74,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
   const isComplete = computed<boolean>(() => {
     return hasValidation.value
       ? isValid.value && !hasErrors.value
-      : context.state.dirty
+      : context.state.dirty && !empty(context.value)
   })
 
   /**

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -68,6 +68,16 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
   })
 
   /**
+   * If the input has validation rules or not.
+   */
+  const hasValidation = ref<boolean>(
+    Array.isArray(node.props.parsedRules) && node.props.parsedRules.length > 0
+  )
+  node.on('prop:parsedRules', ({ payload: rules }) => {
+    hasValidation.value = Array.isArray(rules) && rules.length > 0
+  })
+
+  /**
    * All messages that are currently on display to an end user. This changes
    * based on the current message type visibility, like errorVisibility.
    */
@@ -199,6 +209,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
       submitted: false,
       valid: !node.ledger.value('blocking'),
       errors: !!node.ledger.value('errors'),
+      rules: hasValidation,
       validationVisible,
     },
     type: node.props.type,

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -307,7 +307,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
         context.value = payload
     }
     // The input is dirty after a value has been input by a user
-    if (!context.state.dirty) context.handlers.touch()
+    if (!context.state.dirty && node.isCreated) context.handlers.touch()
   })
 
   /**

--- a/packages/vue/src/composables/setErrors.ts
+++ b/packages/vue/src/composables/setErrors.ts
@@ -47,19 +47,19 @@ function createMessages(
 /**
  * Sets errors on a form, group, or input.
  * @param formId - The id of a form
- * @param formErrors - The errors to set on the form or the form’s inputs
- * @param inputErrors - (optional) The errors to set on the form or the form’s inputs
+ * @param localErrors - The errors to set on the form or the form’s inputs
+ * @param childErrors - (optional) The errors to set on the form or the form’s inputs
  * @public
  */
 export default function setErrors(
   id: string,
-  formErrors: string[] | Record<string, string | string[]>,
-  inputErrors?: string[] | Record<string, string | string[]>
+  localErrors: string[] | Record<string, string | string[]>,
+  childErrors?: string[] | Record<string, string | string[]>
 ): void {
   const node = getNode(id)
   if (node) {
     const sourceKey = `${node.name}-set`
-    createMessages(node, formErrors, inputErrors).forEach((errors) => {
+    createMessages(node, localErrors, childErrors).forEach((errors) => {
       node.store.apply(errors, (message) => message.meta.source === sourceKey)
     })
   } else {

--- a/packages/vue/src/composables/useInput.ts
+++ b/packages/vue/src/composables/useInput.ts
@@ -10,7 +10,15 @@ import {
   createMessage,
   FormKitTypeDefinition,
 } from '@formkit/core'
-import { nodeProps, except, camel, extend, only, kebab } from '@formkit/utils'
+import {
+  nodeProps,
+  except,
+  camel,
+  extend,
+  only,
+  kebab,
+  cloneAny,
+} from '@formkit/utils'
 import {
   watchEffect,
   inject,
@@ -130,7 +138,9 @@ export function useInput(
    * Define the initial component
    */
   const value: any =
-    props.modelValue !== undefined ? props.modelValue : context.attrs.value
+    props.modelValue !== undefined
+      ? props.modelValue
+      : cloneAny(context.attrs.value)
 
   /**
    * Creates the node's initial props from the context, props, and definition

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -43,4 +43,4 @@ export { default as bindings } from './bindings'
 /**
  * Export the reset count explicitly
  */
-export { resetCount, errorHandler, setErrors } from '@formkit/core'
+export { resetCount, errorHandler, setErrors, submitForm } from '@formkit/core'

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,12 +5,6 @@
 export { useInput } from './composables/useInput'
 
 /**
- * Export the setErrors function explicitly.
- * @public
- */
-export { default as setErrors } from './composables/setErrors'
-
-/**
  * Shorthand for creating inputs with standard FormKit features.
  */
 export { createInput } from './composables/createInput'
@@ -49,4 +43,4 @@ export { default as bindings } from './bindings'
 /**
  * Export the reset count explicitly
  */
-export { resetCount, errorHandler } from '@formkit/core'
+export { resetCount, errorHandler, setErrors } from '@formkit/core'

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -4,10 +4,10 @@ import {
   FormKitConfig,
   getNode,
   createConfig,
+  setErrors,
 } from '@formkit/core'
 import type { App, Plugin, InjectionKey } from 'vue'
 import FormKit from './FormKit'
-import setErrors from './composables/setErrors'
 
 /**
  * Augment Vue’s globalProperties.
@@ -60,17 +60,15 @@ function createPlugin(
  * The symbol key for accessing the FormKit node options.
  * @public
  */
-export const optionsSymbol: InjectionKey<FormKitOptions> = Symbol.for(
-  'FormKitOptions'
-)
+export const optionsSymbol: InjectionKey<FormKitOptions> =
+  Symbol.for('FormKitOptions')
 
 /**
  * The symbol key for accessing FormKit root configuration.
  * @public
  */
-export const configSymbol: InjectionKey<FormKitConfig> = Symbol.for(
-  'FormKitConfig'
-)
+export const configSymbol: InjectionKey<FormKitConfig> =
+  Symbol.for('FormKitConfig')
 
 /**
  * Create the FormKit plugin.

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   getNode,
   createConfig,
   setErrors,
+  submitForm,
 } from '@formkit/core'
 import type { App, Plugin, InjectionKey } from 'vue'
 import FormKit from './FormKit'
@@ -33,6 +34,7 @@ export interface FormKitVuePlugin {
     errors: string[] | Record<string, string | string[]>,
     inputErrors?: string[] | Record<string, string | string[]>
   ) => void
+  submit: (formId: string) => void
 }
 
 /**
@@ -53,6 +55,7 @@ function createPlugin(
       }
     },
     setErrors,
+    submit: submitForm,
   }
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,7 +44,9 @@ function createOutputConfig() {
   if (!declarations) {
     const extras = {}
     let fileName =
-      format !== 'iife' ? `index.${format}.js` : `formkit-${pkg}.js`
+      format !== 'iife'
+        ? `index.${format === 'esm' ? 'mjs' : format}`
+        : `formkit-${pkg}.js`
     if (format === 'iife') {
       extras.globals = {
         vue: 'Vue',

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -27,8 +27,9 @@ const cloudfront = new CloudFrontClient(awsConfig)
 const distributionId = 'E1VORKQ727K1W8'
 
 // The current version of Vue
-const vueVersion = JSON.parse(readFileSync('./node_modules/vue/package.json'))
-  .version
+const vueVersion = JSON.parse(
+  readFileSync('./node_modules/vue/package.json')
+).version
 
 async function askForVersion() {
   const { version } = await prompts({
@@ -71,7 +72,7 @@ async function deployESM(version) {
     matches.forEach((file) => {
       if (
         !lstatSync(file).isDirectory() &&
-        (file.endsWith('esm.js') || file.endsWith('.css'))
+        (file.endsWith('index.mjs') || file.endsWith('.css'))
       ) {
         uploads.push(sendFile(version, pkg, file))
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2649,22 +2649,6 @@
     "@vue/compiler-core" "3.2.31"
     "@vue/shared" "3.2.31"
 
-"@vue/compiler-sfc@3.2.29", "@vue/compiler-sfc@^3.2.1":
-  version "3.2.29"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.29.tgz#f76d556cd5fca6a55a3ea84c88db1a2a53a36ead"
-  integrity sha512-X9+0dwsag2u6hSOP/XsMYqFti/edvYvxamgBgCcbSYuXx1xLZN+dS/GvQKM4AgGS4djqo0jQvWfIXdfZ2ET68g==
-  dependencies:
-    "@babel/parser" "^7.16.4"
-    "@vue/compiler-core" "3.2.29"
-    "@vue/compiler-dom" "3.2.29"
-    "@vue/compiler-ssr" "3.2.29"
-    "@vue/reactivity-transform" "3.2.29"
-    "@vue/shared" "3.2.29"
-    estree-walker "^2.0.2"
-    magic-string "^0.25.7"
-    postcss "^8.1.10"
-    source-map "^0.6.1"
-
 "@vue/compiler-sfc@3.2.31":
   version "3.2.31"
   resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz#d02b29c3fe34d599a52c5ae1c6937b4d69f11c2f"
@@ -2676,6 +2660,22 @@
     "@vue/compiler-ssr" "3.2.31"
     "@vue/reactivity-transform" "3.2.31"
     "@vue/shared" "3.2.31"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+    postcss "^8.1.10"
+    source-map "^0.6.1"
+
+"@vue/compiler-sfc@^3.2.1":
+  version "3.2.29"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.29.tgz#f76d556cd5fca6a55a3ea84c88db1a2a53a36ead"
+  integrity sha512-X9+0dwsag2u6hSOP/XsMYqFti/edvYvxamgBgCcbSYuXx1xLZN+dS/GvQKM4AgGS4djqo0jQvWfIXdfZ2ET68g==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.29"
+    "@vue/compiler-dom" "3.2.29"
+    "@vue/compiler-ssr" "3.2.29"
+    "@vue/reactivity-transform" "3.2.29"
+    "@vue/shared" "3.2.29"
     estree-walker "^2.0.2"
     magic-string "^0.25.7"
     postcss "^8.1.10"
@@ -2731,27 +2731,12 @@
     estree-walker "^2.0.2"
     magic-string "^0.25.7"
 
-"@vue/reactivity@3.2.29":
-  version "3.2.29"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.29.tgz#afdc9c111d4139b14600be17ad80267212af6052"
-  integrity sha512-Ryhb6Gy62YolKXH1gv42pEqwx7zs3n8gacRVZICSgjQz8Qr8QeCcFygBKYfJm3o1SccR7U+bVBQDWZGOyG1k4g==
-  dependencies:
-    "@vue/shared" "3.2.29"
-
 "@vue/reactivity@3.2.31", "@vue/reactivity@^3.2.30":
   version "3.2.31"
   resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.31.tgz#fc90aa2cdf695418b79e534783aca90d63a46bbd"
   integrity sha512-HVr0l211gbhpEKYr2hYe7hRsV91uIVGFYNHj73njbARVGHQvIojkImKMaZNDdoDZOIkMsBc9a1sMqR+WZwfSCw==
   dependencies:
     "@vue/shared" "3.2.31"
-
-"@vue/runtime-core@3.2.29":
-  version "3.2.29"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.29.tgz#fb8577b2fcf52e8d967bd91cdf49ab9fb91f9417"
-  integrity sha512-VMvQuLdzoTGmCwIKTKVwKmIL0qcODIqe74JtK1pVr5lnaE0l25hopodmPag3RcnIcIXe+Ye3B2olRCn7fTCgig==
-  dependencies:
-    "@vue/reactivity" "3.2.29"
-    "@vue/shared" "3.2.29"
 
 "@vue/runtime-core@3.2.31":
   version "3.2.31"
@@ -2761,15 +2746,6 @@
     "@vue/reactivity" "3.2.31"
     "@vue/shared" "3.2.31"
 
-"@vue/runtime-dom@3.2.29":
-  version "3.2.29"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.29.tgz#35e9a2bf04ef80b86ac2ca0e7b2ceaccf1e18f01"
-  integrity sha512-YJgLQLwr+SQyORzTsBQLL5TT/5UiV83tEotqjL7F9aFDIQdFBTCwpkCFvX9jqwHoyi9sJqM9XtTrMcc8z/OjPA==
-  dependencies:
-    "@vue/runtime-core" "3.2.29"
-    "@vue/shared" "3.2.29"
-    csstype "^2.6.8"
-
 "@vue/runtime-dom@3.2.31":
   version "3.2.31"
   resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.31.tgz#79ce01817cb3caf2c9d923f669b738d2d7953eff"
@@ -2778,14 +2754,6 @@
     "@vue/runtime-core" "3.2.31"
     "@vue/shared" "3.2.31"
     csstype "^2.6.8"
-
-"@vue/server-renderer@3.2.29":
-  version "3.2.29"
-  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.2.29.tgz#ea6afa361b9c781a868c8da18c761f9b7bc89102"
-  integrity sha512-lpiYx7ciV7rWfJ0tPkoSOlLmwqBZ9FTmQm33S+T4g0j1fO/LmhJ9b9Ctl1o5xvIFVDk9QkSUWANZn7H2pXuxVw==
-  dependencies:
-    "@vue/compiler-ssr" "3.2.29"
-    "@vue/shared" "3.2.29"
 
 "@vue/server-renderer@3.2.31":
   version "3.2.31"
@@ -10255,18 +10223,7 @@ vue-style-loader@^4.1.3:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue@3.2.29:
-  version "3.2.29"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.29.tgz#3571b65dbd796d3a6347e2fd45a8e6e11c13d56a"
-  integrity sha512-cFIwr7LkbtCRanjNvh6r7wp2yUxfxeM2yPpDQpAfaaLIGZSrUmLbNiSze9nhBJt5MrZ68Iqt0O5scwAMEVxF+Q==
-  dependencies:
-    "@vue/compiler-dom" "3.2.29"
-    "@vue/compiler-sfc" "3.2.29"
-    "@vue/runtime-dom" "3.2.29"
-    "@vue/server-renderer" "3.2.29"
-    "@vue/shared" "3.2.29"
-
-vue@^3.2.30:
+vue@^3.0.0, vue@^3.2.30:
   version "3.2.31"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.31.tgz#e0c49924335e9f188352816788a4cca10f817ce6"
   integrity sha512-odT3W2tcffTiQCy57nOT93INw1auq5lYLLYtWpPYQQYQOOdHiqFct9Xhna6GJ+pJQaF67yZABraH47oywkJgFw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,13 @@
     "@jridgewell/trace-mapping" "^0.2.2"
     sourcemap-codec "1.4.8"
 
+"@ampproject/remapping@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.1.tgz#7922fb0817bf3166d8d9e258c57477e3fd1c3610"
+  integrity sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.0"
+
 "@aws-crypto/crc32@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-2.0.0.tgz#4ad432a3c03ec3087c5540ff6e41e6565d2dc153"
@@ -897,7 +904,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.0.tgz#86850b8597ea6962089770952075dcaabb8dba34"
   integrity sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==
 
-"@babel/core@^7.1.0", "@babel/core@^7.12.16", "@babel/core@^7.12.3", "@babel/core@^7.16.5", "@babel/core@^7.17.0", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
+"@babel/core@^7.1.0", "@babel/core@^7.12.16", "@babel/core@^7.12.3", "@babel/core@^7.16.5", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.0.tgz#16b8772b0a567f215839f689c5ded6bb20e864d5"
   integrity sha512-x/5Ea+RO5MvF9ize5DeVICJoVrNv0Mi2RnIABrZEKYvPEpldXwauPkgvYA17cKa6WpU3LoYvYbuEMFtSNFsarA==
@@ -918,6 +925,27 @@
     json5 "^2.1.2"
     semver "^6.3.0"
 
+"@babel/core@^7.17.2":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.3.tgz#6a6f7e9b5cc0182aef531b93cb5dde94071dc20d"
+  integrity sha512-TolSoY0D/G6/e5bufjUK7wqQeHdcK4NbdxHg0hrhx/zN6boloG52oNpxbZuil/GqmAIz2qEnJ0s8ay24j2YwVg==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-compilation-targets" "^7.16.7"
+    "@babel/helper-module-transforms" "^7.16.7"
+    "@babel/helpers" "^7.17.2"
+    "@babel/parser" "^7.17.3"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+
 "@babel/eslint-parser@^7.12.16":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz#eabb24ad9f0afa80e5849f8240d0e5facc2d90d6"
@@ -931,6 +959,15 @@
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.0.tgz#7bd890ba706cd86d3e2f727322346ffdbf98f65e"
   integrity sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.3.tgz#a2c30b0c4f89858cb87050c3ffdfd36bdf443200"
+  integrity sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==
   dependencies:
     "@babel/types" "^7.17.0"
     jsesc "^2.5.1"
@@ -1080,6 +1117,15 @@
     "@babel/traverse" "^7.17.0"
     "@babel/types" "^7.17.0"
 
+"@babel/helpers@^7.17.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.17.2.tgz#23f0a0746c8e287773ccd27c14be428891f63417"
+  integrity sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==
+  dependencies:
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.0"
+    "@babel/types" "^7.17.0"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.16.10"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
@@ -1093,6 +1139,11 @@
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c"
   integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
+
+"@babel/parser@^7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.3.tgz#b07702b982990bf6fdc1da5049a23fece4c5c3d0"
+  integrity sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -1192,7 +1243,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-transform-typescript@^7.16.1":
+"@babel/plugin-transform-typescript@^7.16.1", "@babel/plugin-transform-typescript@^7.16.8":
   version "7.16.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz#591ce9b6b83504903fa9dd3652c357c2ba7a1ee0"
   integrity sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==
@@ -1222,6 +1273,22 @@
     "@babel/helper-hoist-variables" "^7.16.7"
     "@babel/helper-split-export-declaration" "^7.16.7"
     "@babel/parser" "^7.17.0"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.3"
     "@babel/types" "^7.17.0"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -1481,6 +1548,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz#b876e3feefb9c8d3aa84014da28b5e52a0640d72"
   integrity sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==
 
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
+  integrity sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
+
 "@jridgewell/trace-mapping@^0.2.2":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.2.5.tgz#d5061cc513fd3a0a949feb56b8073989865b1abe"
@@ -1488,6 +1560,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     sourcemap-codec "1.4.8"
+
+"@jridgewell/trace-mapping@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz#f6a0832dffd5b8a6aaa633b7d9f8e8e94c83a0c3"
+  integrity sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@mapbox/node-pre-gyp@^1.0.5":
   version "1.0.8"
@@ -1594,33 +1674,27 @@
     error-stack-parser "^2.0.0"
     string-width "^4.2.3"
 
-"@nuxt/kit-edge@^3.0.0-27398533.8edd481", "@nuxt/kit-edge@latest", "@nuxt/kit@npm:@nuxt/kit-edge@3.0.0-27398533.8edd481", "@nuxt/kit@npm:@nuxt/kit-edge@latest":
-  version "3.0.0-27398533.8edd481"
-  resolved "https://registry.yarnpkg.com/@nuxt/kit-edge/-/kit-edge-3.0.0-27398533.8edd481.tgz#988cd8671f4ae9c513ebff41b00c671b78c0d574"
-  integrity sha512-t4CXeic7/ZGgwLvMLCu2lxKRgHg9Lj+8YhEju2nAe1sh/yM0iOZpje8VDubW3CTJp1/gAmBokj1U2VNEsbmcKg==
+"@nuxt/kit@npm:@nuxt/kit-edge@3.0.0-27415326.3c563fa", "@nuxt/kit@npm:@nuxt/kit-edge@latest":
+  version "3.0.0-27415326.3c563fa"
+  resolved "https://registry.yarnpkg.com/@nuxt/kit-edge/-/kit-edge-3.0.0-27415326.3c563fa.tgz#68be233af979505712ed659da42bb22dac69aef5"
+  integrity sha512-dB6RojXBZ4m1zD8MCjgGAryN7ISVt7POMbYyyh+7ygHVxduG1MOrf2gg00OYBt2y1SKrYH3JCNbfzxB/1QfC9Q==
   dependencies:
-    "@nuxt/schema" "npm:@nuxt/schema-edge@3.0.0-27398533.8edd481"
-    c12 "^0.1.1"
+    "@nuxt/schema" "npm:@nuxt/schema-edge@3.0.0-27415326.3c563fa"
+    c12 "^0.1.3"
     consola "^2.15.3"
     defu "^5.0.1"
     globby "^13.1.1"
     hash-sum "^2.0.0"
     jiti "^1.12.15"
+    knitwork "^0.1.0"
     lodash.template "^4.5.0"
-    mlly "^0.4.1"
+    mlly "^0.4.3"
     pathe "^0.2.0"
     pkg-types "^0.3.2"
     scule "^0.2.1"
     semver "^7.3.5"
     unctx "^1.0.2"
     untyped "^0.3.0"
-
-"@nuxt/kit@^0.8.1-edge":
-  version "0.8.1-edge"
-  resolved "https://registry.yarnpkg.com/@nuxt/kit/-/kit-0.8.1-edge.tgz#880c6b28819cd6bc6800771823ba3af392003783"
-  integrity sha512-7kU+mYxRy3w9UohFK/rfrPkKXM9A4LWsTqpFN3MH7mxohy98SFBkf87B6nqE6ulXmztInK+MptS0Lr+VQa0E6w==
-  dependencies:
-    "@nuxt/kit-edge" latest
 
 "@nuxt/module-builder@^0.1.7":
   version "0.1.7"
@@ -1633,16 +1707,16 @@
     pathe "^0.2.0"
     unbuild "^0.6.7"
 
-"@nuxt/nitro@npm:@nuxt/nitro-edge@3.0.0-27398533.8edd481":
-  version "3.0.0-27398533.8edd481"
-  resolved "https://registry.yarnpkg.com/@nuxt/nitro-edge/-/nitro-edge-3.0.0-27398533.8edd481.tgz#7b1302519f668a4dff1989a9a247b0c91a4655b3"
-  integrity sha512-ZdWBY+rvyTjFjQ9dxWN9VKRXxXsBZJmoAKu+6vZw/BmJk/T04Xc0vjyGks9A+UfKp/857QsG8UQRhrZZCSAD2Q==
+"@nuxt/nitro@npm:@nuxt/nitro-edge@3.0.0-27415326.3c563fa":
+  version "3.0.0-27415326.3c563fa"
+  resolved "https://registry.yarnpkg.com/@nuxt/nitro-edge/-/nitro-edge-3.0.0-27415326.3c563fa.tgz#e2e738f581615060e7eb827fe85efb68b763c219"
+  integrity sha512-2hm5Qci8xClPnUhrnVyT/sJNUCwHIrnVatgO6mOOmcZL6NRR9zJWufu4bK2Ivx/gWv3Ug3GGv+yPAFRHTrXkLg==
   dependencies:
     "@cloudflare/kv-asset-handler" "^0.2.0"
     "@netlify/functions" "^0.11.0"
     "@nuxt/design" "0.1.5"
     "@nuxt/devalue" "^2.0.0"
-    "@nuxt/kit" "npm:@nuxt/kit-edge@3.0.0-27398533.8edd481"
+    "@nuxt/kit" "npm:@nuxt/kit-edge@3.0.0-27415326.3c563fa"
     "@rollup/plugin-alias" "^3.1.9"
     "@rollup/plugin-commonjs" "^21.0.1"
     "@rollup/plugin-inject" "^4.0.4"
@@ -1653,7 +1727,7 @@
     "@rollup/plugin-wasm" "^5.1.2"
     "@rollup/pluginutils" "^4.1.2"
     "@types/jsdom" "^16.2.14"
-    "@vercel/nft" "^0.17.4"
+    "@vercel/nft" "^0.17.5"
     archiver "^5.3.0"
     chalk "^5.0.0"
     chokidar "^3.5.3"
@@ -1662,7 +1736,7 @@
     defu "^5.0.1"
     destr "^1.1.0"
     dot-prop "^7.1.1"
-    esbuild "^0.14.18"
+    esbuild "^0.14.21"
     etag "^1.8.1"
     fs-extra "^10.0.0"
     globby "^13.1.1"
@@ -1673,17 +1747,18 @@
     http-proxy "^1.18.1"
     is-primitive "^3.0.1"
     jiti "^1.12.15"
+    knitwork "^0.1.0"
     listhen "^0.2.6"
     mime "^3.0.0"
-    mlly "^0.4.1"
+    mlly "^0.4.3"
     node-fetch "^3.2.0"
     ohmyfetch "^0.4.15"
     ora "^6.0.1"
     p-debounce "^4.0.0"
     pathe "^0.2.0"
     pkg-types "^0.3.2"
-    pretty-bytes "^5.6.0"
-    rollup "^2.67.0"
+    pretty-bytes "^6.0.0"
+    rollup "^2.67.2"
     rollup-plugin-terser "^7.0.2"
     rollup-plugin-visualizer "^5.5.4"
     serve-placeholder "^1.2.4"
@@ -1696,12 +1771,12 @@
     vue-bundle-renderer "^0.3.5"
     vue-server-renderer "^2.6.14"
 
-"@nuxt/schema@npm:@nuxt/schema-edge@3.0.0-27398533.8edd481":
-  version "3.0.0-27398533.8edd481"
-  resolved "https://registry.yarnpkg.com/@nuxt/schema-edge/-/schema-edge-3.0.0-27398533.8edd481.tgz#4bef78f561a426c9df4afb182c7607c3598f1020"
-  integrity sha512-cikGLdW3FuOOWJ+LgTVZAwEkywbayb0qkGEHti0PUbrtVuaixPeaqjrX10vs6Ow+nmKuFDUgjhAmuKPF6h0ajA==
+"@nuxt/schema@npm:@nuxt/schema-edge@3.0.0-27415326.3c563fa":
+  version "3.0.0-27415326.3c563fa"
+  resolved "https://registry.yarnpkg.com/@nuxt/schema-edge/-/schema-edge-3.0.0-27415326.3c563fa.tgz#d9ec28c49fba159978a0b3a3cb0ff484c299f621"
+  integrity sha512-Dxx3XmeLmXmw7kzvH6cr7r7StmSkpTFGVirWCoaUKunwV1kEtsfYfbM0bsoDXdwRk1yZaJJUR8QjrWnsn20oOg==
   dependencies:
-    c12 "^0.1.1"
+    c12 "^0.1.3"
     create-require "^1.1.1"
     defu "^5.0.1"
     jiti "^1.12.15"
@@ -1710,24 +1785,26 @@
     std-env "^3.0.1"
     ufo "^0.7.9"
 
-"@nuxt/vite-builder@npm:@nuxt/vite-builder-edge@3.0.0-27398533.8edd481":
-  version "3.0.0-27398533.8edd481"
-  resolved "https://registry.yarnpkg.com/@nuxt/vite-builder-edge/-/vite-builder-edge-3.0.0-27398533.8edd481.tgz#c6a6a8f31109f16faf05320a8df5bfda8ddaa270"
-  integrity sha512-ICMTaPh+hW8bFnf0ikSRFOocyrkDYpCjfW5nVZQJWjVGUMGKFtGUjwB/Zq9tKX4vr1iWwOH0w3w+D5+uc1eUSA==
+"@nuxt/vite-builder@npm:@nuxt/vite-builder-edge@3.0.0-27415326.3c563fa":
+  version "3.0.0-27415326.3c563fa"
+  resolved "https://registry.yarnpkg.com/@nuxt/vite-builder-edge/-/vite-builder-edge-3.0.0-27415326.3c563fa.tgz#cb5452978a98d622f03a5cee39429ef182b6b369"
+  integrity sha512-wRoyX9J4gXs5wERdxO1oVxJMSCytrqp7tHm0+K+rRkronr+a2v+ptL2sIe3uvQCqgDR13E4I29FekKAPpu6U1w==
   dependencies:
-    "@nuxt/kit" "npm:@nuxt/kit-edge@3.0.0-27398533.8edd481"
-    "@vitejs/plugin-vue" "^2.1.0"
-    "@vitejs/plugin-vue-jsx" "^1.3.3"
+    "@nuxt/kit" "npm:@nuxt/kit-edge@3.0.0-27415326.3c563fa"
+    "@vitejs/plugin-vue" "^2.2.0"
+    "@vitejs/plugin-vue-jsx" "^1.3.4"
     autoprefixer "^10.4.2"
     chokidar "^3.5.3"
     consola "^2.15.3"
     defu "^5.0.1"
-    esbuild "^0.14.18"
+    esbuild "^0.14.21"
     escape-string-regexp "^5.0.0"
     externality "^0.1.6"
     fs-extra "^10.0.0"
+    get-port-please "^2.3.0"
+    knitwork "^0.1.0"
     magic-string "^0.25.7"
-    mlly "^0.4.1"
+    mlly "^0.4.3"
     p-debounce "^4.0.0"
     pathe "^0.2.0"
     postcss-import "^14.0.2"
@@ -1736,23 +1813,23 @@
     rollup-plugin-visualizer "^5.5.4"
     ufo "^0.7.9"
     unplugin "^0.3.2"
-    vite "^2.7.13"
+    vite "^2.8.1"
 
-"@nuxt/webpack-builder@npm:@nuxt/webpack-builder-edge@3.0.0-27398533.8edd481":
-  version "3.0.0-27398533.8edd481"
-  resolved "https://registry.yarnpkg.com/@nuxt/webpack-builder-edge/-/webpack-builder-edge-3.0.0-27398533.8edd481.tgz#b8a3beadd8617e97caf11431664f8b26e5e61d7a"
-  integrity sha512-gIhEqDhZmgCuiKzC+Bu57CafnQIVe31nvvsMbKNHri0wEfQBP3wQYmCvB8xsKu01rweUDzJzP7Aufh6+xyFJXg==
+"@nuxt/webpack-builder@npm:@nuxt/webpack-builder-edge@3.0.0-27415326.3c563fa":
+  version "3.0.0-27415326.3c563fa"
+  resolved "https://registry.yarnpkg.com/@nuxt/webpack-builder-edge/-/webpack-builder-edge-3.0.0-27415326.3c563fa.tgz#d3aa38e04779340db323eeef90131a2bd6567cf9"
+  integrity sha512-+MZmjQhkhsd62nANwpqOEjcxukXPskAzosxfMk13Yqwh7rQAZovDQndz0DLPRo1+ytFtg0wSDsXVRc7j5LxZIA==
   dependencies:
-    "@babel/core" "^7.17.0"
+    "@babel/core" "^7.17.2"
     "@nuxt/friendly-errors-webpack-plugin" "^2.5.2"
-    "@nuxt/kit" "npm:@nuxt/kit-edge@3.0.0-27398533.8edd481"
+    "@nuxt/kit" "npm:@nuxt/kit-edge@3.0.0-27415326.3c563fa"
     "@vue/babel-preset-jsx" "^1.2.4"
     autoprefixer "^10.4.2"
     babel-loader "^8.2.3"
     consola "^2.15.3"
     css-loader "^6.6.0"
     css-minimizer-webpack-plugin "^3.4.1"
-    cssnano "^5.0.16"
+    cssnano "^5.0.17"
     esbuild-loader "^2.18.0"
     escape-string-regexp "^5.0.0"
     file-loader "^6.2.0"
@@ -1762,7 +1839,7 @@
     lodash-es "^4.17.21"
     memfs "^3.4.1"
     mini-css-extract-plugin "^2.5.3"
-    mlly "^0.4.1"
+    mlly "^0.4.3"
     pathe "^0.2.0"
     pify "^5.0.0"
     postcss "^8.4.6"
@@ -2385,6 +2462,23 @@
     resolve-from "^5.0.0"
     rollup-pluginutils "^2.8.2"
 
+"@vercel/nft@^0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.17.5.tgz#eab288a3786b8bd6fc08c0ef0b70d162984d1643"
+  integrity sha512-6n4uXmfkcHAmkI4rJlwFJb8yvWuH6uDOi5qme0yGC1B/KmWJ66dERupdAj9uj7eEmgM7N3bKNY5zOYE7cKZE1g==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.5"
+    acorn "^8.6.0"
+    bindings "^1.4.0"
+    estree-walker "2.0.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.2"
+    node-gyp-build "^4.2.2"
+    node-pre-gyp "^0.13.0"
+    resolve-from "^5.0.0"
+    rollup-pluginutils "^2.8.2"
+
 "@vitejs/plugin-vue-jsx@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-1.3.3.tgz#a757f737aeb04dd4ad627239b7abe4680c7c8aa1"
@@ -2397,15 +2491,27 @@
     "@vue/babel-plugin-jsx" "^1.1.1"
     hash-sum "^2.0.0"
 
+"@vitejs/plugin-vue-jsx@^1.3.4":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-1.3.7.tgz#7e915f935db32053b2e9c28360d2c4cdf5ed8580"
+  integrity sha512-UH+lI/TtBQg1YZeOTBN5yEYvSDNcL2ei8ZgE+0ESX2ULg2xV7rxzw1TB1eHZiMGXOSR8h5AWp/6F1hCcaq8VYA==
+  dependencies:
+    "@babel/core" "^7.17.2"
+    "@babel/plugin-syntax-import-meta" "^7.10.4"
+    "@babel/plugin-transform-typescript" "^7.16.8"
+    "@rollup/pluginutils" "^4.1.2"
+    "@vue/babel-plugin-jsx" "^1.1.1"
+    hash-sum "^2.0.0"
+
 "@vitejs/plugin-vue@^1.4.0":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-1.10.2.tgz#d718479e2789d8a94b63e00f23f1898ba239253a"
   integrity sha512-/QJ0Z9qfhAFtKRY+r57ziY4BSbGUTGsPRMpB/Ron3QPwBZM4OZAZHdTa4a8PafCwU5DTatXG8TMDoP8z+oDqJw==
 
-"@vitejs/plugin-vue@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-2.1.0.tgz#ddf5e0059f84f2ff649afc25ce5a59211e670542"
-  integrity sha512-AZ78WxvFMYd8JmM/GBV6a6SGGTU0GgN/0/4T+FnMMsLzFEzTeAUwuraapy50ifHZsC+G5SvWs86bvaCPTneFlA==
+"@vitejs/plugin-vue@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-2.2.0.tgz#a0affe3ee09f70a9a1415bd39c0f8a58fa78b419"
+  integrity sha512-wXigM1EwN2G7rZcwG6kLk9ivvIMhx2363tCEvMBiXcTu5nePM/12hUPVzPb83Uugt6U+zom1gTpJopi/Ow/jwg==
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.2.1":
   version "1.2.1"
@@ -2517,6 +2623,16 @@
     estree-walker "^2.0.2"
     source-map "^0.6.1"
 
+"@vue/compiler-core@3.2.31":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.31.tgz#d38f06c2cf845742403b523ab4596a3fda152e89"
+  integrity sha512-aKno00qoA4o+V/kR6i/pE+aP+esng5siNAVQ422TkBNM6qA4veXiZbSe8OTXHXquEi/f6Akc+nLfB4JGfe4/WQ==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/shared" "3.2.31"
+    estree-walker "^2.0.2"
+    source-map "^0.6.1"
+
 "@vue/compiler-dom@3.2.29":
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.29.tgz#ad0ead405bd2f2754161335aad9758aa12430715"
@@ -2524,6 +2640,14 @@
   dependencies:
     "@vue/compiler-core" "3.2.29"
     "@vue/shared" "3.2.29"
+
+"@vue/compiler-dom@3.2.31":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.31.tgz#b1b7dfad55c96c8cc2b919cd7eb5fd7e4ddbf00e"
+  integrity sha512-60zIlFfzIDf3u91cqfqy9KhCKIJgPeqxgveH2L+87RcGU/alT6BRrk5JtUso0OibH3O7NXuNOQ0cDc9beT0wrg==
+  dependencies:
+    "@vue/compiler-core" "3.2.31"
+    "@vue/shared" "3.2.31"
 
 "@vue/compiler-sfc@3.2.29", "@vue/compiler-sfc@^3.2.1":
   version "3.2.29"
@@ -2541,6 +2665,22 @@
     postcss "^8.1.10"
     source-map "^0.6.1"
 
+"@vue/compiler-sfc@3.2.31":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz#d02b29c3fe34d599a52c5ae1c6937b4d69f11c2f"
+  integrity sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.31"
+    "@vue/compiler-dom" "3.2.31"
+    "@vue/compiler-ssr" "3.2.31"
+    "@vue/reactivity-transform" "3.2.31"
+    "@vue/shared" "3.2.31"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+    postcss "^8.1.10"
+    source-map "^0.6.1"
+
 "@vue/compiler-ssr@3.2.29":
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.29.tgz#37b15b32dcd2f6b410bb61fca3f37b1a92b7eb1e"
@@ -2548,6 +2688,14 @@
   dependencies:
     "@vue/compiler-dom" "3.2.29"
     "@vue/shared" "3.2.29"
+
+"@vue/compiler-ssr@3.2.31":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.31.tgz#4fa00f486c9c4580b40a4177871ebbd650ecb99c"
+  integrity sha512-mjN0rqig+A8TVDnsGPYJM5dpbjlXeHUm2oZHZwGyMYiGT/F4fhJf/cXy8QpjnLQK4Y9Et4GWzHn9PS8AHUnSkw==
+  dependencies:
+    "@vue/compiler-dom" "3.2.31"
+    "@vue/shared" "3.2.31"
 
 "@vue/devtools-api@^6.0.0-beta.18":
   version "6.0.0-beta.21.1"
@@ -2572,12 +2720,30 @@
     estree-walker "^2.0.2"
     magic-string "^0.25.7"
 
-"@vue/reactivity@3.2.29", "@vue/reactivity@^3.2.29":
+"@vue/reactivity-transform@3.2.31":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity-transform/-/reactivity-transform-3.2.31.tgz#0f5b25c24e70edab2b613d5305c465b50fc00911"
+  integrity sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.31"
+    "@vue/shared" "3.2.31"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+
+"@vue/reactivity@3.2.29":
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.29.tgz#afdc9c111d4139b14600be17ad80267212af6052"
   integrity sha512-Ryhb6Gy62YolKXH1gv42pEqwx7zs3n8gacRVZICSgjQz8Qr8QeCcFygBKYfJm3o1SccR7U+bVBQDWZGOyG1k4g==
   dependencies:
     "@vue/shared" "3.2.29"
+
+"@vue/reactivity@3.2.31", "@vue/reactivity@^3.2.30":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.31.tgz#fc90aa2cdf695418b79e534783aca90d63a46bbd"
+  integrity sha512-HVr0l211gbhpEKYr2hYe7hRsV91uIVGFYNHj73njbARVGHQvIojkImKMaZNDdoDZOIkMsBc9a1sMqR+WZwfSCw==
+  dependencies:
+    "@vue/shared" "3.2.31"
 
 "@vue/runtime-core@3.2.29":
   version "3.2.29"
@@ -2586,6 +2752,14 @@
   dependencies:
     "@vue/reactivity" "3.2.29"
     "@vue/shared" "3.2.29"
+
+"@vue/runtime-core@3.2.31":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.31.tgz#9d284c382f5f981b7a7b5971052a1dc4ef39ac7a"
+  integrity sha512-Kcog5XmSY7VHFEMuk4+Gap8gUssYMZ2+w+cmGI6OpZWYOEIcbE0TPzzPHi+8XTzAgx1w/ZxDFcXhZeXN5eKWsA==
+  dependencies:
+    "@vue/reactivity" "3.2.31"
+    "@vue/shared" "3.2.31"
 
 "@vue/runtime-dom@3.2.29":
   version "3.2.29"
@@ -2596,6 +2770,15 @@
     "@vue/shared" "3.2.29"
     csstype "^2.6.8"
 
+"@vue/runtime-dom@3.2.31":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.31.tgz#79ce01817cb3caf2c9d923f669b738d2d7953eff"
+  integrity sha512-N+o0sICVLScUjfLG7u9u5XCjvmsexAiPt17GNnaWHJUfsKed5e85/A3SWgKxzlxx2SW/Hw7RQxzxbXez9PtY3g==
+  dependencies:
+    "@vue/runtime-core" "3.2.31"
+    "@vue/shared" "3.2.31"
+    csstype "^2.6.8"
+
 "@vue/server-renderer@3.2.29":
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.2.29.tgz#ea6afa361b9c781a868c8da18c761f9b7bc89102"
@@ -2604,10 +2787,23 @@
     "@vue/compiler-ssr" "3.2.29"
     "@vue/shared" "3.2.29"
 
-"@vue/shared@3.2.29", "@vue/shared@^3.2.29":
+"@vue/server-renderer@3.2.31":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.2.31.tgz#201e9d6ce735847d5989403af81ef80960da7141"
+  integrity sha512-8CN3Zj2HyR2LQQBHZ61HexF5NReqngLT3oahyiVRfSSvak+oAvVmu8iNLSu6XR77Ili2AOpnAt1y8ywjjqtmkg==
+  dependencies:
+    "@vue/compiler-ssr" "3.2.31"
+    "@vue/shared" "3.2.31"
+
+"@vue/shared@3.2.29":
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.29.tgz#07dac7051117236431d2f737d16932aa38bbb925"
   integrity sha512-BjNpU8OK6Z0LVzGUppEk0CMYm/hKDnZfYdjSmPOs0N+TR1cLKJAkDwW8ASZUvaaSLEi6d3hVM7jnWnX+6yWnHw==
+
+"@vue/shared@3.2.31", "@vue/shared@^3.2.30":
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.31.tgz#c90de7126d833dcd3a4c7534d534be2fb41faa4e"
+  integrity sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ==
 
 "@vue/test-utils@^2.0.0-rc.14", "@vue/test-utils@^2.0.0-rc.18":
   version "2.0.0-rc.18"
@@ -3256,10 +3452,10 @@ bundle-runner@^0.0.1:
   dependencies:
     source-map "^0.7.3"
 
-c12@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/c12/-/c12-0.1.1.tgz#cdea5c6f3cc848abdebe33690b0bf05d80a9ce55"
-  integrity sha512-bwBCvV2s+IjSOHl7wSxbX007CpEHGr9Qx6qtXwghNeOPlmThxfzZVtdbhHZMiVU+EZiB1XFcQmQ9FwpQr4MWeQ==
+c12@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/c12/-/c12-0.1.3.tgz#432bddd38129203cef10c9741937d965f1601d65"
+  integrity sha512-Y5i83E2V0aOptFvm2aEAo1uxQc4F/OgdrhncxEcv6tbyU0n+wbX7e5A5U+fKBnriNdTmXLcjS811wR5FLnmwJw==
   dependencies:
     defu "^5.0.1"
     dotenv "^14.3.2"
@@ -3743,17 +3939,66 @@ cssnano-preset-default@^5.1.11:
     postcss-svgo "^5.0.3"
     postcss-unique-selectors "^5.0.3"
 
+cssnano-preset-default@^5.1.12:
+  version "5.1.12"
+  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.1.12.tgz#64e2ad8e27a279e1413d2d2383ef89a41c909be9"
+  integrity sha512-rO/JZYyjW1QNkWBxMGV28DW7d98UDLaF759frhli58QFehZ+D/LSmwQ2z/ylBAe2hUlsIWTq6NYGfQPq65EF9w==
+  dependencies:
+    css-declaration-sorter "^6.0.3"
+    cssnano-utils "^3.0.2"
+    postcss-calc "^8.2.0"
+    postcss-colormin "^5.2.5"
+    postcss-convert-values "^5.0.4"
+    postcss-discard-comments "^5.0.3"
+    postcss-discard-duplicates "^5.0.3"
+    postcss-discard-empty "^5.0.3"
+    postcss-discard-overridden "^5.0.4"
+    postcss-merge-longhand "^5.0.6"
+    postcss-merge-rules "^5.0.6"
+    postcss-minify-font-values "^5.0.4"
+    postcss-minify-gradients "^5.0.6"
+    postcss-minify-params "^5.0.5"
+    postcss-minify-selectors "^5.1.3"
+    postcss-normalize-charset "^5.0.3"
+    postcss-normalize-display-values "^5.0.3"
+    postcss-normalize-positions "^5.0.4"
+    postcss-normalize-repeat-style "^5.0.4"
+    postcss-normalize-string "^5.0.4"
+    postcss-normalize-timing-functions "^5.0.3"
+    postcss-normalize-unicode "^5.0.4"
+    postcss-normalize-url "^5.0.5"
+    postcss-normalize-whitespace "^5.0.4"
+    postcss-ordered-values "^5.0.5"
+    postcss-reduce-initial "^5.0.3"
+    postcss-reduce-transforms "^5.0.4"
+    postcss-svgo "^5.0.4"
+    postcss-unique-selectors "^5.0.4"
+
 cssnano-utils@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-3.0.1.tgz#d3cc0a142d3d217f8736837ec0a2ccff6a89c6ea"
   integrity sha512-VNCHL364lh++/ono+S3j9NlUK+d97KNkxI77NlqZU2W3xd2/qmyN61dsa47pTpb55zuU4G4lI7qFjAXZJH1OAQ==
 
-cssnano@^5.0.1, cssnano@^5.0.16, cssnano@^5.0.6:
+cssnano-utils@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-3.0.2.tgz#d82b4991a27ba6fec644b39bab35fe027137f516"
+  integrity sha512-KhprijuQv2sP4kT92sSQwhlK3SJTbDIsxcfIEySB0O+3m9esFOai7dP9bMx5enHAh2MwarVIcnwiWoOm01RIbQ==
+
+cssnano@^5.0.1, cssnano@^5.0.6:
   version "5.0.16"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.16.tgz#4ee97d30411693f3de24cef70b36f7ae2a843e04"
   integrity sha512-ryhRI9/B9VFCwPbb1z60LLK5/ldoExi7nwdnJzpkLZkm2/r7j2X3jfY+ZvDVJhC/0fPZlrAguYdHNFg0iglPKQ==
   dependencies:
     cssnano-preset-default "^5.1.11"
+    lilconfig "^2.0.3"
+    yaml "^1.10.2"
+
+cssnano@^5.0.17:
+  version "5.0.17"
+  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.17.tgz#ff45713c05cfc780a1aeb3e663b6f224d091cabf"
+  integrity sha512-fmjLP7k8kL18xSspeXTzRhaFtRI7DL9b8IcXR80JgtnWBpvAzHT7sCR/6qdn0tnxIaINUN6OEQu83wF57Gs3Xw==
+  dependencies:
+    cssnano-preset-default "^5.1.12"
     lilconfig "^2.0.3"
     yaml "^1.10.2"
 
@@ -4177,6 +4422,11 @@ esbuild-android-arm64@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.18.tgz#027a1cd57e57c6219341e116c4ac41a9952d69d1"
   integrity sha512-AuE8vIwc6QLquwykyscFk0Ji3RFczoOvjka64FJlcjLLhD6VsS584RYlQrSnPpRkv69PunUvyrBoEF7JFTJijg==
 
+esbuild-android-arm64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.21.tgz#8842d0c3b7c81fbe2dc46ddb416ffd6eb822184b"
+  integrity sha512-Bqgld1TY0wZv8TqiQmVxQFgYzz8ZmyzT7clXBDZFkOOdRybzsnj8AZuK1pwcLVA7Ya6XncHgJqIao7NFd3s0RQ==
+
 esbuild-darwin-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz#8e9169c16baf444eacec60d09b24d11b255a8e72"
@@ -4186,6 +4436,11 @@ esbuild-darwin-64@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.18.tgz#a219c50aa98b5bc08d7ce3677f5bae4b8aa5101b"
   integrity sha512-nN1XziZtDy8QYOggaXC3zu0vVh8YJpS8Bol7bHaxx0enTLDSFBCXUUJEKYpmAAJ4OZRPgjXv8NzEHHQWQvLzXg==
+
+esbuild-darwin-64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.21.tgz#ec7df02ad88ecf7f8fc23a3ed7917e07dea0c9c9"
+  integrity sha512-j+Eg+e13djzyYINVvAbOo2/zvZ2DivuJJTaBrJnJHSD7kUNuGHRkHoSfFjbI80KHkn091w350wdmXDNSgRjfYQ==
 
 esbuild-darwin-arm64@0.13.15:
   version "0.13.15"
@@ -4197,6 +4452,11 @@ esbuild-darwin-arm64@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.18.tgz#eb2d17d33c5991c183c99843698182bb702eb592"
   integrity sha512-v0i2n6TCsbxco/W1fN8RgQt3RW00Q9zJO2eqiAdmLWg6Hx0HNHloZyfhF11i7nMUUgW8r5n++ZweIXjAFPE/gQ==
 
+esbuild-darwin-arm64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.21.tgz#0c2a977edec1ef54097ee56a911518c820d4e5e4"
+  integrity sha512-nDNTKWDPI0RuoPj5BhcSB2z5EmZJJAyRtZLIjyXSqSpAyoB8eyAKXl4lB8U2P78Fnh4Lh1le/fmpewXE04JhBQ==
+
 esbuild-freebsd-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz#0b8b7eca1690c8ec94c75680c38c07269c1f4a85"
@@ -4206,6 +4466,11 @@ esbuild-freebsd-64@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.18.tgz#de06b6ce361bdf51fb66e59b220f67c4124cc728"
   integrity sha512-XLyJZTWbSuQJOqw867tBxvto6GjxULvWZYKs6RFHYQPCqgQ0ODLRtBmp4Fqqpde52yOe45npaaoup9IXNfr32A==
+
+esbuild-freebsd-64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.21.tgz#f5b5fc1d031286c3a0949d1bda7db774b7d0404e"
+  integrity sha512-zIurkCHXhxELiDZtLGiexi8t8onQc2LtuE+S7457H/pP0g0MLRKMrsn/IN4LDkNe6lvBjuoZZi2OfelOHn831g==
 
 esbuild-freebsd-arm64@0.13.15:
   version "0.13.15"
@@ -4217,6 +4482,11 @@ esbuild-freebsd-arm64@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.18.tgz#59bb55cd6ac1b2b3c43536c067d8356f4ae7e310"
   integrity sha512-0ItfrR8hePnDcUXxUQxY+VfICcBfeMJCdK6mcNUXnXw6LyHjyUYXWpFXF+J18pg1/YUWRWO1HbsJ7FEwELcQIA==
 
+esbuild-freebsd-arm64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.21.tgz#a05cab908013e4992b31a675850b8c44eb468c0c"
+  integrity sha512-wdxMmkJfbwcN+q85MpeUEamVZ40FNsBa9mPq8tAszDn8TRT2HoJvVRADPIIBa9SWWwlDChIMjkDKAnS3KS/sPA==
+
 esbuild-linux-32@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz#6fd39f36fc66dd45b6b5f515728c7bbebc342a69"
@@ -4226,6 +4496,11 @@ esbuild-linux-32@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.18.tgz#ff68f7ec7c8b8c7dddab4d6e65f1a1d0ff3ab0b9"
   integrity sha512-mnG84D9NsEsoQdBpBT0IsFjm5iAwnd81SP4tRMXZLl09lPvIWjHHSq6LDlb4+L5H5K5y68WC//X5Dr2MtNY3DQ==
+
+esbuild-linux-32@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.21.tgz#638d244cc58b951f447addb4bade628d126ef84b"
+  integrity sha512-fmxvyzOPPh2xiEHojpCeIQP6pXcoKsWbz3ryDDIKLOsk4xp3GbpHIEAWP0xTeuhEbendmvBDVKbAVv3PnODXLg==
 
 esbuild-linux-64@0.13.15:
   version "0.13.15"
@@ -4237,6 +4512,11 @@ esbuild-linux-64@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.18.tgz#d4083d9833580090452a095cd2216100d86f3c7a"
   integrity sha512-HvExRtkeA8l/p+7Lf6aBrnLH+jTCFJTUMJxGKExh2RD8lCXGTeDJFyP+BOEetP80fuuH+Syj79+LVQ9MihdBsg==
 
+esbuild-linux-64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.21.tgz#8eb634abee928be7e35b985fafbfef2f2e31397f"
+  integrity sha512-edZyNOv1ql+kpmlzdqzzDjRQYls+tSyi4QFi+PdBhATJFUqHsnNELWA9vMSzAaInPOEaVUTA5Ml28XFChcy4DA==
+
 esbuild-linux-arm64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz#3891aa3704ec579a1b92d2a586122e5b6a2bfba1"
@@ -4246,6 +4526,11 @@ esbuild-linux-arm64@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.18.tgz#8ce21e188ab9fcdb512f4ada9a637014c1294bec"
   integrity sha512-CCWmilODE1ckw+M7RVqoqKWA4UB0alCyK2bv0ikEeEAwkzinlJeoe94t9CnT/ECSQ2sL+C16idsr+aUviGp7sg==
+
+esbuild-linux-arm64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.21.tgz#e05599ea6253b58394157da162d856f3ead62f9e"
+  integrity sha512-t5qxRkq4zdQC0zXpzSB2bTtfLgOvR0C6BXYaRE/6/k8/4SrkZcTZBeNu+xGvwCU4b5dU9ST9pwIWkK6T1grS8g==
 
 esbuild-linux-arm@0.13.15:
   version "0.13.15"
@@ -4257,6 +4542,11 @@ esbuild-linux-arm@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.18.tgz#a5e1d684c451f379b1dfef7b5a2dcad84cce3f79"
   integrity sha512-+ZL8xfXVNaeaZ2Kxqlw2VYZWRDZ7NSK4zOV9GKNAtkkWURLsPUU84aUOBatRe9BH1O5FDo3LLQSlaA04ed6lhA==
 
+esbuild-linux-arm@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.21.tgz#1ae1078231cf689d3ba894a32d3723c0be9b91fd"
+  integrity sha512-aSU5pUueK6afqmLQsbU+QcFBT62L+4G9hHMJDHWfxgid6hzhSmfRH9U/f+ymvxsSTr/HFRU4y7ox8ZyhlVl98w==
+
 esbuild-linux-mips64le@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz#36b07cc47c3d21e48db3bb1f4d9ef8f46aead4f7"
@@ -4266,6 +4556,11 @@ esbuild-linux-mips64le@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.18.tgz#c3890f178745a9c65bad64322be2b3611c240041"
   integrity sha512-8LjO4+6Vxz5gbyCHO4OONYMF689nLderCtzb8lG1Bncs4ZXHpo6bjvuWeTMRbGUkvAhp+P6hMTzia7RHOC53wQ==
+
+esbuild-linux-mips64le@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.21.tgz#f05be62d126764e99b37edcac5bb49b78c7a8890"
+  integrity sha512-jLZLQGCNlUsmIHtGqNvBs3zN+7a4D9ckf0JZ+jQTwHdZJ1SgV9mAjbB980OFo66LoY+WeM7t3WEnq3FjI1zw4A==
 
 esbuild-linux-ppc64le@0.13.15:
   version "0.13.15"
@@ -4277,10 +4572,25 @@ esbuild-linux-ppc64le@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.18.tgz#a355f515ca84839f5301f8ef745a2b329105e232"
   integrity sha512-0OJk/6iYEmF1J7LXY6+cqf6Ga5vG4an7n1nubTKce7kYqaTyNGfYcTjDZce6lnDVlZTJtwntIMszq1+ZX7Kenw==
 
+esbuild-linux-ppc64le@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.21.tgz#592c98d82dad7982268ef8deed858c4566f07ab1"
+  integrity sha512-4TWxpK391en2UBUw6GSrukToTDu6lL9vkm3Ll40HrI08WG3qcnJu7bl8e1+GzelDsiw1QmfAY/nNvJ6iaHRpCQ==
+
+esbuild-linux-riscv64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.21.tgz#0db7bd6f10d8f9afea973a7d6bf87b449b864b7b"
+  integrity sha512-fElngqOaOfTsF+u+oetDLHsPG74vB2ZaGZUqmGefAJn3a5z9Z2pNa4WpVbbKgHpaAAy5tWM1m1sbGohj6Ki6+Q==
+
 esbuild-linux-s390x@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.18.tgz#81721c22387912778c67495d0a34527f7a2cde66"
   integrity sha512-UNY7YKZHjY31KcNanJK4QaT2/aoIQyS+jViP3QuDRIoYAogRnc6WydylzIkkEzGMaC4fzaXOmQ8fxwpLAXK4Yg==
+
+esbuild-linux-s390x@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.21.tgz#254a9354d34c9d1b41a3e21d2ec9269cbbb2c5df"
+  integrity sha512-brleZ6R5fYv0qQ7ZBwenQmP6i9TdvJCB092c/3D3pTLQHBGHJb5zWgKxOeS7bdHzmLy6a6W7GbFk6QKpjyD6QA==
 
 esbuild-loader@^2.18.0:
   version "2.18.0"
@@ -4304,6 +4614,11 @@ esbuild-netbsd-64@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.18.tgz#eaee109d527a58b582f8fa933d9cadf8840758c2"
   integrity sha512-wE/2xT9KNzLCfEBw24YbVmMmXH92cFIzrRPUlwWH9dIizjvEYYcyQ+peTMVkqzUum7pdlVLZ2CDDqAaZo/nW/w==
 
+esbuild-netbsd-64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.21.tgz#4cb783d060b02bf3b897a9a12cce2b3b547726f8"
+  integrity sha512-nCEgsLCQ8RoFWVV8pVI+kX66ICwbPP/M9vEa0NJGIEB/Vs5sVGMqkf67oln90XNSkbc0bPBDuo4G6FxlF7PN8g==
+
 esbuild-openbsd-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz#b22c0e5806d3a1fbf0325872037f885306b05cd7"
@@ -4313,6 +4628,11 @@ esbuild-openbsd-64@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.18.tgz#96a42615f5548529b7bb32d024bb9c6fb542778c"
   integrity sha512-vdymE2jyuH/FRmTvrguCYSrq81/rUwuhMYyvt/6ibv9ac7xQ674c8qTdT+RH73sR9/2WUD/NsYxrBA/wUVTxcg==
+
+esbuild-openbsd-64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.21.tgz#f886b93feefddbe573528fa4b421c9c6e2bc969b"
+  integrity sha512-h9zLMyVD0T73MDTVYIb/qUTokwI6EJH9O6wESuTNq6+XpMSr6C5aYZ4fvFKdNELW+Xsod+yDS2hV2JTUAbFrLA==
 
 esbuild-sunos-64@0.13.15:
   version "0.13.15"
@@ -4324,6 +4644,11 @@ esbuild-sunos-64@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.18.tgz#869723d73a5f35ba2a4a6c043694d952bd4f831b"
   integrity sha512-X/Tesy6K1MdJF1d5cbzFDxrIMMn0ye+VgTQRI8P5Vo2CcKxOdckwsKUwpRAvg+VDZ6MxrSOTYS9OOoggPUjxTg==
 
+esbuild-sunos-64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.21.tgz#3829e4d57d4cb6950837fe90b0b67cdfb37cf13a"
+  integrity sha512-Kl+7Cot32qd9oqpLdB1tEGXEkjBlijrIxMJ0+vlDFaqsODutif25on0IZlFxEBtL2Gosd4p5WCV1U7UskNQfXA==
+
 esbuild-windows-32@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz#c96d0b9bbb52f3303322582ef8e4847c5ad375a7"
@@ -4333,6 +4658,11 @@ esbuild-windows-32@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.18.tgz#197c8833ed0f6a82055ab63861777749d0ce95c0"
   integrity sha512-glG23I/JzCL4lu7DWFUtVwqFwNwlL0g+ks+mcjjUisHcINoSXTeCNToUN0bHhzn6IlXXnggNQ38Ew/idHPM8+g==
+
+esbuild-windows-32@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.21.tgz#b858a22d1a82e53cdc59310cd56294133f7a95e7"
+  integrity sha512-V7vnTq67xPBUCk/9UtlolmQ798Ecjdr1ZoI1vcSgw7M82aSSt0eZdP6bh5KAFZU8pxDcx3qoHyWQfHYr11f22A==
 
 esbuild-windows-64@0.13.15:
   version "0.13.15"
@@ -4344,6 +4674,11 @@ esbuild-windows-64@0.14.18:
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.18.tgz#569832a99d87fc931a081fe7761c100578275be0"
   integrity sha512-zEiFKHgV/3z14wsVamV98/5mxeOwz+ecyg0pD3fWcBz9j4EOIT1Tg47axypD4QLwiKFvve9mUBYX1cD99qxOyw==
 
+esbuild-windows-64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.21.tgz#7bb5a027d5720cf9caf18a4bedd11327208f1f12"
+  integrity sha512-kDgHjKOHwjfJDCyRGELzVxiP/RBJBTA+wyspf78MTTJQkyPuxH2vChReNdWc+dU2S4gIZFHMdP1Qrl/k22ZmaA==
+
 esbuild-windows-arm64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz#482173070810df22a752c686509c370c3be3b3c3"
@@ -4353,6 +4688,11 @@ esbuild-windows-arm64@0.14.18:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.18.tgz#c1991848fca7b051d1d036d0723406da9696105d"
   integrity sha512-Mh8lZFcPLat13dABN7lZThGUOn9YxoH5RYkhBq0U3WqQohHzKRhllYh7ibFixnkpMLnv8OZEbl8bGLMy03MpfA==
+
+esbuild-windows-arm64@0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.21.tgz#25df54521ad602c826b262ea2e7cc1fe80f5c2f5"
+  integrity sha512-8Sbo0zpzgwWrwjQYLmHF78f7E2xg5Ve63bjB2ng3V2aManilnnTGaliq2snYg+NOX60+hEvJHRdVnuIAHW0lVw==
 
 esbuild@^0.13.12, esbuild@^0.13.8:
   version "0.13.15"
@@ -4377,7 +4717,7 @@ esbuild@^0.13.12, esbuild@^0.13.8:
     esbuild-windows-64 "0.13.15"
     esbuild-windows-arm64 "0.13.15"
 
-esbuild@^0.14.14, esbuild@^0.14.18, esbuild@^0.14.6:
+esbuild@^0.14.14, esbuild@^0.14.6:
   version "0.14.18"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.18.tgz#9c5f58c506ec9e0ec335d20bcb3f9dbd086d0648"
   integrity sha512-vCUoISSltnX7ax01w70pWOSQT+e55o+2P/a+A9MSTukJAt3T4aDZajcjeG4fnZbkvOEv+dkKgdkvljz6vVQD4A==
@@ -4400,6 +4740,31 @@ esbuild@^0.14.14, esbuild@^0.14.18, esbuild@^0.14.6:
     esbuild-windows-32 "0.14.18"
     esbuild-windows-64 "0.14.18"
     esbuild-windows-arm64 "0.14.18"
+
+esbuild@^0.14.21:
+  version "0.14.21"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.21.tgz#b3e05f900f1c4394f596d60d63d9816468f0f671"
+  integrity sha512-7WEoNMBJdLN993dr9h0CpFHPRc3yFZD+EAVY9lg6syJJ12gc5fHq8d75QRExuhnMkT2DaRiIKFThRvDWP+fO+A==
+  optionalDependencies:
+    esbuild-android-arm64 "0.14.21"
+    esbuild-darwin-64 "0.14.21"
+    esbuild-darwin-arm64 "0.14.21"
+    esbuild-freebsd-64 "0.14.21"
+    esbuild-freebsd-arm64 "0.14.21"
+    esbuild-linux-32 "0.14.21"
+    esbuild-linux-64 "0.14.21"
+    esbuild-linux-arm "0.14.21"
+    esbuild-linux-arm64 "0.14.21"
+    esbuild-linux-mips64le "0.14.21"
+    esbuild-linux-ppc64le "0.14.21"
+    esbuild-linux-riscv64 "0.14.21"
+    esbuild-linux-s390x "0.14.21"
+    esbuild-netbsd-64 "0.14.21"
+    esbuild-openbsd-64 "0.14.21"
+    esbuild-sunos-64 "0.14.21"
+    esbuild-windows-32 "0.14.21"
+    esbuild-windows-64 "0.14.21"
+    esbuild-windows-arm64 "0.14.21"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5181,6 +5546,13 @@ get-port-please@^2.1.0:
   dependencies:
     fs-memo "^1.2.0"
 
+get-port-please@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/get-port-please/-/get-port-please-2.3.0.tgz#bf0dddd73a0c6c2c59d81bff60fa98bbde32478a"
+  integrity sha512-zO6ST8v7jBO+uSnm0vaQuZEpdr7DgY9iMgoMLUC+Zfz31HYoDiiQrL78oZspaAryT6NH903Bwk+mYxiCy3X/RQ==
+  dependencies:
+    fs-memo "^1.2.0"
+
 get-stdin@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
@@ -5278,7 +5650,7 @@ globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-globby@^13.1.1:
+globby@^13.1.0, globby@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.1.tgz#7c44a93869b0b7612e38f22ed532bfe37b25ea6f"
   integrity sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==
@@ -6349,7 +6721,7 @@ jest@^27.0.3:
     import-local "^3.0.2"
     jest-cli "^27.4.7"
 
-jiti@^1.12.14, jiti@^1.12.15, jiti@^1.12.9:
+jiti@^1.12.13, jiti@^1.12.14, jiti@^1.12.15, jiti@^1.12.9:
   version "1.12.15"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.12.15.tgz#8f6a141c06524ab32e05d5e3c9b33eeda54ae775"
   integrity sha512-/+K89y6KJA2nISbWrlc/773XdpDgSQq/LdQ+ZZyw2jRxUNyquPtbsDCCCMRzzNORUgroUGc4nAXxJEnQvpViCA==
@@ -6489,6 +6861,11 @@ klona@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
+
+knitwork@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/knitwork/-/knitwork-0.1.0.tgz#9495fde93d2390bcfa7439292fe8a44447f7fc67"
+  integrity sha512-veAmNJu4Niku+zjm2//+xLGsYTwB8OP1jBHjPU5RbQu9Jl263d5PtbM0OaITlYvhLFLov/R12hs0GL4ujzMY3A==
 
 known-css-properties@^0.24.0:
   version "0.24.0"
@@ -6956,6 +7333,11 @@ mlly@^0.4.1:
   resolved "https://registry.yarnpkg.com/mlly/-/mlly-0.4.1.tgz#e483f4be0cf3ffed13adbe93a1cfa849787a6be8"
   integrity sha512-MMJfTYwiasPah+Tx1s948OWd/+dnSxMpwPDgIt4uhnsGRuKgWG6RxUA1SzQI7Tvv0WCcpdast7htAuLU6J7YcA==
 
+mlly@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-0.4.3.tgz#a5c51b073601cc4cc49bda971f24d903a25adc29"
+  integrity sha512-xezyv7hnfFPuiDS3AiJuWs0OxlvooS++3L2lURvmh/1n7UG4O2Ehz9UkwWgg3wyLEPKGVfJLlr2DjjTCl9UJTg==
+
 mri@^1.1.6, mri@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
@@ -7014,6 +7396,69 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+"nitropack@npm:nitropack-edge@latest":
+  version "0.0.0-27409638.e9a44f5"
+  resolved "https://registry.yarnpkg.com/nitropack-edge/-/nitropack-edge-0.0.0-27409638.e9a44f5.tgz#35790bb2894aacfb40458b8351d69d51072223fb"
+  integrity sha512-ybZvflpk2Xqb3GihmxIkgk9wV13GP+QeizU2uIHyWj9ZVbzkB0f1C8r8z/EwVcgtuVYWE+3K87EciemnnQLsPA==
+  dependencies:
+    "@cloudflare/kv-asset-handler" "^0.2.0"
+    "@netlify/functions" "^0.11.0"
+    "@nuxt/devalue" "^2.0.0"
+    "@rollup/plugin-alias" "^3.1.9"
+    "@rollup/plugin-commonjs" "^21.0.1"
+    "@rollup/plugin-inject" "^4.0.4"
+    "@rollup/plugin-json" "^4.1.0"
+    "@rollup/plugin-node-resolve" "^13.1.3"
+    "@rollup/plugin-replace" "^3.0.1"
+    "@rollup/plugin-virtual" "^2.0.3"
+    "@rollup/plugin-wasm" "^5.1.2"
+    "@rollup/pluginutils" "^4.1.2"
+    "@types/jsdom" "^16.2.14"
+    "@vercel/nft" "^0.17.4"
+    archiver "^5.3.0"
+    c12 "^0.1.3"
+    chalk "^5.0.0"
+    chokidar "^3.5.3"
+    connect "^3.7.0"
+    consola "^2.15.3"
+    defu "^5.0.1"
+    destr "^1.1.0"
+    dot-prop "^7.1.1"
+    esbuild "^0.14.14"
+    etag "^1.8.1"
+    fs-extra "^10.0.0"
+    globby "^13.1.0"
+    gzip-size "^7.0.0"
+    h3 "^0.3.9"
+    hasha "^5.2.2"
+    hookable "^5.1.1"
+    http-proxy "^1.18.1"
+    is-primitive "^3.0.1"
+    jiti "^1.12.13"
+    listhen "^0.2.6"
+    mime "^3.0.0"
+    mlly "^0.4.1"
+    mri "^1.2.0"
+    node-fetch "^3.2.0"
+    object-hash "^2.2.0"
+    ohmyfetch "^0.4.15"
+    ora "^6.0.1"
+    p-debounce "^4.0.0"
+    pathe "^0.2.0"
+    pkg-types "^0.3.2"
+    pretty-bytes "^5.6.0"
+    rollup "^2.66.1"
+    rollup-plugin-terser "^7.0.2"
+    rollup-plugin-visualizer "^5.5.4"
+    scule "^0.2.1"
+    serve-placeholder "^1.2.4"
+    serve-static "^1.14.2"
+    std-env "^3.0.1"
+    table "^6.8.0"
+    ufo "^0.7.9"
+    unenv "^0.4.3"
+    unstorage "^0.3.3"
 
 node-domexception@^1.0.0:
   version "1.0.0"
@@ -7187,26 +7632,26 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-"nuxi@npm:nuxi-edge@3.0.0-27398533.8edd481":
-  version "3.0.0-27398533.8edd481"
-  resolved "https://registry.yarnpkg.com/nuxi-edge/-/nuxi-edge-3.0.0-27398533.8edd481.tgz#f2b0fd032b2f173056a9085e7f1067e5f2eeae81"
-  integrity sha512-J50WysKxmX2jZlICGsSq25Krdb1+/ybSnifwQZS3o+RnvdQxvDXM/Xxgxu1AwoEG2TC+E0sFYs8iXrzpH5yTLQ==
+"nuxi@npm:nuxi-edge@3.0.0-27415326.3c563fa":
+  version "3.0.0-27415326.3c563fa"
+  resolved "https://registry.yarnpkg.com/nuxi-edge/-/nuxi-edge-3.0.0-27415326.3c563fa.tgz#2fceecd78a651ac44ce4441da8e7aa4601fc7487"
+  integrity sha512-62IaoFA5wJtfQoioHiRURVlM6yxwT+2Irqlm3TCCxn07ptA2rkj5k4ap2nOYSd/hGnX06CZBkj3f2ubBHNsvIg==
   optionalDependencies:
     fsevents "~2.3.2"
 
-nuxt3@^3.0.0-27396610.ed4f4f5:
-  version "3.0.0-27398533.8edd481"
-  resolved "https://registry.yarnpkg.com/nuxt3/-/nuxt3-3.0.0-27398533.8edd481.tgz#7a67ca04ea996dff63a953501b55b19e2e334aaf"
-  integrity sha512-WnetxdWQqRpiUVxuFCDf50ndN0g3ePOIx0qwWdc5egbneHKcQFTYD2d6esT97mWzPYpMdakFV9TJbSnGH2XXnw==
+nuxt3@^3.0.0-27415326.3c563fa:
+  version "3.0.0-27415326.3c563fa"
+  resolved "https://registry.yarnpkg.com/nuxt3/-/nuxt3-3.0.0-27415326.3c563fa.tgz#82fb376c309c8ecac5cf5071a1f7ca094cd2a909"
+  integrity sha512-5eTqYKabzA2sI1qvOOAdP6sOFcAPneA9TIMAtxcczg4QRxdWNYE59CX43HW62xINIE/sVILID9HDuEmxiUszMg==
   dependencies:
     "@nuxt/design" "^0.1.5"
-    "@nuxt/kit" "npm:@nuxt/kit-edge@3.0.0-27398533.8edd481"
-    "@nuxt/nitro" "npm:@nuxt/nitro-edge@3.0.0-27398533.8edd481"
-    "@nuxt/schema" "npm:@nuxt/schema-edge@3.0.0-27398533.8edd481"
-    "@nuxt/vite-builder" "npm:@nuxt/vite-builder-edge@3.0.0-27398533.8edd481"
-    "@nuxt/webpack-builder" "npm:@nuxt/webpack-builder-edge@3.0.0-27398533.8edd481"
-    "@vue/reactivity" "^3.2.29"
-    "@vue/shared" "^3.2.29"
+    "@nuxt/kit" "npm:@nuxt/kit-edge@3.0.0-27415326.3c563fa"
+    "@nuxt/nitro" "npm:@nuxt/nitro-edge@3.0.0-27415326.3c563fa"
+    "@nuxt/schema" "npm:@nuxt/schema-edge@3.0.0-27415326.3c563fa"
+    "@nuxt/vite-builder" "npm:@nuxt/vite-builder-edge@3.0.0-27415326.3c563fa"
+    "@nuxt/webpack-builder" "npm:@nuxt/webpack-builder-edge@3.0.0-27415326.3c563fa"
+    "@vue/reactivity" "^3.2.30"
+    "@vue/shared" "^3.2.30"
     "@vueuse/head" "^0.7.5"
     chokidar "^3.5.3"
     consola "^2.15.3"
@@ -7214,20 +7659,23 @@ nuxt3@^3.0.0-27396610.ed4f4f5:
     defu "^5.0.1"
     destr "^1.1.0"
     escape-string-regexp "^5.0.0"
+    fs-extra "^10.0.0"
     globby "^13.1.1"
     h3 "^0.3.9"
     hash-sum "^2.0.0"
     hookable "^5.1.1"
     ignore "^5.2.0"
-    mlly "^0.4.1"
+    knitwork "^0.1.0"
+    mlly "^0.4.3"
     murmurhash-es "^0.1.1"
-    nuxi "npm:nuxi-edge@3.0.0-27398533.8edd481"
+    nitropack "npm:nitropack-edge@latest"
+    nuxi "npm:nuxi-edge@3.0.0-27415326.3c563fa"
     ohmyfetch "^0.4.15"
     pathe "^0.2.0"
     scule "^0.2.1"
     ufo "^0.7.9"
     unplugin "^0.3.2"
-    vue "^3.2.29"
+    vue "^3.2.30"
     vue-router "^4.0.12"
 
 nwsapi@^2.2.0:
@@ -7239,6 +7687,11 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.12.0"
@@ -7585,10 +8038,27 @@ postcss-colormin@^5.2.4:
     colord "^2.9.1"
     postcss-value-parser "^4.2.0"
 
+postcss-colormin@^5.2.5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-5.2.5.tgz#d1fc269ac2ad03fe641d462b5d1dada35c69968a"
+  integrity sha512-+X30aDaGYq81mFqwyPpnYInsZQnNpdxMX0ajlY7AExCexEFkPVV+KrO7kXwayqEWL2xwEbNQ4nUO0ZsRWGnevg==
+  dependencies:
+    browserslist "^4.16.6"
+    caniuse-api "^3.0.0"
+    colord "^2.9.1"
+    postcss-value-parser "^4.2.0"
+
 postcss-convert-values@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-5.0.3.tgz#492db08a28af84d57651f10edc8f6c8fb2f6df40"
   integrity sha512-fVkjHm2T0PSMqXUCIhHNWVGjhB9mHEWX2GboVs7j3iCgr6FpIl9c/IdXy0PHWZSQ9LFTRgmj98amxJE6KOnlsA==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
+postcss-convert-values@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-5.0.4.tgz#3e74dd97c581f475ae7b4500bc0a7c4fb3a6b1b6"
+  integrity sha512-bugzSAyjIexdObovsPZu/sBCTHccImJxLyFgeV0MmNBm/Lw5h5XnjfML6gzEmJ3A6nyfCW7hb1JXzcsA4Zfbdw==
   dependencies:
     postcss-value-parser "^4.2.0"
 
@@ -7597,20 +8067,40 @@ postcss-discard-comments@^5.0.2:
   resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.0.2.tgz#811ed34e2b6c40713daab0beb4d7a04125927dcd"
   integrity sha512-6VQ3pYTsJHEsN2Bic88Aa7J/Brn4Bv8j/rqaFQZkH+pcVkKYwxCIvoMQkykEW7fBjmofdTnQgcivt5CCBJhtrg==
 
+postcss-discard-comments@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.0.3.tgz#011acb63418d600fdbe18804e1bbecb543ad2f87"
+  integrity sha512-6W5BemziRoqIdAKT+1QjM4bNcJAQ7z7zk073730NHg4cUXh3/rQHHj7pmYxUB9aGhuRhBiUf0pXvIHkRwhQP0Q==
+
 postcss-discard-duplicates@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.2.tgz#61076f3d256351bdaac8e20aade730fef0609f44"
   integrity sha512-LKY81YjUjc78p6rbXIsnppsaFo8XzCoMZkXVILJU//sK0DgPkPSpuq/cZvHss3EtdKvWNYgWzQL+wiJFtEET4g==
+
+postcss-discard-duplicates@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.3.tgz#10f202a4cfe9d407b73dfea7a477054d21ea0c1f"
+  integrity sha512-vPtm1Mf+kp7iAENTG7jI1MN1lk+fBqL5y+qxyi4v3H+lzsXEdfS3dwUZD45KVhgzDEgduur8ycB4hMegyMTeRw==
 
 postcss-discard-empty@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-5.0.2.tgz#0676a9bcfc44bb00d338352a45ab80845a31d8f0"
   integrity sha512-SxBsbTjlsKUvZLL+dMrdWauuNZU8TBq5IOL/DHa6jBUSXFEwmDqeXRfTIK/FQpPTa8MJMxEHjSV3UbiuyLARPQ==
 
+postcss-discard-empty@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-5.0.3.tgz#ec185af4a3710b88933b0ff751aa157b6041dd6a"
+  integrity sha512-xGJugpaXKakwKI7sSdZjUuN4V3zSzb2Y0LOlmTajFbNinEjTfVs9PFW2lmKBaC/E64WwYppfqLD03P8l9BuueA==
+
 postcss-discard-overridden@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.3.tgz#004b9818cabb407e60616509267567150b327a3f"
   integrity sha512-yRTXknIZA4k8Yo4FiF1xbsLj/VBxfXEWxJNIrtIy6HC9KQ4xJxcPtoaaskh6QptCGrrcGnhKsTsENTRPZOBu4g==
+
+postcss-discard-overridden@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.4.tgz#cc999d6caf18ea16eff8b2b58f48ec3ddee35c9c"
+  integrity sha512-3j9QH0Qh1KkdxwiZOW82cId7zdwXVQv/gRXYDnwx5pBtR1sTkU4cXRK9lp5dSdiM0r0OICO/L8J6sV1/7m0kHg==
 
 postcss-import-resolver@^2.0.0:
   version "2.0.0"
@@ -7658,6 +8148,14 @@ postcss-merge-longhand@^5.0.5:
     postcss-value-parser "^4.2.0"
     stylehacks "^5.0.2"
 
+postcss-merge-longhand@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-5.0.6.tgz#090e60d5d3b3caad899f8774f8dccb33217d2166"
+  integrity sha512-rkmoPwQO6ymJSmWsX6l2hHeEBQa7C4kJb9jyi5fZB1sE8nSCv7sqchoYPixRwX/yvLoZP2y6FA5kcjiByeJqDg==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+    stylehacks "^5.0.3"
+
 postcss-merge-rules@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-5.0.5.tgz#2a18669ec214019884a60f0a0d356803a8138366"
@@ -7668,10 +8166,27 @@ postcss-merge-rules@^5.0.5:
     cssnano-utils "^3.0.1"
     postcss-selector-parser "^6.0.5"
 
+postcss-merge-rules@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-5.0.6.tgz#26b37411fe1e80202fcef61cab027265b8925f2b"
+  integrity sha512-nzJWJ9yXWp8AOEpn/HFAW72WKVGD2bsLiAmgw4hDchSij27bt6TF+sIK0cJUBAYT3SGcjtGGsOR89bwkkMuMgQ==
+  dependencies:
+    browserslist "^4.16.6"
+    caniuse-api "^3.0.0"
+    cssnano-utils "^3.0.2"
+    postcss-selector-parser "^6.0.5"
+
 postcss-minify-font-values@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-5.0.3.tgz#48c455c4cd980ecd07ac9bf3fc58e9d8a2ae4168"
   integrity sha512-bC45rVzEwsLhv/cL1eCjoo2OOjbSk9I7HKFBYnBvtyuIZlf7uMipMATXtA0Fc3jwPo3wuPIW1jRJWKzflMh1sA==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
+postcss-minify-font-values@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-5.0.4.tgz#627d824406b0712243221891f40a44fffe1467fd"
+  integrity sha512-RN6q3tyuEesvyCYYFCRGJ41J1XFvgV+dvYGHr0CeHv8F00yILlN8Slf4t8XW4IghlfZYCeyRrANO6HpJ948ieA==
   dependencies:
     postcss-value-parser "^4.2.0"
 
@@ -7684,6 +8199,15 @@ postcss-minify-gradients@^5.0.5:
     cssnano-utils "^3.0.1"
     postcss-value-parser "^4.2.0"
 
+postcss-minify-gradients@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-5.0.6.tgz#b07cef51a93f075e94053fd972ff1cba2eaf6503"
+  integrity sha512-E/dT6oVxB9nLGUTiY/rG5dX9taugv9cbLNTFad3dKxOO+BQg25Q/xo2z2ddG+ZB1CbkZYaVwx5blY8VC7R/43A==
+  dependencies:
+    colord "^2.9.1"
+    cssnano-utils "^3.0.2"
+    postcss-value-parser "^4.2.0"
+
 postcss-minify-params@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-5.0.4.tgz#230a4d04456609e614db1d48c2eebc21f6490a45"
@@ -7693,10 +8217,26 @@ postcss-minify-params@^5.0.4:
     cssnano-utils "^3.0.1"
     postcss-value-parser "^4.2.0"
 
+postcss-minify-params@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-5.0.5.tgz#86cb624358cd45c21946f8c317893f0449396646"
+  integrity sha512-YBNuq3Rz5LfLFNHb9wrvm6t859b8qIqfXsWeK7wROm3jSKNpO1Y5e8cOyBv6Acji15TgSrAwb3JkVNCqNyLvBg==
+  dependencies:
+    browserslist "^4.16.6"
+    cssnano-utils "^3.0.2"
+    postcss-value-parser "^4.2.0"
+
 postcss-minify-selectors@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-5.1.2.tgz#bc9698f713b9dab7f44f1ec30643fcbad9a043c0"
   integrity sha512-gpn1nJDMCf3g32y/7kl+jsdamhiYT+/zmEt57RoT9GmzlixBNRPohI7k8UIHelLABhdLf3MSZhtM33xuH5eQOQ==
+  dependencies:
+    postcss-selector-parser "^6.0.5"
+
+postcss-minify-selectors@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-5.1.3.tgz#6ac12d52aa661fd509469d87ab2cebb0a1e3a1b5"
+  integrity sha512-9RJfTiQEKA/kZhMaEXND893nBqmYQ8qYa/G+uPdVnXF6D/FzpfI6kwBtWEcHx5FqDbA79O9n6fQJfrIj6M8jvQ==
   dependencies:
     postcss-selector-parser "^6.0.5"
 
@@ -7752,10 +8292,22 @@ postcss-normalize-charset@^5.0.2:
   resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-5.0.2.tgz#eb6130c8a8e950ce25f9ea512de1d9d6a6f81439"
   integrity sha512-fEMhYXzO8My+gC009qDc/3bgnFP8Fv1Ic8uw4ec4YTlhIOw63tGPk1YFd7fk9bZUf1DAbkhiL/QPWs9JLqdF2g==
 
+postcss-normalize-charset@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-5.0.3.tgz#719fb9f9ca9835fcbd4fed8d6e0d72a79e7b5472"
+  integrity sha512-iKEplDBco9EfH7sx4ut7R2r/dwTnUqyfACf62Unc9UiyFuI7uUqZZtY+u+qp7g8Qszl/U28HIfcsI3pEABWFfA==
+
 postcss-normalize-display-values@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.2.tgz#8b5273c6c7d0a445e6ef226b8a5bb3204a55fb99"
   integrity sha512-RxXoJPUR0shSjkMMzgEZDjGPrgXUVYyWA/YwQRicb48H15OClPuaDR7tYokLAlGZ2tCSENEN5WxjgxSD5m4cUw==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
+postcss-normalize-display-values@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.3.tgz#94cc82e20c51cc4ffba6b36e9618adc1e50db8c1"
+  integrity sha512-FIV5FY/qs4Ja32jiDb5mVj5iWBlS3N8tFcw2yg98+8MkRgyhtnBgSC0lxU+16AMHbjX5fbSJgw5AXLMolonuRQ==
   dependencies:
     postcss-value-parser "^4.2.0"
 
@@ -7766,10 +8318,24 @@ postcss-normalize-positions@^5.0.3:
   dependencies:
     postcss-value-parser "^4.2.0"
 
+postcss-normalize-positions@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-5.0.4.tgz#4001f38c99675437b83277836fb4291887fcc6cc"
+  integrity sha512-qynirjBX0Lc73ROomZE3lzzmXXTu48/QiEzKgMeqh28+MfuHLsuqC9po4kj84igZqqFGovz8F8hf44hA3dPYmQ==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
 postcss-normalize-repeat-style@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.3.tgz#488c0ad8aac0fa4f66ef56cc8d604b3fd9bf705f"
   integrity sha512-uk1+xYx0AMbA3nLSNhbDrqbf/rx+Iuq5tVad2VNyaxxJzx79oGieJ6D9F6AfOL2GtiIbP7vTYlpYHtG+ERFXTg==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
+postcss-normalize-repeat-style@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.4.tgz#d005adf9ee45fae78b673031a376c0c871315145"
+  integrity sha512-Innt+wctD7YpfeDR7r5Ik6krdyppyAg2HBRpX88fo5AYzC1Ut/l3xaxACG0KsbX49cO2n5EB13clPwuYVt8cMA==
   dependencies:
     postcss-value-parser "^4.2.0"
 
@@ -7780,6 +8346,13 @@ postcss-normalize-string@^5.0.3:
   dependencies:
     postcss-value-parser "^4.2.0"
 
+postcss-normalize-string@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-5.0.4.tgz#b5e00a07597e7aa8a871817bfeac2bfaa59c3333"
+  integrity sha512-Dfk42l0+A1CDnVpgE606ENvdmksttLynEqTQf5FL3XGQOyqxjbo25+pglCUvziicTxjtI2NLUR6KkxyUWEVubQ==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
 postcss-normalize-timing-functions@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.2.tgz#db4f4f49721f47667afd1fdc5edb032f8d9cdb2e"
@@ -7787,10 +8360,25 @@ postcss-normalize-timing-functions@^5.0.2:
   dependencies:
     postcss-value-parser "^4.2.0"
 
+postcss-normalize-timing-functions@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.3.tgz#47210227bfcba5e52650d7a18654337090de7072"
+  integrity sha512-QRfjvFh11moN4PYnJ7hia4uJXeFotyK3t2jjg8lM9mswleGsNw2Lm3I5wO+l4k1FzK96EFwEVn8X8Ojrp2gP4g==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
 postcss-normalize-unicode@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.3.tgz#10f0d30093598a58c48a616491cc7fa53256dd43"
   integrity sha512-uNC7BmS/7h6to2UWa4RFH8sOTzu2O9dVWPE/F9Vm9GdhONiD/c1kNaCLbmsFHlKWcEx7alNUChQ+jH/QAlqsQw==
+  dependencies:
+    browserslist "^4.16.6"
+    postcss-value-parser "^4.2.0"
+
+postcss-normalize-unicode@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.4.tgz#02866096937005cdb2c17116c690f29505a1623d"
+  integrity sha512-W79Regn+a+eXTzB+oV/8XJ33s3pDyFTND2yDuUCo0Xa3QSy1HtNIfRVPXNubHxjhlqmMFADr3FSCHT84ITW3ig==
   dependencies:
     browserslist "^4.16.6"
     postcss-value-parser "^4.2.0"
@@ -7803,10 +8391,25 @@ postcss-normalize-url@^5.0.4:
     normalize-url "^6.0.1"
     postcss-value-parser "^4.2.0"
 
+postcss-normalize-url@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-5.0.5.tgz#c39efc12ff119f6f45f0b4f516902b12c8080e3a"
+  integrity sha512-Ws3tX+PcekYlXh+ycAt0wyzqGthkvVtZ9SZLutMVvHARxcpu4o7vvXcNoiNKyjKuWecnjS6HDI3fjBuDr5MQxQ==
+  dependencies:
+    normalize-url "^6.0.1"
+    postcss-value-parser "^4.2.0"
+
 postcss-normalize-whitespace@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.3.tgz#fb6bcc9ff2f834448b802657c7acd0956f4591d1"
   integrity sha512-333JWRnX655fSoUbufJ10HJop3c8mrpKkCCUnEmgz/Cb/QEtW+/TMZwDAUt4lnwqP6tCCk0x0b58jqvDgiQm/A==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
+postcss-normalize-whitespace@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.4.tgz#1d477e7da23fecef91fc4e37d462272c7b55c5ca"
+  integrity sha512-wsnuHolYZjMwWZJoTC9jeI2AcjA67v4UuidDrPN9RnX8KIZfE+r2Nd6XZRwHVwUiHmRvKQtxiqo64K+h8/imaw==
   dependencies:
     postcss-value-parser "^4.2.0"
 
@@ -7818,6 +8421,14 @@ postcss-ordered-values@^5.0.4:
     cssnano-utils "^3.0.1"
     postcss-value-parser "^4.2.0"
 
+postcss-ordered-values@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-5.0.5.tgz#e878af822a130c3f3709737e24cb815ca7c6d040"
+  integrity sha512-mfY7lXpq+8bDEHfP+muqibDPhZ5eP9zgBEF9XRvoQgXcQe2Db3G1wcvjbnfjXG6wYsl+0UIjikqq4ym1V2jGMQ==
+  dependencies:
+    cssnano-utils "^3.0.2"
+    postcss-value-parser "^4.2.0"
+
 postcss-reduce-initial@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-5.0.2.tgz#fa424ce8aa88a89bc0b6d0f94871b24abe94c048"
@@ -7826,10 +8437,25 @@ postcss-reduce-initial@^5.0.2:
     browserslist "^4.16.6"
     caniuse-api "^3.0.0"
 
+postcss-reduce-initial@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-5.0.3.tgz#68891594defd648253703bbd8f1093162f19568d"
+  integrity sha512-c88TkSnQ/Dnwgb4OZbKPOBbCaauwEjbECP5uAuFPOzQ+XdjNjRH7SG0dteXrpp1LlIFEKK76iUGgmw2V0xeieA==
+  dependencies:
+    browserslist "^4.16.6"
+    caniuse-api "^3.0.0"
+
 postcss-reduce-transforms@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.3.tgz#df60fab34698a43073e8b87938c71df7a3b040ac"
   integrity sha512-yDnTUab5i7auHiNwdcL1f+pBnqQFf+7eC4cbC7D8Lc1FkvNZhtpkdad+9U4wDdFb84haupMf0rA/Zc5LcTe/3A==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
+postcss-reduce-transforms@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.4.tgz#717e72d30befe857f7d2784dba10eb1157863712"
+  integrity sha512-VIJB9SFSaL8B/B7AXb7KHL6/GNNbbCHslgdzS9UDfBZYIA2nx8NLY7iD/BXFSO/1sRUILzBTfHCoW5inP37C5g==
   dependencies:
     postcss-value-parser "^4.2.0"
 
@@ -7859,10 +8485,25 @@ postcss-svgo@^5.0.3:
     postcss-value-parser "^4.1.0"
     svgo "^2.7.0"
 
+postcss-svgo@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-5.0.4.tgz#cfa8682f47b88f7cd75108ec499e133b43102abf"
+  integrity sha512-yDKHvULbnZtIrRqhZoA+rxreWpee28JSRH/gy9727u0UCgtpv1M/9WEWY3xySlFa0zQJcqf6oCBJPR5NwkmYpg==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+    svgo "^2.7.0"
+
 postcss-unique-selectors@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-5.0.3.tgz#07fd116a8fbd9202e7030f7c4952e7b52c26c63d"
   integrity sha512-V5tX2hadSSn+miVCluuK1IDGy+7jAXSOfRZ2DQ+s/4uQZb/orDYBjH0CHgFrXsRw78p4QTuEFA9kI6C956UnHQ==
+  dependencies:
+    postcss-selector-parser "^6.0.5"
+
+postcss-unique-selectors@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-5.0.4.tgz#08e188126b634ddfa615fb1d6c262bafdd64826e"
+  integrity sha512-5ampwoSDJCxDPoANBIlMgoBcYUHnhaiuLYJR5pj1DLnYQvMRVyFuTA5C3Bvt+aHtiqWpJkD/lXT50Vo1D0ZsAQ==
   dependencies:
     postcss-selector-parser "^6.0.5"
 
@@ -7909,6 +8550,11 @@ pretty-bytes@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
+
+pretty-bytes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-6.0.0.tgz#928be2ad1f51a2e336add8ba764739f9776a8140"
+  integrity sha512-6UqkYefdogmzqAZWzJ7laYeJnaXDy2/J+ZqiiMtS7t7OfpXWTlaeGMwX8U6EFvPV/YWWEKRkS8hKS4k60WHTOg==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
@@ -8223,7 +8869,7 @@ resolve@1.20.0:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.2.0, resolve@^1.20.0:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.2.0, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -8368,10 +9014,17 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.53.2, rollup@^2.59.0, rollup@^2.66.1, rollup@^2.67.0:
+rollup@^2.53.2, rollup@^2.59.0, rollup@^2.66.1:
   version "2.67.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.67.0.tgz#496de7e641dbe39f681c5a82419cb5013917d406"
   integrity sha512-W83AaERwvDiHwHEF/dfAfS3z1Be5wf7n+pO3ZAO5IQadCT2lBTr7WQ2MwZZe+nodbD+n3HtC4OCOAdsOPPcKZQ==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+rollup@^2.67.2:
+  version "2.67.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.67.2.tgz#d95e15f60932ad21e05a870bd0aa0b235d056f04"
+  integrity sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -8875,6 +9528,14 @@ stylehacks@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.0.2.tgz#fa10e5181c6e8dc0bddb4a3fb372e9ac42bba2ad"
   integrity sha512-114zeJdOpTrbQYRD4OU5UWJ99LKUaqCPJTU1HQ/n3q3BwmllFN8kHENaLnOeqVq6AhXrWfxHNZTl33iJ4oy3cQ==
+  dependencies:
+    browserslist "^4.16.6"
+    postcss-selector-parser "^6.0.4"
+
+stylehacks@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.0.3.tgz#2ef3de567bfa2be716d29a93bf3d208c133e8d04"
+  integrity sha512-ENcUdpf4yO0E1rubu8rkxI+JGQk4CgjchynZ4bDBJDfqdy+uhTRSWb8/F3Jtu+Bw5MW45Po3/aQGeIyyxgQtxg==
   dependencies:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
@@ -9499,7 +10160,7 @@ validator@^13.7.0:
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
-vite@^2.4.4, vite@^2.7.13:
+vite@^2.4.4:
   version "2.7.13"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.7.13.tgz#99b56e27dfb1e4399e407cf94648f5c7fb9d77f5"
   integrity sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==
@@ -9507,6 +10168,18 @@ vite@^2.4.4, vite@^2.7.13:
     esbuild "^0.13.12"
     postcss "^8.4.5"
     resolve "^1.20.0"
+    rollup "^2.59.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vite@^2.8.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.2.tgz#6bced4a0a8b0db24636f5159c3f371c156521a58"
+  integrity sha512-zawfykcPVPYva4KusIWORNLr324Qx86/3NpfQSIOJdjnL5pYhwDoImLYMOh4lFLcP/7//tNuWM2vx2F5OSVC9w==
+  dependencies:
+    esbuild "^0.14.14"
+    postcss "^8.4.6"
+    resolve "^1.22.0"
     rollup "^2.59.0"
   optionalDependencies:
     fsevents "~2.3.2"
@@ -9582,7 +10255,7 @@ vue-style-loader@^4.1.3:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue@3.2.29, vue@^3.2.29:
+vue@3.2.29:
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.29.tgz#3571b65dbd796d3a6347e2fd45a8e6e11c13d56a"
   integrity sha512-cFIwr7LkbtCRanjNvh6r7wp2yUxfxeM2yPpDQpAfaaLIGZSrUmLbNiSze9nhBJt5MrZ68Iqt0O5scwAMEVxF+Q==
@@ -9592,6 +10265,17 @@ vue@3.2.29, vue@^3.2.29:
     "@vue/runtime-dom" "3.2.29"
     "@vue/server-renderer" "3.2.29"
     "@vue/shared" "3.2.29"
+
+vue@^3.2.30:
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.31.tgz#e0c49924335e9f188352816788a4cca10f817ce6"
+  integrity sha512-odT3W2tcffTiQCy57nOT93INw1auq5lYLLYtWpPYQQYQOOdHiqFct9Xhna6GJ+pJQaF67yZABraH47oywkJgFw==
+  dependencies:
+    "@vue/compiler-dom" "3.2.31"
+    "@vue/compiler-sfc" "3.2.31"
+    "@vue/runtime-dom" "3.2.31"
+    "@vue/server-renderer" "3.2.31"
+    "@vue/shared" "3.2.31"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5368,9 +5368,9 @@ flatted@^3.1.0:
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
 follow-redirects@^1.0.0:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 foreach@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
Changelog:

#### ⚠️ Breaking change

- The genesis theme should now be imported from `import '@formkit/themes/genesis`.

#### 🎉 New features

- Adds [programmatic form submission](/essentials/forms#submitting-forms-programmatically):
  - Can be submitted by node `node.submit()` (including any child node of the form).
  - Can be submitted via function `this.$formkit.submit('form-id')` (for composition api it's `submitForm('form-id')`).
- Improved `setErrors` DX:
  - Can now be called directly on a node `node.setErrors(nodeErrors, childErrors)`.
  - `setErrors` now supports pure string `node.setErrors('My error')`
- Submit handler is now passed the form’s node for easy error setting.
- A `<FormKit>` component’s [core node](/advanced/core#node) is now available via template ref.
- Adds `data-invalid` attribute to the `outer` section when an input has failing validation messages that are currently displayed ([playground example](https://formkit.link/cb85162e120c9de18e0298dbd8ca849e)).
- Adds `data-errors` attribute to the `outer` section when the input has explicitly placed errors (via prop or `setErrors`).
- Adds `data-complete` attribute to the `outer` section when an input ([playground example](https://formkit.link/cb85162e120c9de18e0298dbd8ca849e)):
  - Either:
    - The input has validation rules.
    - The validation rules are all passing.
    - There are no errors on the input.
  - Or:
    - The input has no validation rules.
    - The input has no errors.
    - The input is dirty and has a value.
- New `context.state` properties:
  - `state.rules` - true when the input has validation rules.
  - `state.errors` - true when the input has explicit errors placed on it.
  - `state.complete` - same as logic as `data-complete`.
  - `state.validationVisible` - true when the `validation-visibility` condition is met (it is showing validation errors if there are any).
- Refactors the Nuxt 3 module for faster build time and better file resolution.
- Adds 🇮🇷 Persian language support (thanks @shahabbasian)
- Adds 🇧🇷 Portuguese language support (thanks @r-martins)
- Adds 🇹🇷 Turkish language support (thanks @ragokan)
- Adds 🇫🇮 Finish language support (thanks @mihqusta)
- Adds 🇦🇷 Spanish language support (thanks @inibg)

#### 📙 Documentation

- Added `node.setErrors` [documentation](/essentials/forms#using-nodeseterrors).
- Added [programmatic form submission documentation](/essentials/forms#submitting-forms-programmatically).
- Improved `context.state` documentation with [new properties and better descriptions](/advanced/context#state).

#### 🐛 Bug fixes

- Fixes an issue that cause server side rendering and server side generation on Nuxt and vite-ssg/vitesse to throw exceptions during build process ([#81](https://github.com/formkit/formkit/issues/81)).
- Fixes a bug that prevented `file` inputs from triggering custom `onChange` events ([#90](https://github.com/formkit/formkit/issues/90)).
- Fixes a bug that prevented forms from outputting their `id` to the DOM.
- Fixes a styling issue in the genesis theme that cause select lists items to be grey before an option was selected when using a placeholder ([#59](https://github.com/formkit/formkit/issues/59))
- Fixes a bug that caused the `:value` prop on forms to be mutated on input ([#72](https://github.com/formkit/formkit/issues/72)).
- Fixes inconsistency between `prop:{propName}` events emitted by default props and custom input defined props ([#73](https://github.com/formkit/formkit/issues/73))