### PR TITLE
feat: adds autoImport opt to nuxt module

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -29,7 +29,8 @@
     "@nuxt/kit": "^3.7.1",
     "chokidar": "^3.5.3",
     "nuxi": "^3.8.1",
-    "pathe": "^1.1.1"
+    "pathe": "^1.1.1",
+    "unplugin-formkit": "^0.2.3"
   },
   "devDependencies": {
     "@nuxt/module-builder": "^0.5.1",

--- a/packages/nuxt/playground/.nuxt/tsconfig.json
+++ b/packages/nuxt/playground/.nuxt/tsconfig.json
@@ -46,13 +46,13 @@
         "../public"
       ],
       "#app": [
-        "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.7_eslint@8.36.0_rollup@3.29.0_stylelint@14.0.1_terser@5.14.2_typescript@5.1.3/node_modules/nuxt/dist/app"
+        "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.10_eslint@8.36.0_rollup@3.29.2_stylelint@14.16.1_terser@5.16.8_typescript@5.1.3/node_modules/nuxt/dist/app"
       ],
       "#app/*": [
-        "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.7_eslint@8.36.0_rollup@3.29.0_stylelint@14.0.1_terser@5.14.2_typescript@5.1.3/node_modules/nuxt/dist/app/*"
+        "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.10_eslint@8.36.0_rollup@3.29.2_stylelint@14.16.1_terser@5.16.8_typescript@5.1.3/node_modules/nuxt/dist/app/*"
       ],
       "vue-demi": [
-        "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.7_eslint@8.36.0_rollup@3.29.0_stylelint@14.0.1_terser@5.14.2_typescript@5.1.3/node_modules/nuxt/dist/app/compat/vue-demi"
+        "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.10_eslint@8.36.0_rollup@3.29.2_stylelint@14.16.1_terser@5.16.8_typescript@5.1.3/node_modules/nuxt/dist/app/compat/vue-demi"
       ],
       "#vue-router": [
         "./vue-router"
@@ -75,14 +75,14 @@
     "./nuxt.d.ts",
     "../**/*",
     "..",
-    "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.7_eslint@8.36.0_rollup@3.29.0_stylelint@14.0.1_terser@5.14.2_typescript@5.1.3/node_modules/nuxt/dist/app",
-    "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.7_eslint@8.36.0_rollup@3.29.0_stylelint@14.0.1_terser@5.14.2_typescript@5.1.3/node_modules/nuxt/dist/app/compat/vue-demi"
+    "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.10_eslint@8.36.0_rollup@3.29.2_stylelint@14.16.1_terser@5.16.8_typescript@5.1.3/node_modules/nuxt/dist/app",
+    "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.10_eslint@8.36.0_rollup@3.29.2_stylelint@14.16.1_terser@5.16.8_typescript@5.1.3/node_modules/nuxt/dist/app/compat/vue-demi"
   ],
   "exclude": [
     "../node_modules",
     "../../node_modules",
     "../../../../node_modules",
-    "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.7_eslint@8.36.0_rollup@3.29.0_stylelint@14.0.1_terser@5.14.2_typescript@5.1.3/node_modules/nuxt/node_modules",
+    "../../../../node_modules/.pnpm/nuxt@3.7.1_@types+node@18.15.10_eslint@8.36.0_rollup@3.29.2_stylelint@14.16.1_terser@5.16.8_typescript@5.1.3/node_modules/nuxt/node_modules",
     "../dist",
     "../.output"
   ]

--- a/packages/nuxt/playground/formkit.config.ts
+++ b/packages/nuxt/playground/formkit.config.ts
@@ -1,10 +1,11 @@
-import { defineFormKitConfig } from '@formkit/vue'
+import { createInput, defineFormKitConfig } from '@formkit/vue'
 
 export default defineFormKitConfig(() => {
-  // @ts-ignore - needed for vitest typecheck
-  const config = useRuntimeConfig()
-
   return {
+    inputs: {
+      foo: createInput({ $el: 'h1', children: 'FOOBAR!' }),
+    },
+    theme: 'genesis',
     // theme: config.theme,
   }
 })

--- a/packages/nuxt/playground/nuxt.config.ts
+++ b/packages/nuxt/playground/nuxt.config.ts
@@ -7,4 +7,7 @@ export default defineNuxtConfig({
     },
   },
   modules: ['../src/module'],
