### PR TITLE
Make localStoragePlugin behave correctly in an SSR context

### DIFF
--- a/packages/addons/src/plugins/localStoragePlugin.ts
+++ b/packages/addons/src/plugins/localStoragePlugin.ts
@@ -41,6 +41,9 @@ export function createLocalStoragePlugin(
     // to 'form' and 'group' inputs — as well as any add-on inputs
     // registered of FormKit type 'group' (eg. 'multi-step').
     if (node.type !== 'group') return
+    
+    // enable SSR support
+    if (typeof window === "undefined") return
 
     const shouldUseLocalStorage = (controlNode: FormKitNode | undefined) => {
       let controlFieldValue = true


### PR DESCRIPTION
localStorage isn't available on the server in a SSR Nuxt app, but we still want the client to come in and restore the form state. 

This change makes the server skip loading the plugin (and not crash on the server due to lack of localStorage access), allowing the client side to handle this properly.