### PR TITLE
fix: update nuxt compatibility

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -12,7 +12,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: 'FormKit',
     configKey: 'formkit',
     compatibility: {
-      nuxt: '^3.0.0',
+      nuxt: '^3.0.0-rc.8'
     },
   },
   defaults: {


### PR DESCRIPTION
In [nuxt/framework#7116](https://github.com/nuxt/framework/pull/7116) nuxt developers made a breaking change allowing modules to use RC constraints. This PR fixes this.