+  formkit: {
+    autoImport: true,
+  },
 })

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,6 +1,5 @@
 import { existsSync } from 'fs'
 import { fileURLToPath } from 'url'
-import { NuxtModule } from '@nuxt/schema'
 import { resolve } from 'pathe'
 import { watch } from 'chokidar'
 import {
@@ -8,11 +7,35 @@ import {
   addPluginTemplate,
   createResolver,
   updateTemplates,
+  addImports,
 } from '@nuxt/kit'
+import { NuxtModule } from '@nuxt/schema'
+import unpluginFormKit from 'unplugin-formkit/vite'
+import { addComponent } from '@nuxt/kit'
 
 export interface ModuleOptions {
-  defaultConfig: boolean
+  defaultConfig?: boolean
   configFile?: string
+  /**
+   * When true FormKit will not install itself globally and will instead inject
+   * a `<FormKitLazyProvider>` around components that use FormKit. Additionally
+   * when true FormKit enables auto-imports for the following:
+   *
+   * - `<FormKit>`
+   * - `<FormKitProvider>`
+   * - `<FormKitMessages>`
+   * - `<FormKitSummary>`
+   * - `getNode()`
+   * - `createInput()`
+   * - `setErrors`,
+   * - `clearErrors`,
+   * - `submitForm`,
+   * - `reset`,
+   * - `FormKitNode`
+   *
+   * @experimental
+   */
+  autoImport?: boolean
 }
 
 const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
@@ -26,76 +49,176 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
   defaults: {
     defaultConfig: true,
     configFile: undefined,
+    autoImport: false,
   },
   async setup(options, nuxt) {
-    const resolver = createResolver(import.meta.url)
-
-    // Add FormKit typescript types explicitly.
-    nuxt.hook('prepare:types', (opts) => {
-      opts.references.push({ types: '@formkit/vue' })
-    })
-
-    const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
-    nuxt.options.build.transpile.push(runtimeDir)
-    nuxt.options.build.transpile.push('@formkit/vue')
-
-    const configBase = resolve(
-      nuxt.options.rootDir,
-      options.configFile || 'formkit.config'
-    )
-
-    if (nuxt.options.dev) {
-      const watcher = watch([`${configBase}.{ts,mjs,js}`, configBase])
-      watcher.on('all', (event) => {
-        if (event === 'add' || event === 'unlink') {
-          updateTemplates({
-            filter: (template) => template.filename === 'formkitPlugin.mjs',
-          })
-        }
-      })
-      nuxt.hook('close', () => {
-        watcher.close()
-      })
+    if (options.autoImport) {
+      useAutoImport(options, nuxt)
+    } else {
+      useFormKitPlugin(options, nuxt)
     }
-
-    addPluginTemplate({
-      async getContents() {
-        const configPath = await resolver.resolvePath(configBase)
-        const configPathExists = existsSync(configPath)
-        if (!configPathExists && options.configFile) {
-          throw new Error(
-            `FormKit configuration was not located at ${configPath}`
-          )
-        } else if (!configPathExists && !options.defaultConfig) {
-          throw new Error(
-            'FormKit defaultConfig was set to false, but no FormKit config file could be found.'
-          )
-        }
-
-        return `import { defineNuxtPlugin } from '#app'
-        import { plugin, defaultConfig, ssrComplete } from '@formkit/vue'
-        import { resetCount } from '@formkit/core'
-
-        ${configPathExists ? `import importedConfig from '${configPath}'` : ''}
-
-        export default defineNuxtPlugin((nuxtApp) => {
-          const config = ${
-            configPathExists
-              ? `defaultConfig(typeof importedConfig === 'function' ? importedConfig() : importedConfig)`
-              : `defaultConfig`
-          }
-          nuxtApp.hook('app:rendered', (renderContext) => {
-            resetCount()
-            ssrComplete(nuxtApp.vueApp)
-          })
-          nuxtApp.vueApp.use(plugin, config)
-
-        })
-        `
-      },
-      filename: 'formkitPlugin.mjs',
-    })
   },
 })
