### PR TITLE
SSR Memory Fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Vitest & Playwright
 on: [push, workflow_dispatch]
 jobs:
-  jest-run:
+  Vitest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,14 +15,26 @@ jobs:
       - run: pnpm build all
       - name: Run Vitest
         run: pnpm test
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
-      - name: Run Playwright tests
-        run: pnpm run playwright
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
+  Playwright:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 7
+    - run: pnpm install --frozen-lockfile
+    - run: pnpm build all
+    - name: Install Playwright Browsers
+      run: pnpm exec playwright install --with-deps
+    - name: Run Playwright tests
+      run: pnpm run playwright
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30
 

--- a/e2e/memoryNuxt.spec.ts
+++ b/e2e/memoryNuxt.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect, Page } from '@playwright/test'
+
+async function cycle(
+  page: Page,
+  total = 50,
+  cycleCount = 0,
+  callback?: (page: Page) => void
+) {
+  return new Promise<void>(async (resolve) => {
+    await page.reload()
+    if (callback) await callback(page)
+    setTimeout(async () => {
+      if (cycleCount < total) await cycle(page, total, cycleCount + 1)
+      resolve()
+    }, 500)
+  })
+}
+
+async function getMemory(page: Page) {
+  // Allow some further GC:
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  await page.reload()
+  return Number(await page.locator('input').first().inputValue())
+}
+
+test('formkit app gets garbage collected in nuxt', async ({ page }) => {
+  await page.goto('http://localhost:3000/')
+  await cycle(page, 2) // Warm up
+  const initialMemory = await getMemory(page)
+  await cycle(page, 20)
+  const finalMemory = await getMemory(page)
+  expect((finalMemory - initialMemory) / 20).toBeLessThan(0.1)
+  expect(finalMemory).toBeLessThan(initialMemory + 5)
+})

