### PR TITLE
fix: prevent css keyframe naming conflict by adding fk prefix

### DIFF
--- a/packages/themes/src/css/genesis/animations.css
+++ b/packages/themes/src/css/genesis/animations.css
@@ -1,10 +1,10 @@
-@keyframes rotate {
+@keyframes fk-rotate {
   100% {
     transform: rotate(360deg);
   }
 }
 
-@keyframes glow {
+@keyframes fk-glow {
   0% {
     box-shadow: 0 0 0 0.1em var(--fk-color-primary);
   }

--- a/packages/themes/src/css/genesis/inputs/button-and-submit.css
+++ b/packages/themes/src/css/genesis/inputs/button-and-submit.css
@@ -56,7 +56,7 @@
     pointer-events: none;
 
     &::before {
-      animation: rotate 0.5s linear infinite;
+      animation: fk-rotate 0.5s linear infinite;
       width: 1.28571428em;
       border: 0.1428571429em solid white;
       border-right-color: transparent;

--- a/packages/themes/src/css/genesis/inputs/file.css
+++ b/packages/themes/src/css/genesis/inputs/file.css
@@ -87,7 +87,7 @@
     }
 
     &[data-file-hover] {
-      animation: glow 0.75s infinite alternate;
+      animation: fk-glow 0.75s infinite alternate;
     }
   }
 

--- a/packages/themes/src/css/genesis/old.css
+++ b/packages/themes/src/css/genesis/old.css
@@ -69,7 +69,7 @@
       pointer-events: none;
 
       &::before {
-        animation: rotate 0.5s linear infinite;
+        animation: fk-rotate 0.5s linear infinite;
         width: 1.28571428em;
         border: 0.1428571429em solid white;
         border-right-color: transparent;


### PR DESCRIPTION
The css keyframe named `rotate` and `glow` is high probability to conflict with other codebase. 
I think it's better to add prefix before the name