### PR TITLE
allows outputting literal SVG code as defaultIcon value

### DIFF
--- a/packages/inputs/src/features/icon.ts
+++ b/packages/inputs/src/features/icon.ts
@@ -13,7 +13,9 @@ import { FormKitNode } from '@formkit/core'
 export default function defaultIcon(sectionKey: string, defaultIcon: string) {
   return (node: FormKitNode): void => {
     if (node.props[`${sectionKey}Icon`] === undefined) {
-      node.props[`${sectionKey}Icon`] = `default:${defaultIcon}`
+      node.props[`${sectionKey}Icon`] = defaultIcon.startsWith('<svg')
+        ? defaultIcon
+        : `default:${defaultIcon}`
     }
   }
 }


### PR DESCRIPTION
This update allows you to provide a literal SVG as the value for `defaultIcon`. Planning to use this for the barcode input package so that we can ship a default barcode SVG while still allowing it to be customized via our existing icon functionality. 