### PR TITLE
adds `./tailwind/genisis` export path to @formkit/themes package.json

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -19,6 +19,11 @@
       "require": "./dist/tailwindcss/index.cjs",
       "types": "./dist/tailwindcss/index.d.ts"
     },
+    "./tailwindcss/genesis": {
+      "import": "./dist/tailwindcss/genesis/index.mjs",
+      "require": "./dist/tailwindcss/genesis/index.cjs",
+      "types": "./dist/tailwindcss/genesis/index.d.ts"
+    },
     "./unocss": {
       "import": "./dist/unocss/index.mjs",
       "require": "./dist/unocss/index.cjs",


### PR DESCRIPTION
fixes #560 — @justin-schroeder can you let me know if more than this needs to be done? For the time being I'm going to update the documentation to include `dist` in the import path since it won't break anything when beta.15 is out an the non-`dist` path starts working as well.