+
+/**
+ * Installs FormKit via lazy loading. This is the preferred method of
+ * installation as it allows for a smaller bundle size and better tree shaking.
+ */
+const useAutoImport = async function installLazy(options, nuxt) {
+  addImports([
+    {
+      from: '@formkit/core',
+      name: 'FormKitNode',
+      type: true,
+    },
+    {
+      from: '@formkit/vue',
+      name: 'createInput',
+    },
+    {
+      from: '@formkit/core',
+      name: 'getNode',
+    },
+    {
+      from: '@formkit/core',
+      name: 'setErrors',
+    },
+    {
+      from: '@formkit/core',
+      name: 'clearErrors',
+    },
+    {
+      from: '@formkit/core',
+      name: 'submitForm',
+    },
+    {
+      from: '@formkit/core',
+      name: 'reset',
+    },
+  ])
+
+  addComponent({
+    name: 'FormKit',
+    export: 'FormKit',
+    filePath: '@formkit/vue',
+    chunkName: '@formkit/vue',
+  })
+
+  addComponent({
+    name: 'FormKitProvider',
+    export: 'FormKitProvider',
+    filePath: '@formkit/vue',
+    chunkName: '@formkit/vue',
+  })
+
+  addComponent({
+    name: 'FormKitMessages',
+    export: 'FormKitMessages',
+    filePath: '@formkit/vue',
+    chunkName: '@formkit/vue',
+  })
+  addComponent({
+    name: 'FormKitSummary',
+    export: 'FormKitSummary',
+    filePath: '@formkit/vue',
+    chunkName: '@formkit/vue',
+  })
+
+  const configBase = resolve(
+    nuxt.options.rootDir,
+    options.configFile || 'formkit.config'
+  )
+
+  nuxt.hook('vite:extendConfig', (config) => {
+    console.log(options)
+    const plugin = unpluginFormKit({
+      defaultConfig: options.defaultConfig,
+      configFile: configBase,
+    }) as any
+    // ☝️ Unfortunately we have this declaration as any right here, this seems
+    // to do with unplugin having a different vite dependency than nuxt, however
+    // this shouldn’t affect runtime.
+    if (Array.isArray(config.plugins)) {
+      config.plugins?.unshift(plugin)
+    } else {
+      config.plugins = [plugin]
+    }
+  })
+} satisfies NuxtModule<ModuleOptions>
+/**
+ * Installs FormKit via Nuxt plugin. This registers the FormKit plugin globally
+ * which is convenient but has the downside of increasing size of the entry
+ * bundle. Eventually this mechanism will deprecated in favor of the lazy
+ * behavior.
+ */
+const useFormKitPlugin = async function installNuxtPlugin(options, nuxt) {
+  const resolver = createResolver(import.meta.url)
+
+  // Add FormKit typescript types explicitly.
+  nuxt.hook('prepare:types', (opts) => {
+    opts.references.push({ types: '@formkit/vue' })
+  })
+
+  const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
+  nuxt.options.build.transpile.push(runtimeDir)
+  nuxt.options.build.transpile.push('@formkit/vue')
+
+  const configBase = resolve(
+    nuxt.options.rootDir,
+    options.configFile || 'formkit.config'
+  )
+
+  if (nuxt.options.dev) {
+    const watcher = watch([`${configBase}.{ts,mjs,js}`, configBase])
+    watcher.on('all', (event) => {
+      if (event === 'add' || event === 'unlink') {
+        updateTemplates({
+          filter: (template) => template.filename === 'formkitPlugin.mjs',
+        })
+      }
+    })
+    nuxt.hook('close', () => {
+      watcher.close()
+    })
+  }
+
+  addPluginTemplate({
+    async getContents() {
+      const configPath = await resolver.resolvePath(configBase)
+      const configPathExists = existsSync(configPath)
+      if (!configPathExists && options.configFile) {
+        throw new Error(
+          `FormKit configuration was not located at ${configPath}`
+        )
+      } else if (!configPathExists && !options.defaultConfig) {
+        throw new Error(
+          'FormKit defaultConfig was set to false, but no FormKit config file could be found.'
+        )
+      }
+
+      return `import { defineNuxtPlugin } from '#app'
+      import { plugin, defaultConfig, ssrComplete } from '@formkit/vue'
+      import { resetCount } from '@formkit/core'
+
+      ${configPathExists ? `import importedConfig from '${configPath}'` : ''}
+
+      export default defineNuxtPlugin((nuxtApp) => {
+        const config = ${
+          configPathExists
+            ? `defaultConfig(typeof importedConfig === 'function' ? importedConfig() : importedConfig)`
+            : `defaultConfig`
+        }
+        nuxtApp.hook('app:rendered', (renderContext) => {
+          resetCount()
+          ssrComplete(nuxtApp.vueApp)
+        })
+        nuxtApp.vueApp.use(plugin, config)
+
+      })
+      `
+    },
+    filename: 'formkitPlugin.mjs',
+  })
+} satisfies NuxtModule<ModuleOptions>
 
 export default module

