### PR TITLE
Performance improvements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,2 @@
 semi: false
 singleQuote: true
-parser: typescript

--- a/examples/package.json
+++ b/examples/package.json
@@ -15,8 +15,6 @@
     "@formkit/vue": "workspace:^0.16.4",
     "@types/react-dom": "^17.0.9",
     "@vitejs/plugin-vue": "^1.4.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "vite": "^2.4.4",
     "vue-router": "4"
   },

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,6 +11,7 @@
     "@formkit/addons": "workspace:^0.16.4",
     "@formkit/core": "workspace:0.16.4",
     "@formkit/i18n": "workspace:0.16.4",
+    "@formkit/inputs": "workspace:0.16.4",
     "@formkit/themes": "workspace:0.16.4",
     "@formkit/vue": "workspace:^0.16.4",
     "@types/react-dom": "^17.0.9",

--- a/examples/src/vue/examples/PerformanceTest.vue
+++ b/examples/src/vue/examples/PerformanceTest.vue
@@ -1,6 +1,288 @@
 <script setup lang="ts">
+import { FormKitNode } from '@formkit/core'
+import { ref } from 'vue'
+
+const showSimple = ref(false)
+
+const groups: { value: number; label: string }[] = []
+for (let i = 0; i < 18; i++) {
+  groups.push({
+    value: i,
+    label: `Group ${i}`,
+  })
+}
+
+const protocols = [
+  { value: 'tcp', label: 'TCP' },
+  { value: 'udp', label: 'UDP' },
+]
+
+const destinations: { value: number; label: string }[] = []
+for (let i = 0; i < 43; i++) {
+  destinations.push({
+    value: i,
+    label: `Destination ${i}`,
+  })
+}
+
+const services: {
+  id: number
+  description: string
+  srcGroup: number
+  destination: number
+  dstPort: number
+  protocol: string
+}[] = []
+for (let i = 0; i < 91; i++) {
+  services.push({
+    id: i,
+    description: `Rule ${i}`,
+    srcGroup: groups[i % groups.length].value,
+    destination: destinations[i % destinations.length].value,
+    dstPort: 8000 + i,
+    protocol: protocols[i % protocols.length].value,
+  })
+}
+
+const renderFormKit = ref(false)
+const renderNative = ref(false)
+
+const onInput = (node: FormKitNode) => {
+  node.on('input', () =>
+    console.log(`node.input (${node.name}, value: ${node._value})`)
+  )
+}
 </script>
 
 <template>
   <h1>Performance</h1>
