### PR TITLE
Feature/class removal token

### DIFF
--- a/packages/core/src/classes.ts
+++ b/packages/core/src/classes.ts
@@ -76,17 +76,18 @@ export function generateClassList(
 }
 
 function handleNegativeClasses(classList: Record<string, boolean>): Record<string, boolean> {
+  const removalToken = '$remove:'
   let hasNegativeClassValue = false
   const applicableClasses = Object.keys(classList).filter((className) => {
-    if (classList[className] && className.startsWith('!')) {
+    if (classList[className] && className.startsWith(removalToken)) {
       hasNegativeClassValue = true
     }
     return classList[className]
   })
   if (applicableClasses.length > 1 && hasNegativeClassValue) {
-    const negativeClasses = applicableClasses.filter(className => className.startsWith('!'))
+    const negativeClasses = applicableClasses.filter(className => className.startsWith(removalToken))
     negativeClasses.map((negativeClass) => {
-      const targetClass = negativeClass.substring(1)
+      const targetClass = negativeClass.substring(removalToken.length)
       classList[targetClass] = false
       classList[negativeClass] = false
     })

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1095,14 +1095,14 @@ describe('classes', () => {
     )
   })
 
-  it('can can remove existing classes if class name string is prefixed with a ! operator', () => {
+  it('can can remove existing classes if class name string is prefixed with the $remove: operator', () => {
     const wrapper = mount(FormKit, {
       props: {
         name: 'classTest',
         classes: {
-          outer: '!formkit-outer test-class-string1',
+          outer: '$remove:formkit-outer test-class-string1',
         },
-        outerClass: '!test-class-string1 should-be-only-me',
+        outerClass: '$remove:test-class-string1 should-be-only-me',
       },
       global: {
         plugins: [[plugin, defaultConfig]],


### PR DESCRIPTION
Updates class removal token to be `$remove:` rather than`!` due to `!` having meaning within Tailwind CSS already.