### PR TITLE
Fixes Type 'ClassFunction' is not assignable to type 'FormKitClasses'

### DIFF
--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -5,18 +5,20 @@ import plugin from 'tailwindcss/plugin'
  * The FormKit plugin for Tailwind
  * @public
  */
-const formKitVariants = plugin(({ addVariant }) => {
-  addVariant('formkit-disabled', ['&[data-disabled]', '[data-disabled] &', '[data-disabled]&'])
-  addVariant('formkit-invalid', ['&[data-invalid]', '[data-invalid] &', '[data-invalid]&'])
-  addVariant('formkit-errors', ['&[data-errors]', '[data-errors] &', '[data-errors]&'])
-  addVariant('formkit-complete', ['&[data-complete]', '[data-complete] &', '[data-complete]&'])
-  addVariant('formkit-loading', ['&[data-loading]', '[data-loading] &', '[data-loading]&'])
-  addVariant('formkit-submitted', ['&[data-submitted]', '[data-submitted] &', '[data-submitted]&'])
-  addVariant('formkit-multiple', ['&[data-multiple]', '[data-multiple] &', '[data-multiple]&'])
-  addVariant('formkit-action', ['.formkit-actions &', '.formkit-actions&'])
-  addVariant('formkit-message-validation', ['[data-message-type="validation"] &', '[data-message-type="validation"]&'])
-  addVariant('formkit-message-error', ['[data-message-type="error"] &', '[data-message-type="error"]&'])
-})
+const formKitVariants = plugin(({ addVariant, theme }) => {
+  const attributes: string[] = theme('formkit.attributes') || [];
+  const messageStates: string[] = theme('formkit.messageStates') || [];
+
+  addVariant('formkit-action', ['.formkit-actions &', '.formkit-actions&']);
+
+  ['disabled', 'invalid', 'errors', 'complete', 'loading', 'submitted', 'multiple', ...attributes].forEach((attribute) => {
+    addVariant(`formkit-${attribute}`, [`&[data-${attribute}]`, `[data-${attribute}] &`, `[data-${attribute}]&`])
+  });
+
+  ['validation', 'error', ...messageStates].forEach((state) => {
+    addVariant(`formkit-message-${state}`, [`[data-message-type="${state}"] &`, `[data-message-type="${state}"]&`])
+  });
+});
 
 /**
  * An object of ClassFunctions

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -21,14 +21,6 @@ const formKitVariants = plugin(({ addVariant, theme }) => {
 });
 
 /**
- * An object of ClassFunctions
- * @internal
- */
-interface FormKitClassFunctions {
-  [index: string]: ClassFunction
-}
-
-/**
  * A function that returns a class list string
  * @internal
  */
@@ -46,7 +38,7 @@ type ClassFunction = (
  */
 export function generateClasses(
   classes: Record<string, Record<string, string>>
-): FormKitClassFunctions {
+): Record<string, string | FormKitClasses | Record<string, boolean>> {
   const classesBySectionKey: Record<string, Record<string, any>> = {}
   Object.keys(classes).forEach((type) => {
     Object.keys(classes[type]).forEach((sectionKey) => {
@@ -62,16 +54,12 @@ export function generateClasses(
 
   Object.keys(classesBySectionKey).forEach((sectionKey) => {
     const classesObject = classesBySectionKey[sectionKey]
-    classesBySectionKey[sectionKey] = function (
-      node: FormKitNode,
-      sectionKey: string,
-      sectionClassList: FormKitClasses | string | Record<string, boolean>
-    ) {
+    classesBySectionKey[sectionKey] = function (node, sectionKey, sectionClassList) {
       return formKitStates(node, sectionKey, sectionClassList, classesObject)
-    }
+    } as ClassFunction
   })
 
-  return classesBySectionKey as FormKitClassFunctions
+  return classesBySectionKey;
 }
 
 function formKitStates(


### PR DESCRIPTION
Fixed #143 when using the new @formkit/tailwindcss generateClasses with typescript enabled.