+  <div class="flex space-x-5 m-9">
+    <span>
+      Render FormKit takes too long
+      <FormKit type="button" @click="renderFormKit = !renderFormKit"
+        >{{ renderFormKit ? 'Hide' : 'Render' }} FormKit</FormKit
+      >
+    </span>
+    <span>
+      Render Native is fast
+      <FormKit type="button" @click="renderNative = !renderNative"
+        >{{ renderNative ? 'Hide' : 'Render' }} native</FormKit
+      >
+    </span>
+  </div>
+  <FormKit v-if="renderFormKit" type="form">
+    <template v-for="service in services" :key="service.id">
+      <div
+        class="flex flex-row my-2 space-x-2 justify-between items-center bg-white dark:bg-dark-900 p-4 shadow-sm rounded-md"
+      >
+        <FormKit type="group">
+          <div class="flex flex-col lg:flex-row lg:space-x-2 w-full">
+            <div class="flex w-full space-x-2">
+              <div class="w-full">
+                <label
+                  class="block text-sm font-medium text-gray-700 dark:text-dark-300"
+                  >Description</label
+                >
+                <FormKit
+                  v-model="service.description"
+                  type="text"
+                  placeholder="Description"
+                  class="w-full"
+                />
+              </div>
+              <div class="w-full">
+                <label
+                  class="block text-sm font-medium text-gray-700 dark:text-dark-300"
+                  >Source group</label
+                >
+                <FormKit
+                  v-model="service.srcGroup"
+                  type="select"
+                  placeholder="Select a group"
+                  class="w-full style-select"
+                  :options="groups"
+                  validation="required"
+                  :validation-messages="{
+                    required: 'Required',
+                  }"
+                />
+              </div>
+              <div class="w-full lg:w-1/2">
+                <label
+                  class="block text-sm font-medium text-gray-700 dark:text-dark-300 min-w-max"
+                  >Destination port</label
+                >
+                <FormKit
+                  v-model="service.dstPort"
+                  type="number"
+                  placeholder="8080"
+                  validation="required|number|min:1|max:65535"
+                  :validation-messages="{
+                    required: 'Required',
+                    number: 'Must be a number',
+                    min: 'Must be at least 1',
+                    max: 'Must be at most 65535',
+                  }"
+                />
+              </div>
+            </div>
+            <div class="flex w-full space-x-2">
+              <div class="w-full">
+                <label
+                  class="block text-sm font-medium text-gray-700 dark:text-dark-300"
+                  >Destination</label
+                >
+                <FormKit
+                  v-model="service.destination"
+                  type="select"
+                  :placeholder="
+                    destinations
+                      ? 'Select a destination'
+                      : 'No destinations available'
+                  "
+                  class="w-full style-select"
+                  :disabled="!destinations.length"
+                  :options="destinations"
+                  validation="required"
+                  :validation-messages="{
+                    required: 'Required',
+                  }"
+                />
+              </div>
+              <div class="w-full lg:w-1/2">
+                <label
+                  class="block text-sm font-medium text-gray-700 dark:text-dark-300"
+                  >Protocol</label
+                >
+                <FormKit
+                  v-model="service.protocol"
+                  type="select"
+                  placeholder="Select a protocol"
+                  class="w-full style-select"
+                  :options="protocols"
+                  validation="required"
+                  :validation-messages="{
+                    required: 'Required',
+                  }"
+                />
+              </div>
+            </div>
+          </div>
+        </FormKit>
+      </div>
+    </template>
+  </FormKit>
+
+  <div v-if="renderNative" type="form">
+    <template v-for="service in services" :key="service.id">
+      <div
+        class="flex flex-row my-2 space-x-2 justify-between items-center bg-white dark:bg-dark-900 p-4 shadow-sm rounded-md"
+      >
+        <div class="flex flex-col lg:flex-row lg:space-x-2 w-full">
+          <div class="flex w-full space-x-2">
+            <div class="w-full">
+              <label
+                class="block text-sm font-medium text-gray-700 dark:text-dark-300"
+                >Description</label
+              >
+              <input
+                v-model="service.description"
+                type="text"
+                placeholder="Description"
+                class="w-full"
+              />
+            </div>
+            <div class="w-full">
+              <label
+                class="block text-sm font-medium text-gray-700 dark:text-dark-300"
+                >Source group</label
+              >
+              <select
+                v-model="service.srcGroup"
+                placeholder="Select a group"
+                class="w-full style-select"
+              >
+                <option
+                  v-for="group in groups"
+                  :key="group.value"
+                  :value="group.value"
+                >
+                  {{ group.label }}
+                </option>
+              </select>
+            </div>
+            <div class="w-full lg:w-1/2">
+              <label
+                class="block text-sm font-medium text-gray-700 dark:text-dark-300 min-w-max"
+                >Destination port</label
+              >
+              <input
+                v-model="service.dstPort"
+                type="number"
+                placeholder="8080"
+              />
+            </div>
+          </div>
+          <div class="flex w-full space-x-2">
+            <div class="w-full">
+              <label
+                class="block text-sm font-medium text-gray-700 dark:text-dark-300"
+                >Destination</label
+              >
+              <select
+                v-model="service.destination"
+                class="w-full style-select"
+                :disabled="!destinations.length"
+              >
+                <option
+                  v-for="destination in destinations"
+                  :key="destination.value"
+                  :value="destination.value"
+                >
+                  {{ destination.label }}
+                </option>
+              </select>
+            </div>
+            <div class="w-full lg:w-1/2">
+              <label
+                class="block text-sm font-medium text-gray-700 dark:text-dark-300"
+                >Protocol</label
+              >
+              <select
+                v-model="service.protocol"
+                placeholder="Select a protocol"
+                class="w-full style-select"
+              >
+                <option
+                  v-for="protocol in protocols"
+                  :key="protocol.value"
+                  :value="protocol.value"
+                >
+                  {{ protocol.label }}
+                </option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+
+  <button @click="() => (showSimple = !showSimple)">Simple test</button>
+  <FormKit type="form" v-if="showSimple">
+    <FormKit
+      type="text"
+      name="foo"
+      label="foo"
+      validation="required"
+      @node="onInput"
+    />
+    <FormKit
+      type="text"
+      name="bar"
+      label="bar"
+      validation="required"
+      @node="onInput"
+    />
+  </FormKit>
 </template>

