### PR TITLE
fix: define name for vue components

### DIFF
--- a/packages/themes/src/css/genesis/inputs/checkbox-and-radio.css
+++ b/packages/themes/src/css/genesis/inputs/checkbox-and-radio.css
@@ -23,51 +23,52 @@
     overflow: hidden;
     opacity: 0;
     left: -999em;
+  }
 
-    & ~ .formkit-decorator {
-      background: var(--fk-bg-decorator);
-      display: block;
-      box-sizing: content-box;
-      width: var(--fk-box-size);
-      height: var(--fk-box-size);
-      flex: 0 0 var(--fk-box-size);
-      border: none;
-      box-shadow: var(--fk-border-box-shadow);
-      border-radius: var(--fk-border-radius);
-      margin: var(--fk-margin-decorator);
-      position: relative;
+  & .formkit-input ~ .formkit-decorator {
+    background: var(--fk-bg-decorator);
+    display: block;
+    box-sizing: content-box;
+    width: var(--fk-box-size);
+    height: var(--fk-box-size);
+    flex: 0 0 var(--fk-box-size);
+    border: none;
+    box-shadow: var(--fk-border-box-shadow);
+    border-radius: var(--fk-border-radius);
+    margin: var(--fk-margin-decorator);
+    position: relative;
+  }
 
-      &::before {
-        background: transparent;
-        content: "";
-        display: block;
-        width: 55%;
-        height: 20%;
-        pointer-events: none;
-        border-bottom: 0.2em solid transparent;
-        border-left: 0.2em solid transparent;
-        transform: rotate(-45deg);
-        transform-origin: bottom left;
-        position: absolute;
-        bottom: 20%;
-        left: 40%;
-      }
-    }
+  & .formkit-input ~ .formkit-decorator::before {
+    background: transparent;
+    content: "";
+    display: block;
+    width: 55%;
+    height: 20%;
+    pointer-events: none;
+    border-bottom: 0.2em solid transparent;
+    border-left: 0.2em solid transparent;
+    transform: rotate(-45deg);
+    transform-origin: bottom left;
+    position: absolute;
+    bottom: 20%;
+    left: 40%;
+  }
 
-    &:checked ~ .formkit-decorator {
-      box-shadow: var(--fk-border-box-shadow-decorator-checked);
+  & .formkit-input ~ .formkit-decorator:checked {
+    box-shadow: var(--fk-border-box-shadow-decorator-checked);
+  }
 
-      &::before {
-        border-color: var(--fk-color-border-focus);
-      }
-    }
-    &:focus ~ .formkit-decorator {
-      box-shadow: var(--fk-border-box-shadow-decorator-focus);
-    }
-    &:focus-visible ~ .formkit-decorator {
-      box-shadow: var(--fk-border-box-shadow-decorator-focus-visible);
-    }
+  & .formkit-input ~ .formkit-decorator:checked::before {
+    border-color: var(--fk-color-border-focus);
+  }
 
+  & .formkit-input:focus ~ .formkit-decorator {
+    box-shadow: var(--fk-border-box-shadow-decorator-focus);
+  }
+
+  & .formkit-input:focus-visible ~ .formkit-decorator {
+    box-shadow: var(--fk-border-box-shadow-decorator-focus-visible);
   }
 
   & .formkit-options {
@@ -78,10 +79,10 @@
   & .formkit-option {
     list-style-type: none;
     margin: var(--fk-margin-option);
+  }
 
-    &:last-child {
-      margin-bottom: 0;
-    }
+  & .formkit-option:last-child {
+    margin-bottom: 0;
   }
 
   & fieldset.formkit-fieldset {

--- a/packages/themes/src/css/genesis/inputs/file.css
+++ b/packages/themes/src/css/genesis/inputs/file.css
@@ -13,10 +13,11 @@
     font-size: var(--fk-font-size-input);
     line-height: var(--fk-line-height-input);
     position: relative;
+  }
 
-    & + .formkit-file-item {
-      margin-top: var(--fk-padding-input-t);
-    }
+  & .formkit-no-files + .formkit-file-item,
+  & .formkit-file-item + .formkit-file-item {
+    margin-top: var(--fk-padding-input-t);
   }
 
   &[data-multiple] .formkit-file-remove {

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -20,6 +20,7 @@ export const parentSymbol: InjectionKey<FormKitNode> = Symbol('FormKitParent')
  * @public
  */
 export const FormKit = defineComponent({
+  name: 'FormKit',
   props,
   emits: {
     /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/vue/src/FormKitIcon.ts
+++ b/packages/vue/src/FormKitIcon.ts
@@ -9,6 +9,7 @@ import { FormKitIconLoader, createIconHandler } from '@formkit/themes'
  * @public
  */
 export const FormKitIcon = defineComponent({
+  name: 'FormKitIcon',
   props: {
     icon: {
       type: String,


### PR DESCRIPTION
This helps with Vue stark trace, if something went wrong. Some other tools also use names, like Histoire. 

 Note: `FormKitSchema` already has `name` defined.