### PR TITLE
feat(themes): :sparkles: adds theme to the tailwindcss plugin

### DIFF
--- a/packages/themes/src/tailwindcss/index.ts
+++ b/packages/themes/src/tailwindcss/index.ts
@@ -4,51 +4,19 @@ import plugin from 'tailwindcss/plugin.js'
  * The FormKit plugin for Tailwind
  * @public
  */
-const FormKitVariants = plugin(({ addVariant }) => {
-  addVariant('formkit-disabled', [
-    '&[data-disabled]',
-    '[data-disabled] &',
-    '[data-disabled]&',
-  ])
-  addVariant('formkit-invalid', [
-    '&[data-invalid]',
-    '[data-invalid] &',
-    '[data-invalid]&',
-  ])
-  addVariant('formkit-errors', [
-    '&[data-errors]',
-    '[data-errors] &',
-    '[data-errors]&',
-  ])
-  addVariant('formkit-complete', [
-    '&[data-complete]',
-    '[data-complete] &',
-    '[data-complete]&',
-  ])
-  addVariant('formkit-loading', [
-    '&[data-loading]',
-    '[data-loading] &',
-    '[data-loading]&',
-  ])
-  addVariant('formkit-submitted', [
-    '&[data-submitted]',
-    '[data-submitted] &',
-    '[data-submitted]&',
-  ])
-  addVariant('formkit-multiple', [
-    '&[data-multiple]',
-    '[data-multiple] &',
-    '[data-multiple]&',
-  ])
-  addVariant('formkit-action', ['.formkit-actions &', '.formkit-actions&'])
-  addVariant('formkit-message-validation', [
-    '[data-message-type="validation"] &',
-    '[data-message-type="validation"]&',
-  ])
-  addVariant('formkit-message-error', [
-    '[data-message-type="error"] &',
-    '[data-message-type="error"]&',
-  ])
+const FormKitVariants = plugin(({ addVariant, theme }) => {
+  const attributes: string[] = theme('formkit.attributes') || []
+  const messageStates: string[] = theme('formkit.messageStates') || []
+
+  addVariant('formkit-action', ['.formkit-actions &', '.formkit-actions&']);
+
+  ['disabled', 'invalid', 'errors', 'complete', 'loading', 'submitted', 'multiple', ...attributes].forEach((attribute) => {
+    addVariant(`formkit-${attribute}`, [`&[data-${attribute}]`, `[data-${attribute}] &`, `[data-${attribute}]&`])
+  });
+
+  ['validation', 'error', ...messageStates].forEach((state) => {
+    addVariant(`formkit-message-${state}`, [`[data-message-type="${state}"] &`, `[data-message-type="${state}"]&`])
+  })
 })
 
 export default FormKitVariants


### PR DESCRIPTION
By adding the theme function from tailwind, it makes it possible to add custom data attributes and message states.

```js
module.exports = {
  ...
  plugins: [
    require('@formkit/tailwindcss')
  ],
  theme: {
    formkit: {
      attributes: ['custom'],
      messageStates: ['success']
    }
  }
}
```