--- a/examples/src/vue/examples/Playground.vue
+++ b/examples/src/vue/examples/Playground.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { createSection } from '@formkit/inputs'
-import { currentSchemaNode } from '@formkit/vue'
+import { getCurrentSchemaNode } from '@formkit/vue'
 
 const outer = createSection('outer', () => ({
   $el: 'div',
@@ -15,8 +15,9 @@ const innerB = createSection('innerB', () => ({
 }))
 
 function switcher(schemaA, schemaB) {
+  console.log('schemaA', schemaA)
   return (extensions) => {
-    if (currentSchemaNode.props.attrs.options) {
+    if (getCurrentSchemaNode().props.attrs.options) {
       return schemaA(extensions)
     }
     return schemaB(extensions)
@@ -30,7 +31,7 @@ const definition = {
 </script>
 
 <template>
-  <FormKit :type="definition" />
+  <FormKit :type="definition" :options="[]" />
 </template>
 
 <style scoped>

--- a/examples/src/vue/examples/Playground.vue
+++ b/examples/src/vue/examples/Playground.vue
@@ -1,23 +1,36 @@
 <script setup>
-  import {ref} from "vue";
+import { createSection } from '@formkit/inputs'
+import { currentSchemaNode } from '@formkit/vue'
 
-  const stringify = (value) => JSON.stringify(value);
+const outer = createSection('outer', () => ({
+  $el: 'div',
+}))
+const innerA = createSection('innerA', () => ({
+  $el: 'div',
+  children: 'Inner a',
+}))
+const innerB = createSection('innerB', () => ({
+  $el: 'div',
+  children: 'Inner b',
+}))
 
-  const currentValue = ref(undefined);
+function switcher(schemaA, schemaB) {
+  return (extensions) => {
+    if (currentSchemaNode.props.attrs.options) {
+      return schemaA(extensions)
+    }
+    return schemaB(extensions)
+  }
+}
+
+const definition = {
+  type: 'input',
+  schema: outer(switcher(innerA(), innerB())),
+}
 </script>
 
 <template>
-  <FormKit
-    v-model="currentValue"
-    type="radio"
-    label="FormKit Input"
-    :options="[
-      { value: true, label: 'Yes' },
-      { value: false, label: 'No' },
-      { value: null, label: 'N/A' },
-    ]"
-  />
-  <div>Value: {{stringify(currentValue)}}</div>
+  <FormKit :type="definition" />
 </template>
 
 <style scoped>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postcss": "^8.3.11",
     "postcss-import": "^14.0.2",
     "postcss-nesting": "^10.1.6",
-    "prettier": "^2.2.1",
+    "prettier": "^2.8.7",
     "prompts": "^2.4.1",
     "rollup": "^2.53.2",
     "rollup-plugin-postcss": "^4.0.1",

--- a/packages/core/__tests__/node.spec.ts
+++ b/packages/core/__tests__/node.spec.ts
@@ -74,9 +74,9 @@ describe('node', () => {
       parent: parentC,
       value: undefined,
     })
-    expect(commitEvent).toHaveBeenCalledTimes(12)
+    expect(commitEvent).toHaveBeenCalledTimes(9)
     node.input([{}, {}, {}], false)
-    expect(commitEvent).toHaveBeenCalledTimes(16)
+    expect(commitEvent).toHaveBeenCalledTimes(13)
   })
 
   it('allows configuration to flow to children', () => {
@@ -827,6 +827,20 @@ describe('input hook', () => {
     await node.settled
     expect(node.value).toBe('hello wor!')
   })
+
+  it('fires the input hook and event on all inputs, but will not commit if the value is the same', () => {
+    const node = createNode({ value: 'hello pluto' })
+    const inputHook = vi.fn((value, next) => next(value))
+    const commitHook = vi.fn((value, next) => next(value))
+    const event = vi.fn(() => {})
+    node.hook.input(inputHook)
+    node.hook.commit(commitHook)
+    node.on('input', event)
+    node.input('hello pluto', false)
+    expect(inputHook).toHaveBeenCalledTimes(1)
+    expect(event).toHaveBeenCalledTimes(1)
+    expect(commitHook).toHaveBeenCalledTimes(0)
+  })
 })
 
 describe('classes hook', () => {
@@ -999,14 +1013,14 @@ describe('value propagation in a node tree', () => {
     email.input('test@example.com')
     username.input('test-user')
     await username.settled
-    expect(commitMiddleware).toHaveBeenCalledTimes(4) // 2 partials, 1 full commit
+    expect(commitMiddleware).toHaveBeenCalledTimes(3) // 2 partials, 1 full commit
     expect(parent.value).toEqual({ email: undefined, username: 'test-user' })
     await email.settled
     expect(parent.value).toEqual({
       email: 'test@example.com',
       username: 'test-user',
     })
-    expect(commitMiddleware).toHaveBeenCalledTimes(5)
+    expect(commitMiddleware).toHaveBeenCalledTimes(4)
   })
 
   it('collects values from a list of children', async () => {

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1732,8 +1732,9 @@ function hydrate(node: FormKitNode, context: FormKitContext): FormKitNode {
         (_value[child.name] && typeof _value[child.name] === 'object')
           ? init(_value[child.name])
           : _value[child.name]
-      // If the two are already equal, don’t recurse.
-      if (eq(childValue, child._value)) return
+      // If the two are already equal or the child is currently disturbed then
+      // don’t send the value down since it will squash the child’s value.
+      if (!child.isSettled || eq(childValue, child._value)) return
       // If there is a change to the child, push the new value down.
       child.input(childValue, false)
     } else {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -194,6 +194,7 @@ export interface FormKitExtendableSchemaRoot {
       Partial<FormKitSchemaNode> | FormKitSchemaCondition
     >
   ): FormKitSchemaDefinition
+  memoKey?: string
 }
 
 /**

--- a/packages/inputs/src/inputs/button.ts
+++ b/packages/inputs/src/inputs/button.ts
@@ -52,4 +52,9 @@ export const button: FormKitTypeDefinition = {
    * Additional features that should be added to your input
    */
   features: [localize('submit'), ignores],
+  /**
+   * A key to use for memoizing the schema. This is used to prevent the schema
+   * from needing to be stringified when performing a memo lookup.
+   */
+  schemaMemoKey: 'h6st4epl3j8',
 }

--- a/packages/inputs/src/inputs/checkbox.ts
+++ b/packages/inputs/src/inputs/checkbox.ts
@@ -100,4 +100,8 @@ export const checkbox: FormKitTypeDefinition = {
     checkboxes,
     defaultIcon('decorator', 'checkboxDecorator'),
   ],
+  /**
+   * The key used to memoize the schema.
+   */
+  schemaMemoKey: 'qje02tb3gu8',
 }

--- a/packages/inputs/src/inputs/file.ts
+++ b/packages/inputs/src/inputs/file.ts
@@ -77,4 +77,8 @@ export const file: FormKitTypeDefinition = {
     defaultIcon('fileRemove', 'fileRemove'),
     defaultIcon('noFiles', 'noFiles'),
   ],
+  /**
+   * The key used to memoize the schema.
+   */
+  schemaMemoKey: '9kqc4852fv8',
 }

--- a/packages/inputs/src/inputs/form.ts
+++ b/packages/inputs/src/inputs/form.ts
@@ -41,4 +41,8 @@ export const form: FormKitTypeDefinition = {
    * Additional features that should be added to your input
    */
   features: [forms, disablesChildren],
+  /**
+   * The key used to memoize the schema.
+   */
+  schemaMemoKey: '5bg016redjo',
 }

--- a/packages/inputs/src/inputs/radio.ts
+++ b/packages/inputs/src/inputs/radio.ts
@@ -65,7 +65,9 @@ export const radio: FormKitTypeDefinition = {
                 decorator(icon('decorator')),
                 suffix()
               ),
-              $if('$option.label', boxLabel('$option.label'))
+              $extend(boxLabel('$option.label'), {
+                if: '$option.label',
+              })
             ),
             boxHelp('$option.help')
           )
@@ -73,7 +75,7 @@ export const radio: FormKitTypeDefinition = {
       )
     ),
     // Help text only goes under the input when it is a single.
-    $if('$options === undefined && $help', help('$help')),
+    $if('$options == undefined && $help', help('$help')),
     messages(message('$message.value'))
   ),
   /**
@@ -98,4 +100,8 @@ export const radio: FormKitTypeDefinition = {
     radios,
     defaultIcon('decorator', 'radioDecorator'),
   ],
+  /**
+   * The key used to memoize the schema.
+   */
+  schemaMemoKey: 'qje02tb3gu8',
 }

