### PR TITLE
adds custom attributes and message states by theme

### DIFF
--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -5,18 +5,20 @@ import plugin from 'tailwindcss/plugin'
  * The FormKit plugin for Tailwind
  * @public
  */
-const formKitVariants = plugin(({ addVariant }) => {
-  addVariant('formkit-disabled', ['&[data-disabled]', '[data-disabled] &', '[data-disabled]&'])
-  addVariant('formkit-invalid', ['&[data-invalid]', '[data-invalid] &', '[data-invalid]&'])
-  addVariant('formkit-errors', ['&[data-errors]', '[data-errors] &', '[data-errors]&'])
-  addVariant('formkit-complete', ['&[data-complete]', '[data-complete] &', '[data-complete]&'])
-  addVariant('formkit-loading', ['&[data-loading]', '[data-loading] &', '[data-loading]&'])
-  addVariant('formkit-submitted', ['&[data-submitted]', '[data-submitted] &', '[data-submitted]&'])
-  addVariant('formkit-multiple', ['&[data-multiple]', '[data-multiple] &', '[data-multiple]&'])
-  addVariant('formkit-action', ['.formkit-actions &', '.formkit-actions&'])
-  addVariant('formkit-message-validation', ['[data-message-type="validation"] &', '[data-message-type="validation"]&'])
-  addVariant('formkit-message-error', ['[data-message-type="error"] &', '[data-message-type="error"]&'])
-})
+const formKitVariants = plugin(({ addVariant, theme }) => {
+  const attributes: string[] = theme('formkit.attributes') || [];
+  const messageStates: string[] = theme('formkit.messageStates') || [];
+
+  addVariant('formkit-action', ['.formkit-actions &', '.formkit-actions&']);
+
+  ['disabled', 'invalid', 'errors', 'complete', 'loading', 'submitted', 'multiple', ...attributes].forEach((attribute) => {
+    addVariant(`formkit-${attribute}`, [`&[data-${attribute}]`, `[data-${attribute}] &`, `[data-${attribute}]&`])
+  });
+
+  ['validation', 'error', ...messageStates].forEach((state) => {
+    addVariant(`formkit-message-${state}`, [`[data-message-type="${state}"] &`, `[data-message-type="${state}"]&`])
+  });
+});
 
 /**
  * An object of ClassFunctions


### PR DESCRIPTION
By adding the theme function from tailwind, it makes it possible to add custom data attributes and message states.

```js
module.exports = {
  ...
  plugins: [
    require('@formkit/tailwindcss')
  ],
  theme: {
    formkit: {
      attributes: ['custom'],
      messageStates: ['success']
    }
  }
}
```