### PR TITLE
fix(nuxt): update `compatibility` version of FormKit's Nuxt module to `>=3.0.0-rc.9`

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -12,7 +12,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: 'FormKit',
     configKey: 'formkit',
     compatibility: {
-      nuxt: '^3.0.0-rc.9',
+      nuxt: '>=3.0.0-rc.9',
     },
   },
   defaults: {

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -12,7 +12,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: 'FormKit',
     configKey: 'formkit',
     compatibility: {
-      nuxt: '^3.0.0',
+      nuxt: '^3.0.0-rc.9',
     },
   },
   defaults: {


### PR DESCRIPTION
FormKit fails to pass Nuxt's compatibility check.

![unknown](https://user-images.githubusercontent.com/48835293/190601692-c7addb93-f593-4e06-beae-2748f9fd2d4e.png)
