### PR TITLE
uses `addComponent` to include built-in FormKit components in Nuxt

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,6 +1,11 @@
 import { existsSync } from 'fs'
 import { fileURLToPath } from 'url'
-import { defineNuxtModule, addPluginTemplate, createResolver } from '@nuxt/kit'
+import {
+  defineNuxtModule,
+  addPluginTemplate,
+  addComponent,
+  createResolver,
+} from '@nuxt/kit'
 
 export interface ModuleOptions {
   defaultConfig: boolean

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -68,5 +68,15 @@ export default defineNuxtModule<ModuleOptions>({
       export: 'FormKitSchema',
       filePath: '@formkit/vue',
     })
+    addComponent({
+      name: 'FormKitMessages',
+      export: 'FormKitMessages',
+      filePath: '@formkit/vue',
+    })
+    addComponent({
+      name: 'FormKitIcon',
+      export: 'FormKitIcon',
+      filePath: '@formkit/vue',
+    })
   },
 })

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -52,5 +52,16 @@ export default defineNuxtModule<ModuleOptions>({
       filename: 'formkitPlugin.mjs',
       options: { importStatement, config },
     })
+
+    addComponent({
+      name: 'FormKit',
+      export: 'FormKit',
+      filePath: '@formkit/vue',
+    })
+    addComponent({
+      name: 'FormKitSchema',
+      export: 'FormKitSchema',
+      filePath: '@formkit/vue',
+    })
   },
 })

--- a/packages/nuxt/src/runtime/plugin.mjs
+++ b/packages/nuxt/src/runtime/plugin.mjs
@@ -1,4 +1,5 @@
 import { defineNuxtPlugin } from '#app'
+// defaultConfig is required because it may be called by options.config below
 import { plugin, defaultConfig } from '@formkit/vue'
 import { resetCount } from '@formkit/core'
 <%= options.importStatement %>


### PR DESCRIPTION
Ok, so tried doing a FormKitSchema without it being in the plugin and without an import, and it renderers client side with a hydration error warning. It does not throw the server error if you manually write an import in the file you're using it in as you mentioned earlier, @justin-schroeder.

I'm adding all 4 components that the @formkit/vue package exports at the moment so that things are rendered via SSR successfully without the Nuxt user needing to write a manual import statement.

FormKit
FormKitSchema
FormKitMessages
FormKitIcon

Fixes #539 