--- a/packages/inputs/src/inputs/select.ts
+++ b/packages/inputs/src/inputs/select.ts
@@ -60,4 +60,8 @@ export const select: FormKitTypeDefinition = {
    * Additional features that should be added to your input
    */
   features: [options, selects, defaultIcon('select', 'select')],
+  /**
+   * The key used to memoize the schema.
+   */
+  schemaMemoKey: 'cb119h43krg',
 }

--- a/packages/inputs/src/inputs/text.ts
+++ b/packages/inputs/src/inputs/text.ts
@@ -52,4 +52,8 @@ export const text: FormKitTypeDefinition = {
    * Additional features that should be added to your input
    */
   features: [],
+  /**
+   * The key used to memoize the schema.
+   */
+  schemaMemoKey: 'c3cc4kflsg',
 }

--- a/packages/inputs/src/inputs/textarea.ts
+++ b/packages/inputs/src/inputs/textarea.ts
@@ -48,4 +48,8 @@ export const textarea: FormKitTypeDefinition = {
    * Additional features that should be added to your input
    */
   features: [initialValue],
+  /**
+   * The key used to memoize the schema.
+   */
+  schemaMemoKey: 'b1n0td79m9g',
 }

--- a/packages/observer/__tests__/observer.spec.ts
+++ b/packages/observer/__tests__/observer.spec.ts
@@ -64,6 +64,20 @@ describe('observer', () => {
     expect(after).toHaveBeenCalledTimes(2)
   })
 
