### PR TITLE
Fixes #735: adds node defined check before blur event

### DIFF
--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -227,6 +227,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
     },
     handlers: {
       blur: (e?: Event) => {
+        if (typeof node === 'undefined') return
         node.store.set(
           createMessage({ key: 'blurred', visible: false, value: true })
         )
@@ -284,7 +285,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
       triggerRef(value)
       triggerRef(_value)
     }
-    ;(async () => {
+    ; (async () => {
       await node.settled
       if (node) node.props._init = cloneAny(node.value)
     })()


### PR DESCRIPTION
Fixes #735 by adding a check to see if node is defined at the moment that blur is called, because sometimes the node is destroyed before the blur event is called by the browser in nuxt.