### PR TITLE
changed FormKitFrameworkContextState to boolean type

### DIFF
--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -440,7 +440,7 @@ export interface FormKitFrameworkContext {
   /**
    * A collection of state trackers/details about the input.
    */
-  state: FormKitFrameworkContextState
+  state: boolean
   /**
    * The type of input "text" or "select" (retrieved from node.props.type). This
    * is not the core node type (input, group, or list).


### PR DESCRIPTION
Fixed wrong type

FormKitFrameworkContextState type give this result, but state is boolean and not  FormKitFrameworkContextState

{
  "blurred": false,
  "complete": false,
  "dirty": false,
  "submitted": false,
  "settled": true,
  "valid": false,   // this is boolean field and not FormKitFrameworkContextState
  "errors": false,
  "rules": false,
  "validationVisible": false
}