### PR TITLE
fix: augment `vue` without `export`

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -38,11 +38,11 @@ const augmentations = {
  * Augment Vue’s globalProperties.
  * @public
  */
-declare module '@vue/runtime-core' {
-  export interface ComponentCustomProperties {
+declare module 'vue' {
+  interface ComponentCustomProperties {
     $formkit: FormKitVuePlugin
   }
-  export interface GlobalComponents {
+  interface GlobalComponents {
     FormKit: typeof FormKit
     FormKitSchema: typeof FormKitSchema
   }


### PR DESCRIPTION
The `vue` recommendation now is to augment `vue` directly: https://vuejs.org/api/utility-types.html#componentcustomproperties.

It's also possible it might be a volar issue that if you have augmentations of both vue + @vue/compiler-core we also lose typing on GlobalComponents. (So this was causing Nuxt components to be untyped.)

