### PR TITLE
feat(inputs): improve form to emit success and error events

### DIFF
--- a/packages/inputs/src/features/forms.ts
+++ b/packages/inputs/src/features/forms.ts
@@ -68,6 +68,12 @@ async function handleSubmit(node: FormKitNode, submitEvent: Event) {
           })
         )
         await retVal
+          .then((response) => {
+            node.emit('submit:success', response)
+          })
+          .catch((e) => {
+            node.emit('submit:error', e)
+          })
         if (autoDisable) node.props.disabled = false
         node.store.remove('loading')
       }


### PR DESCRIPTION
Hey! :)

This PR improves the form `handleSubmit` to emit `submit:success` and `submit:error` events based on the promise of `onSubmit`