### PR TITLE
localStorage Plugin Updates

### DIFF
--- a/examples/src/vue/examples/LocalStoragePlugin.vue
+++ b/examples/src/vue/examples/LocalStoragePlugin.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { createLocalStoragePlugin } from '@formkit/addons'
+import { ref } from 'vue'
 
 const submitHandler = async function () {
   await new Promise((r) => setTimeout(r, 2000))
@@ -9,7 +10,8 @@ const submitHandler = async function () {
   window.location.reload()
 }
 
-const mockUserId = 1
+const mockUserId = 2
+const saveData = ref(true)
 
 async function beforeSave(payload) {
   await new Promise((r) => setTimeout(r, 1000))
@@ -17,8 +19,8 @@ async function beforeSave(payload) {
   return encoded
 }
 async function beforeLoad(payload) {
-  await new Promise((r) => setTimeout(r, 1000))
   const decoded = JSON.parse(atob(payload))
+  await new Promise((r) => setTimeout(r, 1000))
   return decoded
 }
 </script>
@@ -33,13 +35,11 @@ async function beforeLoad(payload) {
     This form's `maxAge` is set to 15 seconds for preserved data. (default is 1
     hour)
   </p>
-
   <FormKit
     v-slot="{ value }"
     type="form"
     :plugins="[
       createLocalStoragePlugin({
-        key: mockUserId,
         prefix: 'myPrefix',
         maxAge: 15000,
         beforeSave: beforeSave,
@@ -50,6 +50,12 @@ async function beforeLoad(payload) {
     use-local-storage
     @submit="submitHandler"
   >
+    <FormKit
+      type="checkbox"
+      name="saveData"
+      :value="true"
+      label="Save my progress as I type"
+    />
     <FormKit type="text" name="name" label="Your name" />
     <FormKit type="text" name="email" label="Your email" />
     <FormKit type="textarea" name="message" label="Your message" />

--- a/examples/src/vue/examples/LocalStoragePlugin.vue
+++ b/examples/src/vue/examples/LocalStoragePlugin.vue
@@ -42,6 +42,7 @@ async function beforeLoad(payload) {
       createLocalStoragePlugin({
         prefix: 'myPrefix',
         maxAge: 15000,
+        control: 'saveData',
         beforeSave: beforeSave,
         beforeLoad: beforeLoad,
       }),
@@ -61,5 +62,15 @@ async function beforeLoad(payload) {
     <FormKit type="textarea" name="message" label="Your message" />
 
     <pre>{{ value }}</pre>
+  </FormKit>
+
+  <h2>Test on a non-form 'group' input</h2>
+  <FormKit
+    type="group"
+    :plugins="[createLocalStoragePlugin()]"
+    use-local-storage
+  >
+    <FormKit type="text" label="Subject" />
+    <FormKit type="textarea" label="Message" />
   </FormKit>
 </template>

--- a/examples/src/vue/examples/LocalStoragePlugin.vue
+++ b/examples/src/vue/examples/LocalStoragePlugin.vue
@@ -8,6 +8,19 @@ const submitHandler = async function () {
   )
   window.location.reload()
 }
+
+const mockUserId = 1
+
+async function beforeSave(payload) {
+  await new Promise((r) => setTimeout(r, 1000))
+  const encoded = btoa(JSON.stringify(payload))
+  return encoded
+}
+async function beforeLoad(payload) {
+  await new Promise((r) => setTimeout(r, 1000))
+  const decoded = JSON.parse(atob(payload))
+  return decoded
+}
 </script>
 
 <template>
@@ -17,21 +30,29 @@ const submitHandler = async function () {
     Localstorage values are cleared on subimt.
   </p>
   <p>
-    This form's `maxAge` is set to 5 seconds for preserved data. (default is 1
+    This form's `maxAge` is set to 15 seconds for preserved data. (default is 1
     hour)
   </p>
 
   <FormKit
     v-slot="{ value }"
     type="form"
-    :plugins="[createLocalStoragePlugin({ prefix: 'myPrefix', maxAge: 5000 })]"
+    :plugins="[
+      createLocalStoragePlugin({
+        key: mockUserId,
+        prefix: 'myPrefix',
+        maxAge: 15000,
+        beforeSave: beforeSave,
+        beforeLoad: beforeLoad,
+      }),
+    ]"
     name="contactForm"
     use-local-storage
     @submit="submitHandler"
   >
-    <FormKit type="text" label="Your name" />
-    <FormKit type="email" label="Your email" />
-    <FormKit type="textarea" label="Your message" />
+    <FormKit type="text" name="name" label="Your name" />
+    <FormKit type="text" name="email" label="Your email" />
+    <FormKit type="textarea" name="message" label="Your message" />
 
     <pre>{{ value }}</pre>
   </FormKit>

--- a/packages/addons/src/plugins/localStoragePlugin.ts
+++ b/packages/addons/src/plugins/localStoragePlugin.ts
@@ -37,7 +37,11 @@ export function createLocalStoragePlugin(
   localStorageOptions?: LocalStorageOptions
 ): FormKitPlugin {
   const localStoragePlugin = (node: FormKitNode) => {
-    if (node.props.type !== 'form') return
+    // only apply if internal FormKit type is 'group'. This applies
+    // to 'form' and 'group' inputs — as well as any add-on inputs
+    // registered of FormKit type 'group' (eg. 'multi-step').
+    console.log(node.type)
+    if (node.type !== 'group') return
 
     const shouldUseLocalStorage = (controlNode: FormKitNode | undefined) => {
       let controlFieldValue = true

--- a/packages/addons/src/plugins/localStoragePlugin.ts
+++ b/packages/addons/src/plugins/localStoragePlugin.ts
@@ -10,6 +10,7 @@ export interface LocalStorageOptions {
   prefix?: string
   maxAge?: number
   key?: string | number
+  control: string
   debounce?: number
   beforeSave?: (payload: any) => any
   beforeLoad?: (payload: any) => any
@@ -29,12 +30,36 @@ export function createLocalStoragePlugin(
 ): FormKitPlugin {
   const localStoragePlugin = (node: FormKitNode) => {
     if (node.props.type !== 'form') return
-    node.addProps(['useLocalStorage'])
+
+    const shouldUseLocalStorage = (controlNode: FormKitNode | undefined) => {
+      let controlFieldValue = true
+      if (controlNode) {
+        controlFieldValue = controlNode.value === true
+      }
+      return undefine(node.props.useLocalStorage) && controlFieldValue
+    }
 
     node.on('created', async () => {
-      const useLocalStorage = undefine(node.props.useLocalStorage)
-      if (!useLocalStorage) return
+      node.addProps(['useLocalStorage'])
+      await node.settled
 
+      // if the user provided a control field, then we need to listen for changes
+      // and use it to determine whether or not to use local storage
+      const controlField = localStorageOptions?.control ?? undefined
+      let controlNode: FormKitNode | undefined
+      if (typeof controlField === 'string') {
+        const controlNode = node.at(controlField)
+        if (controlNode) {
+          controlNode.on('commit', () => {
+            useLocalStorage = shouldUseLocalStorage(controlNode)
+            if (!useLocalStorage) {
+              localStorage.removeItem(storageKey)
+            }
+          })
+        }
+      }
+
+      let useLocalStorage = shouldUseLocalStorage(controlNode)
       let saveTimeout: ReturnType<typeof setTimeout> | number = 0
       const debounce =
         typeof localStorageOptions?.debounce === 'number'
@@ -43,10 +68,11 @@ export function createLocalStoragePlugin(
       const prefix = localStorageOptions?.prefix ?? 'formkit'
       const maxAge = localStorageOptions?.maxAge ?? 3600000 // 1 hour
       const key = localStorageOptions?.key ? `-${localStorageOptions.key}` : '' // for scoping to a specific user
-      const storageKey = `${prefix}-${node.name}${key}`
-      const value = localStorage.getItem(storageKey)
+      const storageKey = `${prefix}${key}-${node.name}`
 
-      if (value) {
+      const loadValue = async () => {
+        const value = localStorage.getItem(storageKey)
+        if (!value) return
         const loadValue = JSON.parse(value)
         if (typeof localStorageOptions?.beforeLoad === 'function') {
           node.props.disabled = true
@@ -67,35 +93,49 @@ export function createLocalStoragePlugin(
         }
       }
 
+      const saveValue = async (payload: unknown) => {
+        let savePayload = payload
+        if (typeof localStorageOptions?.beforeSave === 'function') {
+          try {
+            savePayload = await localStorageOptions.beforeSave(payload)
+          } catch (error) {
+            console.error(error)
+          }
+        }
+
+        if (!savePayload) return
+
+        localStorage.setItem(
+          storageKey,
+          JSON.stringify({
+            maxAge: Date.now() + maxAge,
+            data: savePayload,
+          })
+        )
+      }
+
       node.on('commit', ({ payload }) => {
+        if (!useLocalStorage) return
         // debounce the save to local storage
         clearTimeout(saveTimeout)
         saveTimeout = setTimeout(async () => {
-          let savePayload = payload
-          if (typeof localStorageOptions?.beforeSave === 'function') {
-            try {
-              savePayload = await localStorageOptions.beforeSave(payload)
-            } catch (error) {
-              console.error(error)
-            }
-          }
-
-          if (!savePayload) return
-
-          localStorage.setItem(
-            storageKey,
-            JSON.stringify({
-              maxAge: Date.now() + maxAge,
-              data: savePayload,
-            })
-          )
+          saveValue(payload)
         }, debounce)
+      })
+
+      node.on('prop:useLocalStorage', () => {
+        useLocalStorage = shouldUseLocalStorage(controlNode)
+        if (!useLocalStorage) {
+          localStorage.removeItem(storageKey)
+        }
       })
 
       node.hook.submit((payload, next) => {
         localStorage.removeItem(storageKey)
         return next(payload)
       })
+
+      await loadValue()
     })
   }
   return localStoragePlugin

--- a/packages/addons/src/plugins/localStoragePlugin.ts
+++ b/packages/addons/src/plugins/localStoragePlugin.ts
@@ -4,13 +4,21 @@ import { undefine } from '@formkit/utils'
 /**
  * The options to be passed to {@link createLocalStoragePlugin | createLocalStoragePlugin}
  *
+ * @param prefix - The prefix to use for the local storage key
+ * @param key - The key to use for the local storage entry, useful for scoping data per user
+ * @param control - The form control to use enable or disable saving to localStorage. Must return a boolean value.
+ * @param maxAge - The maximum age of the local storage entry in milliseconds
+ * @param debounce - The debounce time in milliseconds to use when saving to localStorage
+ * @param beforeSave - A function to call for modifying data before saving to localStorage
+ * @param beforeLoad - A function to call for modifying data before loading from localStorage
+ *
  * @public
  */
 export interface LocalStorageOptions {
   prefix?: string
-  maxAge?: number
   key?: string | number
-  control: string
+  control?: string
+  maxAge?: number
   debounce?: number
   beforeSave?: (payload: any) => any
   beforeLoad?: (payload: any) => any


### PR DESCRIPTION
- Plugin can be applied to any input of FormKit type 'group' (form, group, multi-step, step, etc). Closes #718 
- New `key` option for easy keying of localStorage data to application data such as a user ID.
- New `control` option that takes the name of an input and uses the inputs value to enable / disable saving.
- New `debounce` option to adjust frequency of saving to localStorage.
- New `beforeSave` and `beforeLoad` options to allow transforming of data to and from localStorage.

Updated docs: https://formkit-com-git-feature-localstorage-plugin-updates-formkit.vercel.app/plugins/local-storage 