### PR TITLE
fix(themes): :bug: fixes plugins to work with pro repeaters

### DIFF
--- a/packages/themes/src/tailwindcss/index.ts
+++ b/packages/themes/src/tailwindcss/index.ts
@@ -1,22 +1,40 @@
 import plugin from 'tailwindcss/plugin.js'
 
+const outerAttributes = [
+  'disabled',
+  'invalid',
+  'errors',
+  'complete',
+  'loading',
+  'submitted',
+  'multiple',
+  'has-prefix-icon',
+  'has-suffix-icon',
+]
+
 /**
  * The FormKit plugin for Tailwind
  * @public
  */
-const FormKitVariants = plugin(({ addVariant, theme }) => {
-  const attributes: string[] = theme('formkit.attributes') || []
-  const messageStates: string[] = theme('formkit.messageStates') || []
+// @ts-expect-error matchVariant is not documented or have types
+const FormKitVariants = plugin(function ({ matchVariant }) {
+  const attributes = outerAttributes.reduce((a, v) => ({ ...a, [v]: v }), {})
 
-  addVariant('formkit-action', ['.formkit-actions &', '.formkit-actions&']);
-
-  ['disabled', 'invalid', 'errors', 'complete', 'loading', 'submitted', 'multiple', 'has-prefix-icon', 'has-suffix-icon', ...attributes].forEach((attribute) => {
-    addVariant(`formkit-${attribute}`, [`&[data-${attribute}]`, `[data-${attribute}] &`, `[data-${attribute}]&`])
-  });
-
-  ['validation', 'error', ...messageStates].forEach((state) => {
-    addVariant(`formkit-message-${state}`, [`[data-message-type="${state}"] &`, `[data-message-type="${state}"]&`])
-  })
+  matchVariant(
+    'formkit',
+    (value = '', { modifier }: { modifier: string }) => {
+      return modifier
+        ? [
+            `[data-${value}='true']:merge(.group\\/${modifier})&`,
+            `[data-${value}='true']:merge(.group\\/${modifier}) &`,
+          ]
+        : [
+            `[data-${value}='true']:not([data-type='repeater'])&`,
+            `[data-${value}='true']:not([data-type='repeater']) &`,
+          ]
+    },
+    { values: attributes }
+  )
 })
 
 export default FormKitVariants

--- a/packages/themes/src/unocss/index.ts
+++ b/packages/themes/src/unocss/index.ts
@@ -1,35 +1,38 @@
 import type { Preset, Variant } from 'unocss'
 
-const actionsVariants: Variant = (matcher) => {
-  const match = matcher.match(/^formkit-action[:-]/)
-
-  if (!match) return matcher;
-
-  return {
-    matcher: matcher.slice(match[0].length),
-    selector: s => `.formkit-actions ${s}, .formkit-actions${s}`
-  }
-}
+const outerAttributes = [
+  'disabled',
+  'invalid',
+  'errors',
+  'complete',
+  'loading',
+  'submitted',
+  'multiple',
+  'has-prefix-icon',
+  'has-suffix-icon',
+]
 
 const attributesVariants: Variant = (matcher) => {
-  const match = matcher.match(/^formkit-([_\d\w]+)[:-]/)
+  const match = matcher.match(
+    new RegExp(`^formkit-(${outerAttributes.join('|')})(/[_\\d\\w]+)?[:-]`)
+  )
 
-  if (!match) return matcher;
-
-  return {
-    matcher: matcher.slice(match[0].length),
-    selector: s => `${s}[data-${match[1]}], [data-${match[1]}] ${s}, [data-${match[1]}]${s}`
-  }
-}
-
-const messageStatesVariants: Variant = (matcher) => {
-  const match = matcher.match(/^formkit-message-([_\d\w]+)[:-]/)
-
-  if (!match) return matcher;
+  if (!match) return matcher
 
   return {
     matcher: matcher.slice(match[0].length),
-    selector: s => `[data-message-type="${match[1]}"] ${s}, [data-message-type="${match[1]}"]${s}`
+    selector: (s) => {
+      if (match[2]) {
+        return `
+          [data-${match[1]}="true"].group\\${match[2]}${s},
+          [data-${match[1]}="true"].group\\${match[2]} ${s}
+        `
+      }
+      return `
+      	[data-${match[1]}="true"]:not([data-type='repeater'])${s},
+        [data-${match[1]}="true"]:not([data-type='repeater']) ${s}
+      `
+    },
   }
 }
 
@@ -40,11 +43,7 @@ const messageStatesVariants: Variant = (matcher) => {
 const FormKitVariants = (): Preset => {
   return {
     name: 'unocss-preset-formkit',
-    variants: [
-      actionsVariants,
-      attributesVariants,
-      messageStatesVariants
-    ]
+    variants: [attributesVariants],
   }
 }
 

--- a/packages/themes/src/windicss/index.ts
+++ b/packages/themes/src/windicss/index.ts
@@ -1,34 +1,30 @@
 import plugin from 'windicss/plugin'
 
+const outerAttributes = [
+  'disabled',
+  'invalid',
+  'errors',
+  'complete',
+  'loading',
+  'submitted',
+  'multiple',
+  'has-prefix-icon',
+  'has-suffix-icon',
+]
+
 /**
  * The FormKit plugin for WindiCSS
  * @public
  */
-const FormKitVariants = plugin(({ addVariant, theme }) => {
-  const attributes: string[] = (theme('formkit.attributes', []) as string[])
-  const messageStates: string[] = (theme('formkit.messageStates', []) as string[])
-
-  addVariant('formkit-action', ({ modifySelectors }) => {
-    return modifySelectors(({ className }) => {
-      return `.formkit-actions .${className}, .formkit-actions.${className}`
-    })
-  });
-
-  ['disabled', 'invalid', 'errors', 'complete', 'loading', 'submitted', 'multiple', 'has-prefix-icon', 'has-suffix-icon', ...attributes].forEach((attribute) => {
+const FormKitVariants = plugin(({ addVariant }) => {
+  outerAttributes.forEach((attribute) => {
     addVariant(`formkit-${attribute}`, ({ modifySelectors }) => {
       return modifySelectors(({ className }) => {
-        return `.${className}[data-${attribute}], [data-${attribute}] .${className}, [data-${attribute}].${className}`
+        return `[data-${attribute}='true']:not([data-type='repeater']).${className},
+        [data-${attribute}='true']:not([data-type='repeater']) .${className}`
       })
     })
-  });
-
-  ['validation', 'error', ...messageStates].forEach((state) => {
-    addVariant(`formkit-message-${state}`, ({ modifySelectors }) => {
-      return modifySelectors(({ className }) => {
-        return `.${className}[data-message-type="${state}"], [data-message-type="${state}"] .${className}, [data-message-type="${state}"].${className}`
-      })
-    })
-  });
+  })
 })
 
 export default FormKitVariants


### PR DESCRIPTION
It fixes Tailwindcss/Windicss/Unocss to not get repeaters invalid state for inner inputs states.

It adds a new feature of grouping that came with Tailwindcss 3.2, that makes it possible to target groups when specifing variants to nested rule sets, by setting a `group/*` to the outer class of the element you want to group and to adding `formkit-invalid/*:text-red-500` to the section you want to style based on the group state.