### PR TITLE
Feature/inline class removal

### DIFF
--- a/examples/src/vue/examples/BasicForm.vue
+++ b/examples/src/vue/examples/BasicForm.vue
@@ -63,6 +63,7 @@ const submitHandler = async function (data: { email: string }) {
       placeholder="jon@foo.com"
       validation="required|email|length:16,9"
       validation-visibility="live"
+      outer-class="my-class !formkit-outer"
     />
     <FormKit
       type="file"

--- a/packages/core/src/classes.ts
+++ b/packages/core/src/classes.ts
@@ -52,20 +52,37 @@ export function generateClassList(
   ...args: Record<string, boolean>[]
 ): string | null {
   const combinedClassList = args.reduce((finalClassList, currentClassList) => {
-    if (!currentClassList) return finalClassList
+    if (!currentClassList) return handleNegativeClasses(finalClassList)
     const { $reset, ...classList } = currentClassList
     if ($reset) {
-      return classList
+      return handleNegativeClasses(classList)
     }
-    return Object.assign(finalClassList, classList)
+    return handleNegativeClasses(Object.assign(finalClassList, classList))
   }, {})
 
-  return (
-    Object.keys(
-      node.hook.classes.dispatch({ property, classes: combinedClassList })
-        .classes
-    )
-      .filter((key) => combinedClassList[key])
-      .join(' ') || null
+  return Object.keys(
+    node.hook.classes.dispatch({ property, classes: combinedClassList })
+      .classes
   )
+    .filter((key) => combinedClassList[key])
+    .join(' ') || null
+}
+
+function handleNegativeClasses(classList: Record<string, boolean>): Record<string, boolean> {
+  let hasNegativeClassValue = false
+  const applicableClasses = Object.keys(classList).filter((className) => {
+    if (classList[className] && className.startsWith('!')) {
+      hasNegativeClassValue = true
+    }
+    return classList[className]
+  })
+  if (applicableClasses.length > 1 && hasNegativeClassValue) {
+    const negativeClasses = applicableClasses.filter(className => className.startsWith('!'))
+    negativeClasses.map((negativeClass) => {
+      const targetClass = negativeClass.substring(1)
+      classList[targetClass] = false
+      classList[negativeClass] = false
+    })
+  }
+  return classList
 }

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1040,6 +1040,24 @@ describe('classes', () => {
     )
   })
 
+  it.only('can can remove existing classes if class name string is prefixed with a ! operator', () => {
+    const wrapper = mount(FormKit, {
+      props: {
+        name: 'classTest',
+        classes: {
+          outer: '!formkit-outer test-class-string1',
+        },
+        outerClass: '!test-class-string1 should-be-only-me',
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    expect(wrapper.find('[data-type="text"]').html()).toContain(
+      'class="should-be-only-me'
+    )
+  })
+
   it('can apply new classes from functions', () => {
     const wrapper = mount(FormKit, {
       props: {


### PR DESCRIPTION
New feature for class lists, allows removal of a class with the `!` operator using string syntax. This will allow users to be a bit more surgical than `$reset` without requiring the use of the object syntax for class props.

This:
```html
<FormKit
  :outer-class="{
    'formkit-outer': false,
    'my-class': true
  }"
/>
```
Can be written as:
```html
<FormKit 
  outer-class="my-class !formkit-outer"
/>
```

