### PR TITLE
Adds family support to generateClasses

### DIFF
--- a/packages/tailwindcss/playground/src/theme.js
+++ b/packages/tailwindcss/playground/src/theme.js
@@ -1,19 +1,23 @@
 const textClassification = {
   label: 'block mb-1 font-bold text-sm formkit-invalid:text-red-500',
-  inner: 'max-w-md border border-gray-400 rounded-lg mb-1 overflow-hidden focus-within:border-blue-500 formkit-submitted:formkit-invalid:border-red-500',
-  input: 'w-full h-10 px-3 border-none text-base text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-0 formkit-multiple:h-48',
+  inner:
+    'max-w-md border border-gray-400 rounded-lg mb-1 overflow-hidden focus-within:border-blue-500 formkit-submitted:formkit-invalid:border-red-500',
+  input:
+    'w-full h-10 px-3 border-none text-base text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-0 formkit-multiple:h-48',
 }
 const boxClassification = {
   fieldset: 'max-w-md border border-gray-400 rounded-md px-2 pb-1',
   legend: 'font-bold text-sm',
   wrapper: 'flex items-center mb-1 cursor-pointer',
   help: 'mb-2',
-  input: 'form-check-input appearance-none h-5 w-5 mr-2 border border-gray-500 rounded-sm bg-white checked:bg-blue-500 focus:outline-none focus:ring-0 transition duration-200',
-  label: 'text-sm text-gray-700 mt-1'
+  input:
+    'form-check-input appearance-none h-5 w-5 mr-2 border border-gray-500 rounded-sm bg-white checked:bg-blue-500 focus:outline-none focus:ring-0 transition duration-200',
+  label: 'text-sm text-gray-700 mt-1',
 }
 const buttonClassification = {
   wrapper: 'mb-1',
-  input: 'bg-blue-500 hover:bg-blue-700 text-white text-sm font-normal py-3 px-5 rounded'
+  input:
+    'bg-blue-500 hover:bg-blue-700 text-white text-sm font-normal py-3 px-5 rounded',
 }
 
 export default {
@@ -21,44 +25,34 @@ export default {
     outer: 'w-60 mb-5 formkit-disabled:opacity-30',
     help: 'text-xs text-gray-500',
     messages: 'list-none p-0 mt-1 mb-3',
-    message: 'text-red-500 mb-1 text-xs'
+    message: 'text-red-500 mb-1 text-xs',
   },
+  'family:text': textClassification,
   button: buttonClassification,
   color: {
     label: 'block mb-1 font-bold text-sm',
-    input: 'w-16 h-8 appearance-none cursor-pointer border border-gray-300 rounded-md mb-2 p-1'
+    input:
+      'w-16 h-8 appearance-none cursor-pointer border border-gray-300 rounded-md mb-2 p-1',
   },
-  date: textClassification,
-  'datetime-local': textClassification,
-  checkbox: boxClassification,
-  email: textClassification,
   file: {
     label: 'block mb-1 font-bold text-sm',
     inner: 'max-w-md cursor-pointer',
-    input: 'text-gray-600 text-sm mb-1 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:bg-blue-500 file:text-white hover:file:bg-blue-600',
+    input:
+      'text-gray-600 text-sm mb-1 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:bg-blue-500 file:text-white hover:file:bg-blue-600',
     noFiles: 'block text-gray-800 text-sm mb-1',
     fileItem: 'block flex text-gray-800 text-sm mb-1',
-    removeFiles: 'ml-auto text-blue-500 text-sm'
+    removeFiles: 'ml-auto text-blue-500 text-sm',
   },
-  month: textClassification,
-  number: textClassification,
-  password: textClassification,
   radio: Object.assign({}, boxClassification, {
     input: boxClassification.input.replace('rounded-sm', 'rounded-full'),
   }),
   range: {
     inner: 'max-w-md',
-    input: 'form-range appearance-none w-full h-2 p-0 bg-gray-200 rounded-full focus:outline-none focus:ring-0 focus:shadow-none'
+    input:
+      'form-range appearance-none w-full h-2 p-0 bg-gray-200 rounded-full focus:outline-none focus:ring-0 focus:shadow-none',
   },
-  search: textClassification,
-  select: textClassification,
-  submit: buttonClassification,
-  tel: textClassification,
-  text: textClassification,
   textarea: Object.assign({}, textClassification, {
-    input: 'block w-full h-32 px-3 border-none text-base text-gray-700 placeholder-gray-400 focus:shadow-outline',
+    input:
+      'block w-full h-32 px-3 border-none text-base text-gray-700 placeholder-gray-400 focus:shadow-outline',
   }),
-  time: textClassification,
-  url: textClassification,
-  week: textClassification,
 }

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -1,4 +1,9 @@
-import { FORMKIT_VERSION, FormKitNode, FormKitClasses, FormKitEvent } from '@formkit/core'
+import {
+  FORMKIT_VERSION,
+  FormKitNode,
+  FormKitClasses,
+  FormKitEvent,
+} from '@formkit/core'
 
 /**
  * A function that returns a class list string
@@ -11,15 +16,15 @@ type ClassFunction = (node: FormKitNode, sectionKey: string) => string
  * @public
  */
 export interface FormKitIconLoader {
-  (iconName: string):string | undefined | Promise<string | undefined>
+  (iconName: string): string | undefined | Promise<string | undefined>
 }
 
 /**
  * A function that returns a remote url for retrieving an SVG icon by name
  * @public
  */
