### PR TITLE
feat: allow setting `rootClasses` to false

### DIFF
--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -275,10 +275,10 @@ export type FormKitTraps = Map<string | symbol, FormKitTrap>
 export interface FormKitConfig {
   delimiter: string
   classes?: Record<string, FormKitClasses | string | Record<string, boolean>>
-  rootClasses: (
+  rootClasses: ((
     sectionKey: string,
     node: FormKitNode
-  ) => Record<string, boolean>
+  ) => Record<string, boolean>) | false
   rootConfig?: FormKitRootConfig
   [index: string]: any
 }

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1252,25 +1252,26 @@ describe('classes', () => {
     expect(wrapper.html()).toContain('class="foo-outer"')
   })
 
-  it('allows setting rootClasses to false', () => {
-    const wrapper = mount(FormKit, {
-      props: {
-        name: 'classTest',
-      },
-      global: {
-        plugins: [
-          [
-            plugin,
-            defaultConfig({
-              config: {
-                rootClasses: false,
-              },
-            }),
+  it('does not throw errors if rootClasses is false', () => {
+    expect(() =>
+      mount(FormKit, {
+        props: {
+          name: 'classTest',
+        },
+        global: {
+          plugins: [
+            [
+              plugin,
+              defaultConfig({
+                config: {
+                  rootClasses: false,
+                },
+              }),
+            ],
           ],
-        ],
-      },
-    })
-    expect(wrapper.html()).toContain('class=""')
+        },
+      })
+    ).not.toThrow()
   })
 
   it('does not throw errors if rootClasses returns undefined', () => {

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1252,6 +1252,27 @@ describe('classes', () => {
     expect(wrapper.html()).toContain('class="foo-outer"')
   })
 
+  it('allows setting rootClasses to false', () => {
+    const wrapper = mount(FormKit, {
+      props: {
+        name: 'classTest',
+      },
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              config: {
+                rootClasses: false,
+              },
+            }),
+          ],
+        ],
+      },
+    })
+    expect(wrapper.html()).toContain('class=""')
+  })
+
   it('does not throw errors if rootClasses returns undefined', () => {
     expect(() =>
       mount(FormKit, {


### PR DESCRIPTION
This PR adds a shortcut for boilerplate `rootClasses: () => ({})`, which could become `rootClasses: false`.