--- a/packages/vue/src/FormKitProvider.ts
+++ b/packages/vue/src/FormKitProvider.ts
@@ -73,11 +73,17 @@ export const FormKitConfigLoader = /* #__PURE__ */ defineComponent(
     let config = {}
     if (props.configFile) {
       const configFile = await import(
-        /*@__formkit.config.ts__*/ props.configFile
+        /*@__formkit.config.ts__*/ /* @vite-ignore */ props.configFile
       )
       config = 'default' in configFile ? configFile.default : configFile
     }
     const useDefaultConfig = props.defaultConfig ?? true
+
+    // Ensure this a factory function for runtimeConfig in nuxt.
+    if (typeof config === 'function') {
+      config = config()
+    }
+
     if (useDefaultConfig) {
       const { defaultConfig } = await import('./defaultConfig')
       config = /* @__PURE__ */ defaultConfig(config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       pathe:
         specifier: ^1.1.1
         version: 1.1.1
+      unplugin-formkit:
+        specifier: ^0.2.3
+        version: 0.2.3(rollup@3.29.2)(vite@4.4.9)
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^0.5.1
@@ -423,11 +426,11 @@ importers:
         version: link:../themes
       tailwindcss:
         specifier: ^3.0.0
-        version: 3.2.7(postcss@8.4.27)(ts-node@10.9.1)
+        version: 3.2.7(postcss@8.4.30)(ts-node@10.9.1)
     devDependencies:
       '@types/tailwindcss':
         specifier: ^3.0.10
-        version: 3.1.0(postcss@8.4.27)(ts-node@10.9.1)
+        version: 3.1.0(postcss@8.4.30)(ts-node@10.9.1)
 
   packages/themes:
     dependencies:
@@ -436,7 +439,7 @@ importers:
         version: link:../core
       tailwindcss:
         specifier: ^3.2.0
-        version: 3.2.7(postcss@8.4.27)(ts-node@10.9.1)
+        version: 3.2.7(postcss@8.4.30)(ts-node@10.9.1)
       unocss:
         specifier: ^0.31.0
         version: 0.31.0(vite@2.9.16)
@@ -1968,6 +1971,7 @@ packages:
   /@babel/highlight@7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
@@ -3293,6 +3297,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: true
     bundledDependencies:
       - napi-wasm
@@ -3732,11 +3737,11 @@ packages:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
     dev: true
 
-  /@types/tailwindcss@3.1.0(postcss@8.4.27)(ts-node@10.9.1):
+  /@types/tailwindcss@3.1.0(postcss@8.4.30)(ts-node@10.9.1):
     resolution: {integrity: sha512-JxPzrm609hzvF4nmOI3StLjbBEP3WWQxDDJESqR1nh94h7gyyy3XSl0hn5RBMJ9mPudlLjtaXs5YEBtLw7CnPA==}
     deprecated: This is a stub types definition. tailwindcss provides its own type definitions, so you do not need this installed.
     dependencies:
-      tailwindcss: 3.2.7(postcss@8.4.27)(ts-node@10.9.1)
+      tailwindcss: 3.2.7(postcss@8.4.30)(ts-node@10.9.1)
     transitivePeerDependencies:
       - postcss
       - ts-node
@@ -5104,7 +5109,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -6879,6 +6884,7 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /fsevents@2.3.3:
@@ -8328,6 +8334,10 @@ packages:
     hasBin: true
     dev: true
 
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: true
+
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
@@ -9178,13 +9188,13 @@ packages:
       resolve: 1.22.1
     dev: true
 
-  /postcss-import@14.1.0(postcss@8.4.27):
+  /postcss-import@14.1.0(postcss@8.4.30):
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.27
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.1
@@ -9211,14 +9221,14 @@ packages:
       postcss: 8.4.21
     dev: true
 
-  /postcss-js@4.0.1(postcss@8.4.27):
+  /postcss-js@4.0.1(postcss@8.4.30):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.27
+      postcss: 8.4.30
 
   /postcss-load-config@3.1.4(postcss@8.4.21)(ts-node@10.9.1):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -9238,7 +9248,7 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-load-config@3.1.4(postcss@8.4.27)(ts-node@10.9.1):
+  /postcss-load-config@3.1.4(postcss@8.4.30)(ts-node@10.9.1):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -9251,7 +9261,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.27
+      postcss: 8.4.30
       ts-node: 10.9.1(@types/node@18.15.10)(typescript@5.1.3)
       yaml: 1.10.2
 
@@ -9462,13 +9472,13 @@ packages:
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-nested@6.0.0(postcss@8.4.27):
+  /postcss-nested@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.27
+      postcss: 8.4.30
       postcss-selector-parser: 6.0.11
 
   /postcss-nesting@10.2.0(postcss@8.4.21):
@@ -9828,7 +9838,6 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -10192,7 +10201,7 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: false
 
   /rollup@3.27.0:
@@ -10200,14 +10209,14 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /rollup@3.29.2:
     resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /rrweb-cssom@0.6.0:
     resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
@@ -10835,7 +10844,7 @@ packages:
       - ts-node
     dev: true
 
-  /tailwindcss@3.2.7(postcss@8.4.27)(ts-node@10.9.1):
+  /tailwindcss@3.2.7(postcss@8.4.30)(ts-node@10.9.1):
     resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -10856,11 +10865,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.27
-      postcss-import: 14.1.0(postcss@8.4.27)
-      postcss-js: 4.0.1(postcss@8.4.27)
-      postcss-load-config: 3.1.4(postcss@8.4.27)(ts-node@10.9.1)
-      postcss-nested: 6.0.0(postcss@8.4.27)
+      postcss: 8.4.30
+      postcss-import: 14.1.0(postcss@8.4.30)
+      postcss-js: 4.0.1(postcss@8.4.30)
+      postcss-load-config: 3.1.4(postcss@8.4.30)(ts-node@10.9.1)
+      postcss-nested: 6.0.0(postcss@8.4.30)
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -11321,6 +11330,29 @@ packages:
       - vite
     dev: true
 
+  /unplugin-formkit@0.2.3(rollup@3.29.2)(vite@4.4.9):
+    resolution: {integrity: sha512-zn5fo+RyNUjfzfA0mVQUdpaSNxpVBNJewMJRw1uFSLzwCOMBqRoWNjU8WR9BJzBWN4QgPWPF6gWDvKNwOsZCPQ==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: ^3
+      vite: '>=3'
+      webpack: ^4 || ^5
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      pathe: 1.1.1
+      rollup: 3.29.2
+      unplugin: 1.4.0
+      vite: 4.4.9(@types/node@18.15.10)(terser@5.16.8)
+    dev: false
+
   /unplugin-vue-router@0.6.4(rollup@3.29.2)(vue-router@4.2.4)(vue@3.3.4):
     resolution: {integrity: sha512-9THVhhtbVFxbsIibjK59oPwMI1UCxRWRPX7azSkTUABsxovlOXJys5SJx0kd/0oKIqNJuYgkRfAgPuO77SqCOg==}
     peerDependencies:
@@ -11599,11 +11631,11 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.54
-      postcss: 8.4.27
+      postcss: 8.4.30
       resolve: 1.22.1
       rollup: 2.77.3
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: false
 
   /vite@4.4.7(@types/node@18.15.10)(sass@1.60.0)(terser@5.16.8):
@@ -11641,7 +11673,7 @@ packages:
       sass: 1.60.0
       terser: 5.16.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /vite@4.4.9(@types/node@18.15.10)(terser@5.16.8):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
@@ -11677,8 +11709,7 @@ packages:
       rollup: 3.29.2
       terser: 5.16.8
     optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
+      fsevents: 2.3.3
 
   /vitest@0.33.0(jsdom@21.1.1)(terser@5.16.8):
     resolution: {integrity: sha512-1CxaugJ50xskkQ0e969R/hW47za4YXDUfWJDxip1hwbnhUjYolpfUn2AMOulqG/Dtd9WYAtkHmM/m3yKVrEejQ==}


### PR DESCRIPTION
In this PR:

An alternative strategy for the `@formkit/nuxt` module. Specifically the module no longer globally installs a plugin, but instead performs direct-injection of a `<FormKitLazyProvider>` at build time. Additionally this alternative strategy uses auto-imports for FormKit components and several functions:

- `<FormKit>`
- `<FormKitProvider>`
`<FormKitMessages>`
`<FormKitSummary>`
`getNode()`
`createInput()`
`setErrors`,
`clearErrors`,
`submitForm`,
`reset`,
`FormKitNode`