### PR TITLE
fix: add formkitschema in plugin creation

### DIFF
--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -480,6 +480,8 @@ export type FormKitOptions = Partial<
     props: Partial<FormKitProps>
     children: FormKitNode[] | Set<FormKitNode>
     plugins: FormKitPlugin[]
+    alias: string
+    schemaAlias: string
   }
 >
 

--- a/packages/nuxt/src/runtime/plugin.mjs
+++ b/packages/nuxt/src/runtime/plugin.mjs
@@ -1,9 +1,7 @@
 import { defineNuxtPlugin } from '#app'
-import { plugin, defaultConfig, FormKitSchema } from '@formkit/vue'
+import { plugin, defaultConfig } from '@formkit/vue'
 <%= options.importStatement %>
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp
-    .use(plugin, <%= options.config %>)
-    .component('FormKitSchema', FormKitSchema)
+  nuxtApp.vueApp.use(plugin, <%= options.config %>)
 })

--- a/packages/nuxt/src/runtime/plugin.mjs
+++ b/packages/nuxt/src/runtime/plugin.mjs
@@ -1,7 +1,9 @@
 import { defineNuxtPlugin } from '#app'
-import { plugin, defaultConfig } from '@formkit/vue'
+import { plugin, defaultConfig, FormKitSchema } from '@formkit/vue'
 <%= options.importStatement %>
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(plugin, <%= options.config %>)
+  nuxtApp.vueApp
+    .use(plugin, <%= options.config %>)
+    .component('FormKitSchema', FormKitSchema)
 })

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -13,7 +13,7 @@ export const parentSymbol: InjectionKey<FormKitNode> = Symbol('FormKitParent')
  * The root FormKit component.
  * @public
  */
-const FormKit = defineComponent({
+export const FormKit = defineComponent({
   props,
   emits: {
     /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/vue/src/FormKitSchema.ts
+++ b/packages/vue/src/FormKitSchema.ts
@@ -766,3 +766,5 @@ export const FormKitSchema = defineComponent({
     return () => render()
   },
 })
+
+export default FormKitSchema

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -10,6 +10,7 @@ import {
 } from '@formkit/core'
 import type { App, Plugin, InjectionKey } from 'vue'
 import FormKit from './FormKit'
+import FormKitSchema from './FormKitSchema'
 
 /**
  * The global instance of the FormKit plugin.
@@ -36,7 +37,9 @@ function createPlugin(
   app: App<any>,
   options: FormKitOptions & Record<string, any>
 ): FormKitVuePlugin {
-  app.component(options.alias || 'FormKit', FormKit)
+  app
+    .component(options.alias || 'FormKit', FormKit)
+    .component(options.schemaAlias || 'FormKitSchema', FormKitSchema)
   return {
     get: getNode,
     setLocale: (locale: string) => {
@@ -79,6 +82,7 @@ export const plugin: Plugin = {
     const options: FormKitOptions = Object.assign(
       {
         alias: 'FormKit',
+        schemaAlias: 'FormKitSchema',
       },
       typeof _options === 'function' ? _options() : _options
     )


### PR DESCRIPTION
@justin-schroeder base on you feedback, moved FormKitSchema to the plugin installation. 

- register `FormKitSchema` as a component in `createPlugin`
- align exports of `FormKit` & `FormKitSchema`
- add `alias` and `schemaAlias` props to the `FormKitOptions` type

Hope that's better