### PR TITLE
fix(autoAnimatePlugin): do not assume the existence of default `animationTargets` object

### DIFF
--- a/packages/addons/src/plugins/autoAnimatePlugin.ts
+++ b/packages/addons/src/plugins/autoAnimatePlugin.ts
@@ -144,9 +144,8 @@ export function createAutoAnimatePlugin(
                   typeof sectionName === 'string'
                 ) {
                   if (
-                    animationTargets.global.includes(sectionName) ||
-                    (animationTargets[node.props.type] &&
-                      animationTargets[node.props.type].includes(sectionName))
+                    animationTargets.global?.includes(sectionName) ||
+                    animationTargets[node.props.type]?.includes(sectionName)
                   ) {
                     isAnimationTarget = true
                   }


### PR DESCRIPTION
The `animationTargets` parameter could be set to any object with properties different to the default one, hence worth checking first whether the properties exist to avoid errors.