+  it('does not call an observer if the value has not changed', () => {
+    const node = createNode({ name: 'username', value: 'foo' })
+    const observed = createObserver(node)
+    const callback = vi.fn((n: FormKitObservedNode) => {
+      if (n.value === 'bar') {
+        // do things
+      }
+    })
+    observed.watch(callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+    node.input('foo', false)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
   it('can watch a node accessing its child', async () => {
     const child = createNode({ name: 'username', value: 'foo' })
     const node = createNode({

--- a/packages/observer/src/index.ts
+++ b/packages/observer/src/index.ts
@@ -134,6 +134,7 @@ export function createObserver(
       return createObserver(value, deps)
     }
     if (property === 'value') addDependency('commit')
+    if (property === '_value') addDependency('input')
     if (property === 'props') return observeProps(value)
     if (property === 'ledger') return observeLedger(value)
     return value

--- a/packages/observer/src/index.ts
+++ b/packages/observer/src/index.ts
@@ -45,7 +45,10 @@ export type FormKitDependencies = Map<FormKitNode, Set<string>> & {
  *
  * @public
  */
-export type FormKitObserverReceipts = Map<FormKitNode, { [index: string]: string }>
+export type FormKitObserverReceipts = Map<
+  FormKitNode,
+  { [index: string]: string }
+>
 
 /**
  * A callback to watch for nodes.
@@ -196,6 +199,7 @@ export function createObserver(
  * Given two maps (`toAdd` and `toRemove`), apply the dependencies as event
  * listeners on the underlying nodes.
  * @param node - The node to apply dependencies to.
+ * @param deps - A tuple of toAdd and toRemove FormKitDependencies maps.
  * @param callback - The callback to add or remove.
  * @internal
  */
@@ -247,6 +251,7 @@ export function removeListeners(receipts: FormKitObserverReceipts): void {
  * code when those dependencies are manipulated.
  * @param node - The node to observer
  * @param block - The block of code to observe
+ * @param after - A function to call after a effect has been run.
  * @public
  */
 function watch<T extends FormKitWatchable>(

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -278,6 +278,7 @@ function run(
     validation.queued = false
     const newDeps = node.stopObserve()
     applyListeners(node, diffDeps(validation.deps, newDeps), () => {
+      // Event callback for when the deps change:
       validation.queued = true
       if (state.rerun) clearTimeout(state.rerun)
       state.rerun = setTimeout(
@@ -458,7 +459,7 @@ function createCustomMessage(
 ): string | undefined {
   const customMessage =
     node.props.validationMessages &&
-      has(node.props.validationMessages, validation.name)
+    has(node.props.validationMessages, validation.name)
       ? node.props.validationMessages[validation.name]
       : undefined
   if (typeof customMessage === 'function') {

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1872,7 +1872,7 @@ describe('exposures', () => {
     )
   })
 
-  it('debounces the input event and not the inputRaw event', async () => {
+  it('debounces the input event (not fired on mount) and not the inputRaw event', async () => {
     const wrapper = mount(FormKit, {
       props: {
         type: 'group',
@@ -1896,8 +1896,8 @@ describe('exposures', () => {
       },
     })
     await new Promise((r) => setTimeout(r, 50))
-    expect(wrapper.emitted('inputRaw')!.length).toBe(5)
-    expect(wrapper.emitted('input')!.length).toBe(1)
+    expect(wrapper.emitted('inputRaw')!.length).toBe(4)
+    expect(wrapper.emitted('input')).toBe(undefined)
   })
 
   it('can set values on a group with values that dont have correlating nodes', async () => {

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -19,6 +19,11 @@ import { props } from './props'
 export const parentSymbol: InjectionKey<FormKitNode> = Symbol('FormKitParent')
 
 /**
+ * This variable is set to the node that is currently having its schema created.
+ */
+export let currentSchemaNode: FormKitNode | null = null
+
+/**
  * The root FormKit component.
  *
  * @public
@@ -56,7 +61,9 @@ export const FormKit = defineComponent({
       const schemaDefinition = node.props?.definition?.schema
       if (!schemaDefinition) error(601, node)
       if (typeof schemaDefinition === 'function') {
+        currentSchemaNode = node
         schema.value = schemaDefinition({ ...props.sectionsSchema })
+        currentSchemaNode = null
         if (
           (memoKey && props.sectionsSchema) ||
           ('memoKey' in schemaDefinition &&

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -62,7 +62,9 @@ export const FormKit = defineComponent({
       if (!schemaDefinition) error(601, node)
       if (typeof schemaDefinition === 'function') {
         currentSchemaNode = node
+        console.log('before--')
         schema.value = schemaDefinition({ ...props.sectionsSchema })
+        console.log('after--')
         currentSchemaNode = null
         if (
           (memoKey && props.sectionsSchema) ||

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -20,8 +20,17 @@ export const parentSymbol: InjectionKey<FormKitNode> = Symbol('FormKitParent')
 
 /**
  * This variable is set to the node that is currently having its schema created.
+ *
+ * @internal
  */
-export let currentSchemaNode: FormKitNode | null = null
+let currentSchemaNode: FormKitNode | null = null
+
+/**
+ * Returns the node that is currently having its schema created.
+ *
+ * @public
+ */
+export const getCurrentSchemaNode = () => currentSchemaNode
 
 /**
  * The root FormKit component.
@@ -62,9 +71,7 @@ export const FormKit = defineComponent({
       if (!schemaDefinition) error(601, node)
       if (typeof schemaDefinition === 'function') {
         currentSchemaNode = node
-        console.log('before--')
         schema.value = schemaDefinition({ ...props.sectionsSchema })
-        console.log('after--')
         currentSchemaNode = null
         if (
           (memoKey && props.sectionsSchema) ||

--- a/packages/vue/src/FormKitSchema.ts
+++ b/packages/vue/src/FormKitSchema.ts
@@ -275,7 +275,8 @@ function get(nodeRefs: Record<string, Ref<unknown>>, id?: string) {
  */
 function parseSchema(
   library: FormKitComponentLibrary,
-  schema: FormKitSchemaNode | FormKitSchemaNode[]
+  schema: FormKitSchemaNode | FormKitSchemaNode[],
+  memoKey?: string
 ): SchemaProvider {
   /**
    * Given an if/then/else schema node, pre-compile the node and return the
@@ -714,7 +715,7 @@ function parseSchema(
     providerCallback: SchemaProviderCallback,
     key
   ) {
-    const memoKey = JSON.stringify(schema)
+    memoKey ??= JSON.stringify(schema)
     memoKeys[memoKey] ??= 0
     memoKeys[memoKey]++
     const [render, compiledProviders] = has(memo, memoKey)
@@ -840,12 +841,16 @@ export const FormKitSchema = defineComponent({
       type: Object as PropType<FormKitComponentLibrary>,
       default: () => ({}),
     },
+    memoKey: {
+      type: String,
+      required: false,
+    },
   },
   setup(props, context) {
     const instance = getCurrentInstance()
     let instanceKey = {}
     instanceScopes.set(instanceKey, [])
-    let provider = parseSchema(props.library, props.schema)
+    let provider = parseSchema(props.library, props.schema, props.memoKey)
     let render: RenderChildren
     let data: Record<string, any>
     // // Re-parse the schema if it changes:
@@ -854,7 +859,7 @@ export const FormKitSchema = defineComponent({
       (newSchema, oldSchema) => {
         const oldKey = instanceKey
         instanceKey = {}
-        provider = parseSchema(props.library, props.schema)
+        provider = parseSchema(props.library, props.schema, props.memoKey)
         render = createRenderFn(provider, data, instanceKey)
         if (newSchema === oldSchema) {
           // In this edge case, someone pushed/modified something in the schema

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -29,7 +29,7 @@ export * from './plugin'
 /**
  * The root FormKit component.
  */
-export { default as FormKit, parentSymbol } from './FormKit'
+export { default as FormKit, parentSymbol, currentSchemaNode } from './FormKit'
 
 /**
  * The FormKitMessages component.
@@ -40,12 +40,24 @@ export { FormKitMessages } from './FormKitMessages'
 /**
  * The FormKitSchema component.
  */
-export { FormKitSchema, Renderable, RenderableList, RenderableSlot, RenderableSlots, FormKitComponentLibrary, VirtualNode } from './FormKitSchema'
+export {
+  FormKitSchema,
+  Renderable,
+  RenderableList,
+  RenderableSlot,
+  RenderableSlots,
+  FormKitComponentLibrary,
+  VirtualNode,
+} from './FormKitSchema'
 
 /**
  * The default configuration.
  */
-export { default as defaultConfig, DefaultConfigOptions, PluginConfigs } from './defaultConfig'
+export {
+  default as defaultConfig,
+  DefaultConfigOptions,
+  PluginConfigs,
+} from './defaultConfig'
 
 /**
  * The vue specific FormKit core plugin. This is generally required for all

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -29,7 +29,7 @@ export * from './plugin'
 /**
  * The root FormKit component.
  */
-export { default as FormKit, parentSymbol, currentSchemaNode } from './FormKit'
+export { default as FormKit, parentSymbol, getCurrentSchemaNode } from './FormKit'
 
 /**
  * The FormKitMessages component.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,7 @@ importers:
       '@formkit/addons': workspace:^0.16.4
       '@formkit/core': workspace:0.16.4
       '@formkit/i18n': workspace:0.16.4
+      '@formkit/inputs': workspace:0.16.4
       '@formkit/themes': workspace:0.16.4
       '@formkit/vue': workspace:^0.16.4
       '@types/react': ^17.0.19
@@ -149,6 +150,7 @@ importers:
       '@formkit/addons': link:../packages/addons
       '@formkit/core': link:../packages/core
       '@formkit/i18n': link:../packages/i18n
+      '@formkit/inputs': link:../packages/inputs
       '@formkit/themes': link:../packages/themes
       '@formkit/vue': link:../packages/vue
       '@types/react-dom': 17.0.19
@@ -4360,6 +4362,7 @@ packages:
   /commander/9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+    requiresBuild: true
 
   /commondir/1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
       postcss: ^8.3.11
       postcss-import: ^14.0.2
       postcss-nesting: ^10.1.6
-      prettier: ^2.2.1
+      prettier: ^2.8.7
       prompts: ^2.4.1
       rollup: ^2.53.2
       rollup-plugin-postcss: ^4.0.1
@@ -141,8 +141,6 @@ importers:
       '@types/react': ^17.0.19
       '@types/react-dom': ^17.0.9
       '@vitejs/plugin-vue': ^1.4.0
-      react: ^17.0.2
-      react-dom: ^17.0.2
       sass: ^1.45.1
       vite: ^2.4.4
       vue-router: '4'
@@ -155,8 +153,6 @@ importers:
       '@formkit/vue': link:../packages/vue
       '@types/react-dom': 17.0.19
       '@vitejs/plugin-vue': 1.10.2_vite@2.9.15
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
       vite: 2.9.15_sass@1.60.0
       vue-router: 4.1.6
     devDependencies:
@@ -7182,13 +7178,6 @@ packages:
       is-unicode-supported: 1.3.0
     dev: true
 
-  /loose-envify/1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
-    dependencies:
-      js-tokens: 4.0.0
-    dev: false
-
   /loupe/2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
     dependencies:
@@ -8031,6 +8020,7 @@ packages:
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /object-hash/3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -9071,17 +9061,6 @@ packages:
       destr: 1.2.2
       flat: 5.0.2
 
-  /react-dom/17.0.2_react@17.0.2:
-    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
-    peerDependencies:
-      react: 17.0.2
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react: 17.0.2
-      scheduler: 0.20.2
-    dev: false
-
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
@@ -9089,14 +9068,6 @@ packages:
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
-
-  /react/17.0.2:
-    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-    dev: false
 
   /read-cache/1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -9499,13 +9470,6 @@ packages:
     dependencies:
       xmlchars: 2.2.0
     dev: true
-
-  /scheduler/0.20.2:
-    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-    dev: false
 
   /scule/0.2.1:
     resolution: {integrity: sha512-M9gnWtn3J0W+UhJOHmBxBTwv8mZCan5i1Himp60t6vvZcor0wr+IM0URKmIglsWJ7bRujNAVVN77fp+uZaWoKg==}


### PR DESCRIPTION
This pull requests contains a number of performance enhancements which results in ~3x reduction in "time to mount" compared to previous versions of FormKit. There is still more optimization that can be done, particularly in regards to restructuring code to avoid garbage collection — but most of the super low hanging fruit has been addressed.

- The `input` event will not `disturb` or `commit` changes if the node is an `input` and the value is unchanged.
- `group` and `list` nodes will no longer hydrate children on commit unless there is a change in the child’s value.
- Inputs and schemas can now explicitly define a `schemaMemoKey` to avoid expensive `JSON.stringify()` as a `memoKey` in the schema parser.
- The component level `@input` event will no longer fire until after the node is mounted (and settled).

Due to the above changes, this PR does have some minor breaking changes. You can preview these changes by installing the `@dev` tag of FormKit:

```
npm install @formkit/vue@dev
```

Of course, as always, be sure there aren’t any other `@formkit` dependencies (like `@formkit/addons` or `@formkit/themes` that rely on other versions).

I'm interested in hearing any feedback from @dominikklein or @azertyalex on this. Obviously FormKit is doing a *lot* more than a naïve Vue implementation, so I'm more interested in hearing if this is improving existing project boot times. ❤️