--- a/e2e/memoryNuxt.spec.ts
+++ b/e2e/memoryNuxt.spec.ts
@@ -24,7 +24,7 @@ async function getMemory(page: Page) {
 }
 
 test('formkit app gets garbage collected in nuxt', async ({ page }) => {
-  await page.goto('http://localhost:3000/')
+  await page.goto('http://localhost:8484/')
   await cycle(page, 2) // Warm up
   const initialMemory = await getMemory(page)
   await cycle(page, 20)

--- a/e2e/memoryNuxt.spec.ts
+++ b/e2e/memoryNuxt.spec.ts
@@ -24,6 +24,7 @@ async function getMemory(page: Page) {
 }
 
 test('formkit app gets garbage collected in nuxt', async ({ page }) => {
+  test.setTimeout(60000)
   await page.goto('http://localhost:8484/')
   await cycle(page, 2) // Warm up
   const initialMemory = await getMemory(page)

--- a/e2e/memorySSR.spec.ts
+++ b/e2e/memorySSR.spec.ts
@@ -1,8 +1,14 @@
 import { test, expect, Page } from '@playwright/test'
 
-async function cycle(page: Page, total = 50, cycleCount = 0) {
+async function cycle(
+  page: Page,
+  total = 50,
+  cycleCount = 0,
+  callback?: (page: Page) => void
+) {
   return new Promise<void>(async (resolve) => {
     await page.reload()
+    if (callback) await callback(page)
     setTimeout(async () => {
       if (cycleCount < total) await cycle(page, total, cycleCount + 1)
       resolve()
@@ -28,11 +34,12 @@ test('standard vue source app gets garbage collected (control)', async ({
   expect(finalMemory).toBeLessThan(initialMemory + 5)
 })
 
-test('formkit app gets garbage collected', async ({ page }) => {
+test.only('formkit app gets garbage collected', async ({ page }) => {
   await page.goto('http://localhost:8686/')
   await cycle(page, 2) // Warm up
   const initialMemory = await getMemory(page)
   await cycle(page, 20)
   const finalMemory = await getMemory(page)
+  expect((finalMemory - initialMemory) / 20).toBeLessThan(0.1)
   expect(finalMemory).toBeLessThan(initialMemory + 5)
 })

--- a/e2e/memorySSR.spec.ts
+++ b/e2e/memorySSR.spec.ts
@@ -34,7 +34,7 @@ test('standard vue source app gets garbage collected (control)', async ({
   expect(finalMemory).toBeLessThan(initialMemory + 5)
 })
 
-test.only('formkit app gets garbage collected', async ({ page }) => {
+test('formkit app gets garbage collected', async ({ page }) => {
   await page.goto('http://localhost:8686/')
   await cycle(page, 2) // Warm up
   const initialMemory = await getMemory(page)

--- a/e2e/servers/formKitMemoryServer.mjs
+++ b/e2e/servers/formKitMemoryServer.mjs
@@ -4,10 +4,64 @@ import { plugin, defaultConfig } from '@formkit/vue'
 import http from 'http'
 
 const template = `<FormKit type="form">
-  <FormKit label="Sample 1" type="text" validation="required" validation-visibility="live" />
-  <FormKit label="Sample 2" type="text" validation="required" validation-visibility="live" />
-  <FormKit label="Sample 3" type="text" validation="required" validation-visibility="live" />
-  <FormKit label="Sample 4" type="text" validation="required" validation-visibility="live" />
+  <FormKit
+    type="text"
+    name="name"
+    id="name"
+    validation="required|not:Admin"
+    label="Name"
+    help="Enter your character's full name"
+    placeholder="“Scarlet Sword”"
+  />
+
+  <FormKit
+    type="select"
+    label="Class"
+    name="class"
+    id="class"
+    placeholder="Select a class"
+    :options="['Warrior', 'Mage', 'Assassin']"
+  />
+
+  <FormKit
+    type="range"
+    name="strength"
+    id="strength"
+    label="Strength"
+    value="5"
+    validation="min:2|max:9"
+    validation-visibility="live"
+    min="1"
+    max="10"
+    step="1"
+    help="How many strength points should this character have?"
+  />
+
+  <FormKit
+    type="range"
+    name="skill"
+    id="skill"
+    validation="required|max:10"
+    label="Skill"
+    value="5"
+    min="1"
+    max="10"
+    step="1"
+    help="How much skill points to start with"
+  />
+
+  <FormKit
+    type="range"
+    name="dexterity"
+    id="dexterity"
+    validation="required|max:10"
+    label="Dexterity"
+    value="5"
+    min="1"
+    max="10"
+    step="1"
+    help="How much dexterity points to start with"
+  />
 </FormKit>`
 
 const server = http.createServer((req, res) => {
@@ -23,7 +77,7 @@ const server = http.createServer((req, res) => {
   app.use(plugin, defaultConfig)
 
   renderToString(app).then((html) => {
-    globalThis.gc() // eslint-disable-line no-undef
+    if (typeof globalThis.gc === 'function') globalThis.gc() // eslint-disable-line no-undef
     res.statusCode = 200
     res.setHeader('Content-Type', 'text/html')
     res.end(`<!DOCTYPE />

--- a/e2e/servers/formKitMemoryServer.mjs
+++ b/e2e/servers/formKitMemoryServer.mjs
@@ -1,6 +1,6 @@
 import { createSSRApp } from 'vue'
 import { renderToString } from '@vue/server-renderer'
-import { plugin, defaultConfig } from '@formkit/vue'
+import { plugin, defaultConfig, ssrComplete } from '@formkit/vue'
 import http from 'http'
 
 const template = `<FormKit type="form">
@@ -77,6 +77,7 @@ const server = http.createServer((req, res) => {
   app.use(plugin, defaultConfig)
 
   renderToString(app).then((html) => {
+    ssrComplete(app)
     if (typeof globalThis.gc === 'function') globalThis.gc() // eslint-disable-line no-undef
     res.statusCode = 200
     res.setHeader('Content-Type', 'text/html')
@@ -89,8 +90,6 @@ const server = http.createServer((req, res) => {
       <div id="app">${html}</div>
     </html>`)
   })
-
-  app = null
 })
 
 server.listen(8686, 'localhost', () => {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "playwright-server": "vite preview --config ./examples/vite.config.ts --port 8787 --host",
     "nuxt-pack": "cd packages/nuxt && pnpm prepack",
     "nuxt-dev": "cd packages/nuxt && pnpm dev",
+    "nuxt-build": "cd packages/nuxt && pnpm build",
     "tailwind-dev": "vite packages/tailwindcss/playground --host",
     "tailwind-css": "npx tailwindcss -c packages/tailwindcss/playground/tailwind.config.cjs -i packages/tailwindcss/playground/src/index.css -o packages/tailwindcss/playground/dist/index.css --watch"
   },

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "playwright": "playwright test --config ./playwright.config.ts",
     "playwright-build": "vite build --config ./examples/vite.config.ts",
     "playwright-server": "vite preview --config ./examples/vite.config.ts --port 8787 --host",
-    "nuxt-pack": "nuxt-module-build packages/nuxt",
-    "nuxt-dev": "nuxi dev packages/nuxt/playground",
+    "nuxt-pack": "cd packages/nuxt && pnpm prepack",
+    "nuxt-dev": "cd packages/nuxt && pnpm dev",
     "tailwind-dev": "vite packages/tailwindcss/playground --host",
     "tailwind-css": "npx tailwindcss -c packages/tailwindcss/playground/tailwind.config.cjs -i packages/tailwindcss/playground/src/index.css -o packages/tailwindcss/playground/dist/index.css --watch"
   },

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1830,6 +1830,10 @@ function destroy(node: FormKitNode, context: FormKitContext) {
   node.emit('destroyed', node)
   context._e.flush()
   context._value = context.value = undefined
+  for (const property in context.context) {
+    delete context.context[property]
+  }
+  context.plugins.clear()
   context.context = null! // eslint-disable-line @typescript-eslint/no-non-null-assertion
 }
 

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -19,7 +19,8 @@
   ],
   "scripts": {
     "prepack": "nuxt-module-build",
-    "dev": "nuxi dev playground"
+    "dev": "nuxi dev playground",
+    "build": "nuxi build playground"
   },
   "dependencies": {
     "@formkit/core": "0.16.4",

--- a/packages/nuxt/playground/.nuxt/tsconfig.json
+++ b/packages/nuxt/playground/.nuxt/tsconfig.json
@@ -48,16 +48,16 @@
         "public"
       ],
       "#app": [
-        "../../../node_modules/.pnpm/nuxt@3.3.1_er5663cxvbd4jd6tsj56chveyu/node_modules/nuxt/dist/app"
+        "../../../node_modules/.pnpm/nuxt@3.3.2_5v5fhw66uehklgxmcvwgstryt4/node_modules/nuxt/dist/app"
       ],
       "#app/*": [
-        "../../../node_modules/.pnpm/nuxt@3.3.1_er5663cxvbd4jd6tsj56chveyu/node_modules/nuxt/dist/app/*"
+        "../../../node_modules/.pnpm/nuxt@3.3.2_5v5fhw66uehklgxmcvwgstryt4/node_modules/nuxt/dist/app/*"
       ],
       "vue-demi": [
-        "../../../node_modules/.pnpm/nuxt@3.3.1_er5663cxvbd4jd6tsj56chveyu/node_modules/nuxt/dist/app/compat/vue-demi"
+        "../../../node_modules/.pnpm/nuxt@3.3.2_5v5fhw66uehklgxmcvwgstryt4/node_modules/nuxt/dist/app/compat/vue-demi"
       ],
       "@vueuse/head": [
-        "../../../node_modules/.pnpm/@unhead+vue@1.1.23_vue@3.2.47/node_modules/@unhead/vue/dist/index"
+        "../../../node_modules/.pnpm/@unhead+vue@1.1.25_vue@3.2.47/node_modules/@unhead/vue/dist/index"
       ],
       "#imports": [
         ".nuxt/imports"

--- a/packages/nuxt/playground/app.vue
+++ b/packages/nuxt/playground/app.vue
@@ -1,5 +1,17 @@
+<script lang="ts" setup>
+let memoryValue
+if (typeof window === 'undefined') {
+  if (typeof globalThis.gc === 'function') gc()
+  memoryValue = Math.round(process.memoryUsage().heapUsed / 1000 / 100) / 10
+}
+</script>
+
 <template>
   <div class="my-form">
+    <label>
+      Server memory
+      <input id="memory" :value="memoryValue">
+    </label>
     <FormKit
       type="form"
       :value="{ hydration_test: 'Testing hydration', tailwind: 'lots' }"
@@ -15,35 +27,28 @@
         :classes="{
           label: {
             'text-gray-600': false,
-            'text-red-600': true
-          }
+            'text-red-600': true,
+          },
         }"
         help="Gray label text color removed, red added."
         validation="required"
         validation-visibility="live"
         value="This is hydrated"
       />
-      <FormKit
-        id="hydration_test"
-        type="textarea"
-        name="hydration_test"
-      />
+      <FormKit id="hydration_test" type="textarea" name="hydration_test" />
       <FormKit
         label="How much do you like Tailwind?"
         type="radio"
         name="tailwind"
         :options="{
           little: 'I like it a little',
-          lots: 'I like it a lot'
+          lots: 'I like it a lot',
         }"
         help="I only get the `radio` styles because the config has conditional logic"
       />
     </FormKit>
   </div>
 </template>
-
-<script lang="ts" setup>
-</script>
 
 <style>
 .my-form {

--- a/packages/nuxt/src/runtime/plugin.mjs
+++ b/packages/nuxt/src/runtime/plugin.mjs
@@ -1,11 +1,13 @@
 import { defineNuxtPlugin } from '#app'
-import { plugin, defaultConfig } from '@formkit/vue'
+import { plugin, defaultConfig, ssrComplete } from '@formkit/vue'
 import { resetCount } from '@formkit/core'
 <%= options.importStatement %>
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.hook('app:rendered', () => {
+  nuxtApp.hook('app:rendered', (renderContext) => {
     resetCount()
+    ssrComplete(nuxtApp.vueApp)
   })
   nuxtApp.vueApp.use(plugin, <%= options.config %>)
+
 })

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -95,7 +95,7 @@ export const FormKit = defineComponent({
 
     // // If someone emits the schema event, we re-generate the schema
     if (!isServer) {
-      // node.on('schema', generateSchema)
+      node.on('schema', generateSchema)
     }
 
     context.emit('node', node)

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -12,6 +12,11 @@ import { FormKitSchema } from './FormKitSchema'
 import { props } from './props'
 
 /**
+ * Flag to determine if we are running on the server.
+ */
+const isServer = typeof window === 'undefined'
+
+/**
  * The symbol that represents the formkit parent injection value.
  *
  * @public
@@ -89,7 +94,9 @@ export const FormKit = defineComponent({
     generateSchema()
 
     // // If someone emits the schema event, we re-generate the schema
-    node.on('schema', generateSchema)
+    if (!isServer) {
+      // node.on('schema', generateSchema)
+    }
 
     context.emit('node', node)
     const library = node.props.definition.library as

--- a/packages/vue/src/FormKitSchema.ts
+++ b/packages/vue/src/FormKitSchema.ts
@@ -916,6 +916,7 @@ export const FormKitSchema = defineComponent({
      * remove any memory allocations that were made during the render process.
      */
     function cleanUp() {
+      if (isServer) console.log('cleaning up ssr')
       // Perform cleanup operations
       clean(props.schema, props.memoKey, instanceKey)
       provider.clean()

--- a/packages/vue/src/FormKitSchema.ts
+++ b/packages/vue/src/FormKitSchema.ts
@@ -916,7 +916,6 @@ export const FormKitSchema = defineComponent({
      * remove any memory allocations that were made during the render process.
      */
     function cleanUp() {
-      if (isServer) console.log('cleaning up ssr')
       // Perform cleanup operations
       clean(props.schema, props.memoKey, instanceKey)
       provider.clean()

--- a/packages/vue/src/FormKitSchema.ts
+++ b/packages/vue/src/FormKitSchema.ts
@@ -37,6 +37,12 @@ import {
   isNode,
   sugar,
 } from '@formkit/core'
+import { onSSRComplete } from './composables/onSSRComplete'
+
+/**
+ * A simple flag to tell if we are running on the server or not.
+ */
+const isServer = typeof window === 'undefined'
 
 /**
  * A library of components available to the schema (in addition to globally
@@ -719,12 +725,16 @@ function parseSchema(
     key: object
   ) {
     memoKey ??= JSON.stringify(schema)
-    memoKeys[memoKey] ??= 0
-    memoKeys[memoKey]++
     const [render, compiledProviders] = has(memo, memoKey)
       ? memo[memoKey]
       : [createElements(library, schema), providers]
-    memo[memoKey] = [render, compiledProviders]
+
+    if (!isServer) {
+      memoKeys[memoKey] ??= 0
+      memoKeys[memoKey]++
+      memo[memoKey] = [render, compiledProviders]
+    }
+
     compiledProviders.forEach((compiledProvider) => {
       compiledProvider(providerCallback, key)
     })
@@ -870,25 +880,27 @@ export const FormKitSchema = defineComponent({
     let render: RenderChildren
     let data: Record<string, any>
     // // Re-parse the schema if it changes:
-    watch(
-      () => props.schema,
-      (newSchema, oldSchema) => {
-        const oldKey = instanceKey
-        instanceKey = {}
-        provider = parseSchema(props.library, props.schema, props.memoKey)
-        render = createRenderFn(provider, data, instanceKey)
-        if (newSchema === oldSchema) {
-          // In this edge case, someone pushed/modified something in the schema
-          // and we've successfully re-parsed, but since the schema is not
-          // referenced in the render function it technically isnt a dependency
-          // and we need to force a re-render since we swapped out the render
-          // function completely.
-          ;(instance?.proxy?.$forceUpdate as unknown as CallableFunction)()
-        }
-        clean(props.schema, props.memoKey, oldKey)
-      },
-      { deep: true }
-    )
+    if (!isServer) {
+      watch(
+        () => props.schema,
+        (newSchema, oldSchema) => {
+          const oldKey = instanceKey
+          instanceKey = {}
+          provider = parseSchema(props.library, props.schema, props.memoKey)
+          render = createRenderFn(provider, data, instanceKey)
+          if (newSchema === oldSchema) {
+            // In this edge case, someone pushed/modified something in the schema
+            // and we've successfully re-parsed, but since the schema is not
+            // referenced in the render function it technically isnt a dependency
+            // and we need to force a re-render since we swapped out the render
+            // function completely.
+            ;(instance?.proxy?.$forceUpdate as unknown as CallableFunction)()
+          }
+          clean(props.schema, props.memoKey, oldKey)
+        },
+        { deep: true }
+      )
+    }
 
     // // Watch the data object explicitly
     watchEffect(() => {
@@ -899,16 +911,27 @@ export const FormKitSchema = defineComponent({
       render = createRenderFn(provider, data, instanceKey)
     })
 
-    onUnmounted(() => {
+    /**
+     * Perform cleanup operations when the component is unmounted. This should
+     * remove any memory allocations that were made during the render process.
+     */
+    function cleanUp() {
       // Perform cleanup operations
       clean(props.schema, props.memoKey, instanceKey)
       provider.clean()
       /* eslint-disable @typescript-eslint/no-non-null-assertion */
+      if (data.node) data.node.destroy()
       data.slots = null!
       data = null!
       render = null!
       /* eslint-enable @typescript-eslint/no-non-null-assertion */
-    })
+    }
+
+    // For browser rendering:
+    onUnmounted(cleanUp)
+    // For SSR rendering:
+    onSSRComplete(getCurrentInstance()?.appContext.app, cleanUp)
+
     return () => render()
   },
 })

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -446,6 +446,12 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
 
   // The context is complete
   node.emit('context', node, false)
+
+  node.on('destroyed', () => {
+    node.context = undefined
+    /* @ts-ignore */
+    node = null
+  })
 }
 
 export default vueBindings

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -279,7 +279,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
     }
     ;(async () => {
       await node.settled
-      node.props._init = cloneAny(node.value)
+      if (node) node.props._init = cloneAny(node.value)
     })()
   })
 

--- a/packages/vue/src/composables/onSSRComplete.ts
+++ b/packages/vue/src/composables/onSSRComplete.ts
@@ -9,7 +9,7 @@ const isServer = typeof window === 'undefined'
  * A map of Vue applications to a set of callbacks to be flushed after SSR is
  * complete.
  */
-const ssrCompleteRegistry = new WeakMap<App<any>, Set<CallableFunction>>()
+const ssrCompleteRegistry = new Map<App<any>, Set<CallableFunction>>()
 
 /**
  * Flush all callbacks registered with onSSRComplete for a given app.

--- a/packages/vue/src/composables/onSSRComplete.ts
+++ b/packages/vue/src/composables/onSSRComplete.ts
@@ -1,0 +1,44 @@
+import { App } from 'vue'
+
+/**
+ * A flag indicating if this is (likely) a server context.
+ */
+const isServer = typeof window === 'undefined'
+
+/**
+ * A map of Vue applications to a set of callbacks to be flushed after SSR is
+ * complete.
+ */
+const ssrCompleteRegistry = new WeakMap<App<any>, Set<CallableFunction>>()
+
+/**
+ * Flush all callbacks registered with onSSRComplete for a given app.
+ * @param app - The Vue application.
+ * @public
+ */
+export function ssrComplete(app: App<any>) {
+  if (!isServer) return
+  const callbacks = ssrCompleteRegistry.get(app)
+  if (!callbacks) return
+  for (const callback of callbacks) {
+    callback()
+  }
+  callbacks.clear()
+  ssrCompleteRegistry.delete(app)
+}
+
+/**
+ * Register a callback for when SSR is complete. No-op if not in a server
+ * context.
+ * @param app - The Vue application.
+ * @param callback - The callback to be called after SSR is complete.
+ * @public
+ */
+export function onSSRComplete(
+  app: App<any> | undefined,
+  callback: CallableFunction
+) {
+  if (!isServer || !app) return
+  if (!ssrCompleteRegistry.has(app)) ssrCompleteRegistry.set(app, new Set())
+  ssrCompleteRegistry.get(app)?.add(callback)
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -29,7 +29,11 @@ export * from './plugin'
 /**
  * The root FormKit component.
  */
-export { default as FormKit, parentSymbol, getCurrentSchemaNode } from './FormKit'
+export {
+  default as FormKit,
+  parentSymbol,
+  getCurrentSchemaNode,
+} from './FormKit'
 
 /**
  * The FormKitMessages component.
@@ -81,3 +85,8 @@ export {
   submitForm,
   reset,
 } from '@formkit/core'
+
+/**
+ * SSR support for cleanup operations relating to SSR.
+ */
+export { ssrComplete, onSSRComplete } from './composables/onSSRComplete'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,19 +37,22 @@ export default defineConfig({
       command: 'pnpm playwright-build && pnpm playwright-server',
       url: 'http://127.0.0.1:8787',
       reuseExistingServer: false,
-      // reuseExistingServer: !process.env.CI,
     },
     {
       command: 'node --expose-gc e2e/servers/formKitMemoryServer.mjs',
       url: 'http://localhost:8686',
       reuseExistingServer: false,
-      // reuseExistingServer: !process.env.CI,
     },
     {
       command: 'node --expose-gc e2e/servers/vueMemoryServer.mjs',
       url: 'http://localhost:8585',
       reuseExistingServer: false,
-      // reuseExistingServer: !process.env.CI,
+    },
+    {
+      command:
+        'pnpm nuxt-build && node --expose-gc packages/nuxt/playground/.output/server/index.mjs',
+      url: 'http://localhost:3000',
+      reuseExistingServer: false,
     },
   ],
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,8 +50,8 @@ export default defineConfig({
     },
     {
       command:
-        'pnpm nuxt-build && node --expose-gc packages/nuxt/playground/.output/server/index.mjs',
-      url: 'http://localhost:3000',
+        'pnpm nuxt-build && NITRO_PORT=8484 node --expose-gc packages/nuxt/playground/.output/server/index.mjs',
+      url: 'http://localhost:8484',
       reuseExistingServer: false,
     },
   ],


### PR DESCRIPTION
This PR adds a new global "hook" to `@formkit/vue`: `onSSRComplete`

Since FormKit makes heavy use of memoization and requires a manual cleanup event. This is typically handled on the front end inside `onUnmounted`, but since Vue does not currently have any hooks that fire after SSR we needed to create our own (see: https://github.com/vuejs/core/issues/8066).

This allows any first or third party to manually indicate that SSR has completed and it is safe to perform cleanup operations. This PR implements the new hook in our first-party Nuxt module and adds backing tests.