### PR TITLE
fix: update value, if modelValue is initially undefined

### DIFF
--- a/packages/vue/src/composables/useInput.ts
+++ b/packages/vue/src/composables/useInput.ts
@@ -152,7 +152,7 @@ export function useInput(
   /**
    * Determines if the prop is v-modeled.
    */
-  const isVModeled = props.modelValue !== undefined
+  const isVModeled = 'modelValue' in props
 
   /**
    * Determines if the object being passed as a v-model is reactive.

--- a/packages/vue/src/composables/useInput.ts
+++ b/packages/vue/src/composables/useInput.ts
@@ -162,10 +162,9 @@ export function useInput(
   /**
    * Define the initial component
    */
-  const value: any =
-    props.modelValue !== undefined
-      ? props.modelValue
-      : cloneAny(context.attrs.value)
+  const value: any = isVModeled
+    ? props.modelValue
+    : cloneAny(context.attrs.value)
 
   /**
    * Creates the node's initial props from the context, props, and definition


### PR DESCRIPTION
Properly fix #235

[Vue SFC Playground](https://sfc.vuejs.org/#eNp9Uj1vg0AM/SvuLbRSwqkrgkhVlnbr1C63UDAJEfch30EHxH+vD2iapFU3np/9fM+PUTw5lw49ikzkvqLWBfAYerdTptXOUoARCBuYoCGrIeHWRBmAldxb7VYmlRFELW5QprLGB9D+AEUUuE+esessvFvq6rvkQZlcLvt4E4OA2nVlQEYA+fFxN47z8DTlktFcbY3rAwxbbWvsCiWYV2Kh5nfcMCCZy+VZWWzE8uqtLl168taw6TGOq5XwSmQwV2KNnUSsxDEE5zMpfVNFeyefWjpI/kqpN6HVmKLX2w+ynx6JhZXYXGhILg5IW0JTIyH9p3nT+ks3yk7KTGzl+9h/BHdOZzxg2PfEcuGF0yhNhdc5LiE5ss5zTDU2rcHXiO75CrznOqbLkDiecR2oM0jmw7+VHatCaxbFDQyxkC0o/WmBoiigZ4vzNP9aE3u6DGr6AtSB560=). You can add/remove `modelValue` in `defineProps` to see how it behaves on `props`.

----

Without the fix FormKit component works unexpectedly:
- when initial value is `undefined`, it won't register it with `node.input`
- it won't update `context._value`, if `modelValue` changes from `undefined` to anything else

Essentially, binding between `context._value` and `modelValue` is lost. `modelValue` with undefined value works well with native Vue components.