### PR TITLE
feat(plugin): adds new optionAsPlugin, adding the possibility of mapping options

### DIFF
--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -4,6 +4,7 @@ import { de, fr, bg } from '@formkit/i18n'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import './assets/styles/main.scss'
 import App from './vue/App.vue'
+import OptionAsPlugin from './vue/examples/OptionAsPlugin.vue'
 import BasicForm from './vue/examples/BasicForm.vue'
 import ThemePlugin from './vue/examples/ThemePlugin.vue'
 import ThirdPartyIcons from './vue/examples/3rdPartyIcons.vue'
@@ -14,7 +15,7 @@ import FileUpload from './vue/examples/FileUpload.vue'
 import GroupInput from './vue/examples/Group.vue'
 import TSXExample from './vue/examples/TSXExample.tsx'
 import ModifySchema from './vue/examples/ModifySchema.vue'
-import { createAutoAnimatePlugin } from '@formkit/addons'
+import { createAutoAnimatePlugin, optionsAsPlugin } from '@formkit/addons'
 import '@formkit/themes/genesis'
 
 const myInput = createInput(CurrencyInput)
@@ -31,7 +32,7 @@ const config = defaultConfig({
     formkit: `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 0.0182495H0V4.01533H4V8.01167L7.9989 8.01167V12.0088H4V16.0058H0V20.0029H4V16.0058H8V12.0088H11.9989V8.01167L8 8.01167V4.01459H4V0.0182495ZM11.9983 20.0029H15.9977H15.9983H19.9972H19.9977H23.9972V24H19.9977H19.9972H15.9983H15.9977H11.9983V20.0029Z" fill="currentColor"/></svg>`
   },
   inputs: { foo: myInput },
-  plugins: [createAutoAnimatePlugin()],
+  plugins: [createAutoAnimatePlugin(), optionsAsPlugin({ labelAs: 'name', valueAs: 'id' })],
 })
 
 // Install FormKit:
@@ -80,6 +81,10 @@ const router = createRouter({
     {
       path: '/plugin-schema',
       component: ModifySchema,
+    },
+    {
+      path: '/option-as-plugin',
+      component: OptionAsPlugin,
     },
   ],
 })

--- a/examples/src/vue/Navigation.vue
+++ b/examples/src/vue/Navigation.vue
@@ -46,6 +46,11 @@
           Modify schema with plugin
         </router-link>
       </li>
+      <li>
+        <router-link to="/option-as-plugin">
+          OptionAs Plugin
+        </router-link>
+      </li>
     </ul>
   </nav>
 </template>

--- a/examples/src/vue/examples/OptionAsPlugin.vue
+++ b/examples/src/vue/examples/OptionAsPlugin.vue
@@ -1,0 +1,84 @@
+<template>
+  <h1>OptionAs Plugin</h1>
+  {{ users }}
+  <FormKit id="form" v-model="data" type="form" @submit="submitHandler">
+    <FormKit name="normal-select" type="select" label="Normal Select" :stop-option-map="true" :options="normalCases" />
+
+    <FormKit name="with-select" type="select" label="With Plugin" :options="users" />
+    <FormKit name="with-select-another-label" type="select" label="With Another Label" label-as="description"
+      :options="users" />
+
+    <FormKit name="with-checkbox" type="checkbox" label="With Plugin" :options="users" />
+
+    <FormKit name="with-radio" type="radio" label="With Plugin" :options="users" />
+
+    <FormKit type="button" @click="addUser" label="New User" />
+  </FormKit>
+  <pre>{{ data }}</pre>
+</template>
+
+<script setup lang="ts">
+import { setErrors } from '@formkit/vue';
+import { ref } from 'vue';
+
+const data = ref({});
+
+const normalCases = [
+  {
+    value: 1,
+    label: 'You can disable the plugin with stop-option-map',
+  },
+  {
+    value: 2,
+    label: 'Normal Case',
+  },
+];
+
+const users = ref([
+  {
+    id: 1,
+    name: 'Justin Schroeder',
+    description: 'Smart Justin!'
+  },
+  {
+    id: 2,
+    name: 'Luan Nguyen',
+    description: 'Smart Luan!'
+  },
+  {
+    id: 3,
+    name: 'Andrew Boyd',
+    description: 'Smart Andrew!'
+  },
+  {
+    id: 4,
+    name: 'Chris Adams',
+    description: 'Smart Chris!'
+  },
+  {
+    id: 5,
+    name: 'Chris Ellinger',
+    description: 'Smart Chris!'
+  },
+  {
+    id: 6,
+    name: 'Sasha Milenkovic',
+    description: 'Smart Sasha!'
+  },
+  {
+    id: 7,
+    name: 'Gustavo Fenilli',
+    description: 'Not so Smart Gustavo!',
+    attrs: { disabled: true }
+  },
+]);
+
+const addUser = () => {
+  users.value = [...users.value, { id: 8, name: 'New User', description: 'New Description' }];
+};
+
+const submitHandler = async function () {
+  await new Promise(r => setTimeout(r, 2000))
+  setErrors('form', ['This isn’t setup to actually do anything.'])
+}
+</script>

