### PR TITLE
Add data-invalid on form submission

### DIFF
--- a/packages/inputs/src/composables/outer.ts
+++ b/packages/inputs/src/composables/outer.ts
@@ -9,7 +9,7 @@ const outer = composable('outer', () => ({
     'data-disabled': '$disabled || undefined',
     'data-complete': '$state.complete || undefined',
     'data-invalid':
-      '$state.valid === false && ($state.validationVisible || $state.submitted) || undefined',
+      '$state.valid === false && $state.validationVisible || undefined',
     'data-errors': '$state.errors || undefined',
   },
 }))

--- a/packages/inputs/src/composables/outer.ts
+++ b/packages/inputs/src/composables/outer.ts
@@ -9,7 +9,7 @@ const outer = composable('outer', () => ({
     'data-disabled': '$disabled || undefined',
     'data-complete': '$state.complete || undefined',
     'data-invalid':
-      '$state.valid === false && $state.validationVisible || undefined',
+      '$state.valid === false && ($state.validationVisible || $state.submitted) || undefined',
     'data-errors': '$state.errors || undefined',
   },
 }))

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -54,6 +54,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
    * The current visibility state of validation messages.
    */
   const validationVisible = computed<boolean>(() => {
+    if (context.state.submitted) return true
     switch (validationVisibility.value) {
       case 'live':
         return true


### PR DESCRIPTION
I propose this change to make the error styles via [data-invalid] class in css visibles when the form is submitted