### PR TITLE
fix: fix checkbox css selector

### DIFF
--- a/packages/themes/src/css/genesis/inputs/checkbox-and-radio.css
+++ b/packages/themes/src/css/genesis/inputs/checkbox-and-radio.css
@@ -55,11 +55,11 @@
     left: 40%;
   }
 
-  & .formkit-input ~ .formkit-decorator:checked {
+  & .formkit-input:checked ~ .formkit-decorator {
     box-shadow: var(--fk-border-box-shadow-decorator-checked);
   }
 
-  & .formkit-input ~ .formkit-decorator:checked::before {
+  & .formkit-input:checked ~ .formkit-decorator::before {
     border-color: var(--fk-color-border-focus);
   }
 


### PR DESCRIPTION
The style of checkbox in genesis theme has broken by  https://github.com/formkit/formkit/commit/678f6729de99bc859381f5efe1e6f0cea4448adc of PR #314.

fixed it to work as originally intended.