--- a/examples/src/vue/examples/OptionAsPlugin.vue
+++ b/examples/src/vue/examples/OptionAsPlugin.vue
@@ -2,7 +2,7 @@
   <h1>OptionAs Plugin</h1>
   {{ users }}
   <FormKit id="form" v-model="data" type="form" @submit="submitHandler">
-    <FormKit name="normal-select" type="select" label="Normal Select" :stop-option-map="true" :options="normalCases" />
+    <FormKit name="normal-select" type="select" label="Normal Select" :options="normalCases" />
 
     <FormKit name="with-select" type="select" label="With Plugin" :options="users" />
     <FormKit name="with-select-another-label" type="select" label="With Another Label" label-as="description"
@@ -26,7 +26,7 @@ const data = ref({});
 const normalCases = [
   {
     value: 1,
-    label: 'You can disable the plugin with stop-option-map',
+    label: 'You can use options as normal',
   },
   {
     value: 2,

--- a/packages/addons/src/index.ts
+++ b/packages/addons/src/index.ts
@@ -1,1 +1,2 @@
 export * from './plugins/autoAnimatePlugin'
+export * from './plugins/optionsAsPlugin';

--- a/packages/addons/src/plugins/optionsAsPlugin.ts
+++ b/packages/addons/src/plugins/optionsAsPlugin.ts
@@ -1,6 +1,12 @@
 import { FormKitNode, FormKitPlugin } from '@formkit/core';
 import { FormKitOptionsList } from '@formkit/inputs';
 
+declare module '@formkit/inputs' {
+  interface FormKitOptionsPropExtensions {
+    mappingOptions: Record<string, any>[];
+  }
+};
+
 /**
  * Types for OptionsAsPlugin options
  * @public

--- a/packages/addons/src/plugins/optionsAsPlugin.ts
+++ b/packages/addons/src/plugins/optionsAsPlugin.ts
@@ -1,0 +1,55 @@
+import { FormKitNode, FormKitPlugin, FormKitProps } from '@formkit/core';
+import { FormKitOptionsList } from '@formkit/inputs';
+
+/**
+ * Types for OptionsAsPlugin options
+ * @public
+ */
+export interface MappingOptions {
+  labelAs?: string;
+  valueAs?: string;
+};
+
+/**
+ * Map values based on node options
+ * @internal
+ */
+const mapOptions = (mappingOptions: Partial<FormKitProps>, options: string[] | FormKitOptionsList) => {
+  return options.map((option) => {
+    if (typeof option === 'string' || typeof option === 'number') return option;
+
+    return {
+      ...option,
+      label: mappingOptions.labelAs ? option[mappingOptions.labelAs] : undefined,
+      value: mappingOptions.valueAs ? option[mappingOptions.valueAs] : undefined
+    };
+  });
+};
+
+/**
+ * Adds labelAs and valueAs to be mapped for inputs with options
+ * @param options - A MappingOptions interface
+ * @public
+ */
+export const optionsAsPlugin = (options?: MappingOptions): FormKitPlugin => (node: FormKitNode) => {
+  if (!node.props.options || !Array.isArray(node.props.options)) return;
+
+  node.addProps(['labelAs', 'valueAs', 'stopOptionMap']);
+
+  if (node.props.stopOptionMap) return;
+
+  if (!node.props.labelAs) node.props.labelAs = options?.labelAs;
+  if (!node.props.valueAs) node.props.valueAs = options?.valueAs;
+
+  if (!(node.props.labelAs || node.props.valueAs)) return;
+
+  node.props.options = mapOptions(node.props, node.props.options);
+
+  node.hook.prop((prop, next) => {
+    if (prop.prop === 'options') {
+      prop.value = mapOptions(node.props, prop.value);
+    }
+
+    return next(prop);
+  });
+};


### PR DESCRIPTION
By adding `labelAs` and `valueAs` you can map options to use those keys to find in an object. You can also disable ( to use the core label/value ) for any options enabled input with the prop `:stop-option-map="true"`.

I would like insights and any ideas to improve this plugin ( and if any errors you find ) so I can fix before the PR is accepted.