### PR TITLE
adds named export of genesisIcons to assist Tailwind users

### DIFF
--- a/packages/icons/src/genesisIcons.ts
+++ b/packages/icons/src/genesisIcons.ts
@@ -1,0 +1,30 @@
+import {
+  add,
+  check,
+  circle,
+  close,
+  spinner,
+  star,
+  trash,
+} from './icons/application'
+import { arrowDown, arrowUp, down } from './icons/directional'
+import { fileDoc } from './icons/file'
+
+const genesisIcons = {
+  add,
+  arrowDown,
+  arrowUp,
+  check,
+  close,
+  checkboxDecorator: check,
+  fileItem: fileDoc,
+  fileRemove: close,
+  noFiles: fileDoc,
+  radioDecorator: circle,
+  select: down,
+  spinner,
+  star,
+  trash,
+}
+
+export default genesisIcons

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,4 +1,9 @@
 import * as icons from './icons-single'
 export * from './collections'
+import genesisIcons from './genesisIcons'
 
 export default icons
+export {
+  icons,
+  genesisIcons
+}


### PR DESCRIPTION
will allow for including the default gensis icon set without needing to map it yourself if you're a Tailwind user. 

```js
// formkit.config.js
import { generateClasses } from "@formkit/themes"
import { genesis } from "@formkit/themes/tailwindcss"
import { genesisIcons } from "@formkit/icons"

const config = {
  config: {
    classes: generateClasses(genesis),
  },
  icons: {
    ...genesisIcons
  },
}

export default config
```