### PR TITLE
feat: allow passing custom wrapping schema to `createInput`

### DIFF
--- a/packages/vue/src/composables/createInput.ts
+++ b/packages/vue/src/composables/createInput.ts
@@ -1,6 +1,6 @@
 import { FormKitTypeDefinition, FormKitSchemaNode } from '@formkit/core'
 import { cloneAny } from '@formkit/utils'
-import { createSection, FormKitSection, useSchema } from '@formkit/inputs'
+import { createSection, FormKitSection, useSchema, FormKitSchemaExtendableSection } from '@formkit/inputs'
 import { Component, markRaw } from 'vue'
 
 let totalCreated = 1
@@ -31,6 +31,7 @@ function isComponent(obj: any): obj is Component {
  * @param schemaOrComponent - The actual schema of the input or the component.
  * @param definitionOptions - Any options in the FormKitTypeDefinition you want
  * to define.
+ * @param wrappingSchema - Custom wrapping schema to replace the default one. 
  *
  * @returns {@link @formkit/core#FormKitTypeDefinition | FormKitTypeDefinition}
  *
@@ -39,7 +40,7 @@ function isComponent(obj: any): obj is Component {
 export function createInput(
   schemaOrComponent: FormKitSchemaNode | FormKitSection | Component,
   definitionOptions: Partial<FormKitTypeDefinition> = {},
-  wrappingSchema: typeof useSchema = useSchema
+  wrappingSchema: (inputSection: FormKitSection) => FormKitSchemaExtendableSection = useSchema
 ): FormKitTypeDefinition {
   const definition: FormKitTypeDefinition = {
     type: 'input',

--- a/packages/vue/src/composables/createInput.ts
+++ b/packages/vue/src/composables/createInput.ts
@@ -38,7 +38,8 @@ function isComponent(obj: any): obj is Component {
  */
 export function createInput(
   schemaOrComponent: FormKitSchemaNode | FormKitSection | Component,
-  definitionOptions: Partial<FormKitTypeDefinition> = {}
+  definitionOptions: Partial<FormKitTypeDefinition> = {},
+  wrappingSchema: typeof useSchema = useSchema
 ): FormKitTypeDefinition {
   const definition: FormKitTypeDefinition = {
     type: 'input',
@@ -60,8 +61,8 @@ export function createInput(
     schema = createSection('input', () => cloneAny(schemaOrComponent))
   }
 
-  // Use the default wrapping schema
-  definition.schema = useSchema(schema || 'Schema undefined')
+  // Use the user-provided or default wrapping schema
+  definition.schema = wrappingSchema(schema || 'Schema undefined')
   if (!definition.schemaMemoKey) {
     definition.schemaMemoKey = `${Math.random()}`
   }


### PR DESCRIPTION
This PR allows passing a user-provided wrapping schema to the `createInput` function (which defaults to the currently used `useSchema` if not provided).

It might resolve (depending on the specific use-case) the following concern mentioned in the support channel on Discord:
https://discord.com/channels/793529058377072650/940340536747896842/1118232111283974185