### PR TITLE
Adds node reset event

### DIFF
--- a/packages/core/__tests__/node.spec.ts
+++ b/packages/core/__tests__/node.spec.ts
@@ -1364,4 +1364,12 @@ describe('resetting', () => {
     node.reset()
     expect(node.value).toEqual({ alpha: 'abc' })
   })
+
+  it('emits an reset event', async () => {
+    const resetEvent = jest.fn()
+    const node = createNode({ value: 'foobar' })
+    node.on('reset', resetEvent)
+    node.reset()
+    expect(resetEvent).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/core/src/reset.ts
+++ b/packages/core/src/reset.ts
@@ -59,6 +59,7 @@ export function reset(
     // release the events.
     node._e.play(node)
     clearState(node)
+    node.emit('reset', node)
     return node
   }
   warn(152, id)


### PR DESCRIPTION
At the moment no event will be emitted when the node reset functionality is used.

With these changes, a `reset` event will be emitted at the end of a node reset call.