### PR TITLE
Moves `iconWasAlreadyLoaded` check to after `defualt:` prefix splitting

### DIFF
--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -283,14 +283,15 @@ export function createIconHandler(
     }
     if (typeof iconName !== 'string') return // bail if we got something that wasn't a boolean or string
 
-    // check if we've already loaded the icon before
-    const iconWasAlreadyLoaded = iconName in iconRegistry
-
     // is this a default icon that should only load from a stylesheet?
     const isDefault = iconName.startsWith('default:')
     iconName = isDefault ? iconName.split(':')[1] : iconName
 
+    // check if we've already loaded the icon before
+    const iconWasAlreadyLoaded = iconName in iconRegistry
+
     let loadedIcon: string | undefined | Promise<string | undefined> = undefined
+
     if (iconWasAlreadyLoaded) {
       return iconRegistry[iconName]
     } else if (!iconRequests[iconName]) {


### PR DESCRIPTION
So, the icons were getting into the registry as expected, but the current plugin was checking for existence of something like `select` before removing the `default:` prefix, and `'default:select' !=== 'select'` so the defaults would not be found. This fixes that by changing the order.