### PR TITLE
Adds FormKit integration to the Nuxt DevTools

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { defineNuxtModule, addPluginTemplate, createResolver } from '@nuxt/kit'
+import { addCustomTab } from '@nuxt/devtools/kit'
 
 export interface ModuleOptions {
   defaultConfig: boolean
@@ -46,6 +47,16 @@ export default defineNuxtModule<ModuleOptions>({
         'FormKit defaultConfig was set to false, but not FormKit config file could be found.'
       )
     }
+
+    addCustomTab({
+      name: 'formkit',
+      title: 'FormKit',
+      icon: 'vscode-icons:file-type-formkit',
+      view: {
+        type: 'iframe',
+        src: 'https://formkit.com/getting-started/what-is-formkit',
+      },
+    })
 
     addPluginTemplate({
       src: await resolver.resolve('runtime/plugin.mjs'),


### PR DESCRIPTION
This PR adds FormKit's documentation to a new custom tab on the Nuxt DevTools, following [official recommandations](https://devtools.nuxtjs.org/module/guide#contributing-to-view).

Note that, for now, you need to use the [DevTools' edge channel](https://github.com/nuxt/devtools#edge-release-channel), as stated in [this recent tweet from Sébastien Chopin](https://twitter.com/Atinux/status/1633376222922039296?s=20).