- export interface FormKitIconLoaderUrl {
-  (iconName: string):string | undefined
+export interface FormKitIconLoaderUrl {
+  (iconName: string): string | undefined
 }
 
 /**
@@ -68,9 +73,13 @@ function addClassesBySection(
   classesByType: Record<string, () => string>
 ): string {
   const type = node.props.type
+  const family = node.props.family
   let classList = ''
   if (classesByType.global) {
     classList += classesByType.global + ' '
+  }
+  if (classesByType[`family:${family}`]) {
+    classList += classesByType[`family:${family}`] + ' '
   }
   if (classesByType[type]) {
     classList += classesByType[type]
@@ -85,8 +94,8 @@ function addClassesBySection(
 /**
  * The document's computed CSS styles
  */
-let documentStyles: Record<any, any>|undefined = undefined
-let documentThemeLinkTag: HTMLElement|null = null
+let documentStyles: Record<any, any> | undefined = undefined
+let documentThemeLinkTag: HTMLElement | null = null
 
 /**
  * Stores the state of theme loading
@@ -105,13 +114,15 @@ const themeLoaded = new Promise<void>((res) => {
  * Check if we are client-side
  */
 const isClient = typeof window !== 'undefined' && typeof fetch !== 'undefined'
-documentStyles = isClient ? getComputedStyle(document.documentElement) : undefined
+documentStyles = isClient
+  ? getComputedStyle(document.documentElement)
+  : undefined
 
 /**
  * The FormKit icon Registry - a global record of loaded icons.
  * @public
  */
-export const iconRegistry: Record<string, string|undefined> = {}
+export const iconRegistry: Record<string, string | undefined> = {}
 
 /**
  * A collection of existing icon requests to avoid duplicate fetching
@@ -129,8 +140,8 @@ export function createThemePlugin(
   theme?: string,
   icons?: Record<string, string | undefined>,
   iconLoaderUrl?: FormKitIconLoaderUrl,
-  iconLoader?: FormKitIconLoader,
-): ((node: FormKitNode) => any) {
+  iconLoader?: FormKitIconLoader
+): (node: FormKitNode) => any {
   if (icons) {
     // add any user-provided icons to the registry
     Object.assign(iconRegistry, icons)
@@ -145,17 +156,10 @@ export function createThemePlugin(
     // we have the theme loaded locally
     themeDidLoad()
     themeWasRequested = true
-  } else if (
-    theme &&
-    !themeWasRequested &&
-    isClient
-  ) {
+  } else if (theme && !themeWasRequested && isClient) {
     // we have the theme name but need to request it remotely
     loadTheme(theme)
-  } else if (
-    !themeWasRequested &&
-    isClient
-  ) {
+  } else if (!themeWasRequested && isClient) {
     // we don't have a discoverable theme, so don't wait for it
     themeDidLoad()
   }
@@ -170,11 +174,14 @@ export function createThemePlugin(
     loadIconPropIcons(node, node.props.iconHandler)
 
     node.on('created', () => {
-
       // set up the `-icon` click handlers
       if (node?.context?.handlers) {
-        node.context.handlers.iconClick = (sectionKey: string): ((e: MouseEvent) => void) | void => {
-          const clickHandlerProp = `on${sectionKey.charAt(0).toUpperCase()}${sectionKey.slice(1)}IconClick`
+        node.context.handlers.iconClick = (
+          sectionKey: string
+        ): ((e: MouseEvent) => void) | void => {
+          const clickHandlerProp = `on${sectionKey
+            .charAt(0)
+            .toUpperCase()}${sectionKey.slice(1)}IconClick`
           const handlerFunction = node.props[clickHandlerProp]
           if (handlerFunction && typeof handlerFunction === 'function') {
             return (e: MouseEvent) => {
@@ -194,12 +201,8 @@ export function createThemePlugin(
 /**
  * Loads a FormKit theme
  */
-function loadTheme (theme: string) {
-  if (
-    !theme ||
-    !isClient ||
-    typeof getComputedStyle !== 'function'
-  ) {
+function loadTheme(theme: string) {
+  if (!theme || !isClient || typeof getComputedStyle !== 'function') {
     // if we're not client-side then bail
     return
   }
@@ -216,17 +219,16 @@ function loadTheme (theme: string) {
     // if we have a window object
     isClient &&
     // we don't have an existing theme OR the theme being set up is different
-    ((
-      !documentStyles?.getPropertyValue('--formkit-theme') &&
-      !documentThemeLinkTag
-    ) || (
-      documentThemeLinkTag?.getAttribute('data-theme') &&
-      documentThemeLinkTag?.getAttribute('data-theme') !== theme
-    ))
+    ((!documentStyles?.getPropertyValue('--formkit-theme') &&
+      !documentThemeLinkTag) ||
+      (documentThemeLinkTag?.getAttribute('data-theme') &&
+        documentThemeLinkTag?.getAttribute('data-theme') !== theme))
   ) {
     // if for some reason we didn't overwrite the __FKV__ token during publish
     // then use the `latest` tag for CDN fetching. (this applies to local dev as well)
-    const formkitVersion = FORMKIT_VERSION.startsWith('__') ? 'latest' : FORMKIT_VERSION
+    const formkitVersion = FORMKIT_VERSION.startsWith('__')
+      ? 'latest'
+      : FORMKIT_VERSION
     const themeUrl = `https://cdn.jsdelivr.net/npm/@formkit/themes@${formkitVersion}/dist/${theme}/theme.css`
     const link = document.createElement('link')
     link.type = 'text/css'
@@ -251,8 +253,13 @@ function loadTheme (theme: string) {
  * @param iconLoader - a function for loading an icon when it's not found in the iconRegistry
  * @public
  */
-export function createIconHandler (iconLoader?: FormKitIconLoader, iconLoaderUrl?: FormKitIconLoaderUrl): FormKitIconLoader {
-  return (iconName: string | boolean): string | undefined | Promise<string|undefined> => {
+export function createIconHandler(
+  iconLoader?: FormKitIconLoader,
+  iconLoaderUrl?: FormKitIconLoaderUrl
+): FormKitIconLoader {
+  return (
+    iconName: string | boolean
+  ): string | undefined | Promise<string | undefined> => {
     if (typeof iconName === 'boolean') {
       return // do nothing if we're dealing with a boolean
     }
@@ -269,24 +276,33 @@ export function createIconHandler (iconLoader?: FormKitIconLoader, iconLoaderUrl
     const isDefault = iconName.startsWith('default:')
     iconName = isDefault ? iconName.split(':')[1] : iconName
 
-    let loadedIcon:(string | undefined | Promise<string | undefined>) = undefined
+    let loadedIcon: string | undefined | Promise<string | undefined> = undefined
     if (icon || iconName in iconRegistry) {
       return icon
     } else if (!iconRequests[iconName]) {
       loadedIcon = getIconFromStylesheet(iconName)
-      loadedIcon = isClient && typeof loadedIcon === 'undefined' ? Promise.resolve(loadedIcon) : loadedIcon
+      loadedIcon =
+        isClient && typeof loadedIcon === 'undefined'
+          ? Promise.resolve(loadedIcon)
+          : loadedIcon
       if (loadedIcon instanceof Promise) {
-        iconRequests[iconName] = loadedIcon.then((iconValue) => {
-          if (!iconValue && typeof iconName === 'string' && !isDefault) {
-            return loadedIcon = typeof iconLoader === 'function' ? iconLoader(iconName) : getRemoteIcon(iconName, iconLoaderUrl)
-          }
-          return iconValue
-        }).then((finalIcon) => {
-          if (typeof iconName === 'string') {
-            iconRegistry[isDefault ? `default:${iconName}` : iconName] = finalIcon
-          }
-          return finalIcon
-        })
+        iconRequests[iconName] = loadedIcon
+          .then((iconValue) => {
+            if (!iconValue && typeof iconName === 'string' && !isDefault) {
+              return (loadedIcon =
+                typeof iconLoader === 'function'
+                  ? iconLoader(iconName)
+                  : getRemoteIcon(iconName, iconLoaderUrl))
+            }
+            return iconValue
+          })
+          .then((finalIcon) => {
+            if (typeof iconName === 'string') {
+              iconRegistry[isDefault ? `default:${iconName}` : iconName] =
+                finalIcon
+            }
+            return finalIcon
+          })
       } else if (typeof loadedIcon === 'string') {
         iconRegistry[isDefault ? `default:${iconName}` : iconName] = loadedIcon
         return loadedIcon
@@ -296,7 +312,9 @@ export function createIconHandler (iconLoader?: FormKitIconLoader, iconLoaderUrl
   }
 }
 
-function getIconFromStylesheet(iconName: string): string | undefined | Promise<string|undefined> {
+function getIconFromStylesheet(
+  iconName: string
+): string | undefined | Promise<string | undefined> {
   if (!isClient) return
   if (themeHasLoaded) {
     return loadStylesheetIcon(iconName)
@@ -307,7 +325,7 @@ function getIconFromStylesheet(iconName: string): string | undefined | Promise<s
   }
 }
 
-function loadStylesheetIcon (iconName: string) {
+function loadStylesheetIcon(iconName: string) {
   const cssVarIcon = documentStyles?.getPropertyValue(`--fk-icon-${iconName}`)
   if (cssVarIcon) {
     // if we have a matching icon in the CSS properties, then decode it
@@ -325,9 +343,17 @@ function loadStylesheetIcon (iconName: string) {
  * @param iconName - The string name of the icon
  * @public
  */
-function getRemoteIcon(iconName: string, iconLoaderUrl?: FormKitIconLoaderUrl): Promise<string | undefined> | undefined {
-  const formkitVersion = FORMKIT_VERSION.startsWith('__') ? 'latest' : FORMKIT_VERSION
-  const fetchUrl = typeof iconLoaderUrl === 'function' ? iconLoaderUrl(iconName) : `https://cdn.jsdelivr.net/npm/@formkit/icons@${formkitVersion}/dist/icons/${iconName}.svg`
+function getRemoteIcon(
+  iconName: string,
+  iconLoaderUrl?: FormKitIconLoaderUrl
+): Promise<string | undefined> | undefined {
+  const formkitVersion = FORMKIT_VERSION.startsWith('__')
+    ? 'latest'
+    : FORMKIT_VERSION
+  const fetchUrl =
+    typeof iconLoaderUrl === 'function'
+      ? iconLoaderUrl(iconName)
+      : `https://cdn.jsdelivr.net/npm/@formkit/icons@${formkitVersion}/dist/icons/${iconName}.svg`
   if (!isClient) return undefined
   return fetch(`${fetchUrl}`)
     .then(async (r) => {
@@ -337,7 +363,7 @@ function getRemoteIcon(iconName: string, iconLoaderUrl?: FormKitIconLoaderUrl): 
       }
       return undefined
     })
-    .catch(e => {
+    .catch((e) => {
       console.error(e)
       return undefined
     })
@@ -346,7 +372,10 @@ function getRemoteIcon(iconName: string, iconLoaderUrl?: FormKitIconLoaderUrl): 
 /**
  * Loads icons for the matching `-icon` props on a given node
  */
-function loadIconPropIcons(node: FormKitNode, iconHandler: FormKitIconLoader): void {
+function loadIconPropIcons(
+  node: FormKitNode,
+  iconHandler: FormKitIconLoader
+): void {
   const iconRegex = /^[a-zA-Z-]+(?:-icon|Icon)$/
   const iconProps = Object.keys(node.props).filter((prop) => {
     return iconRegex.test(prop)
@@ -359,11 +388,19 @@ function loadIconPropIcons(node: FormKitNode, iconHandler: FormKitIconLoader): v
 /**
  * Loads an icon from an icon-prop declaration eg. suffix-icon="settings"
  */
-function loadPropIcon(node: FormKitNode, iconHandler: FormKitIconLoader, sectionKey: string): Promise<void> | void {
+function loadPropIcon(
+  node: FormKitNode,
+  iconHandler: FormKitIconLoader,
+  sectionKey: string
+): Promise<void> | void {
   const iconName = node.props[sectionKey]
   const loadedIcon = iconHandler(iconName)
-  const rawIconProp = `_raw${sectionKey.charAt(0).toUpperCase()}${sectionKey.slice(1)}`
-  const clickHandlerProp = `on${sectionKey.charAt(0).toUpperCase()}${sectionKey.slice(1)}Click`
+  const rawIconProp = `_raw${sectionKey
+    .charAt(0)
+    .toUpperCase()}${sectionKey.slice(1)}`
+  const clickHandlerProp = `on${sectionKey
+    .charAt(0)
+    .toUpperCase()}${sectionKey.slice(1)}Click`
   node.addProps([rawIconProp, clickHandlerProp])
   // listen for changes to the icon prop
   node.on(`prop:${sectionKey}`, reloadIcon)
@@ -385,7 +422,9 @@ function reloadIcon(event: FormKitEvent): void | Promise<void> {
   const iconName = event.payload
   const iconHandler = node?.props?.iconHandler
   const sectionKey = event.name.split(':')[1]
-  const rawIconProp = `_raw${sectionKey.charAt(0).toUpperCase()}${sectionKey.slice(1)}`
+  const rawIconProp = `_raw${sectionKey
+    .charAt(0)
+    .toUpperCase()}${sectionKey.slice(1)}`
 
   if (iconHandler && typeof iconHandler === 'function') {
     const loadedIcon = iconHandler(iconName)


### PR DESCRIPTION
Adds support for input families:

```js
generateClasses({
  'family:text': 'classes to apply to text inputs here'
})
```