### PR TITLE
Added decorator types for checkbox slots

### DIFF
--- a/packages/inputs/src/props.ts
+++ b/packages/inputs/src/props.ts
@@ -367,7 +367,7 @@ export interface OptionSlotData<Props extends FormKitInputs<Props>> {
 }
 
 /**
- * The slots available to the sekect input, these extend the base slots.
+ * The slots available to the select input, these extend the base slots.
  * @public
  */
 export interface FormKitSelectSlots<Props extends FormKitInputs<Props>>
@@ -378,10 +378,11 @@ export interface FormKitSelectSlots<Props extends FormKitInputs<Props>>
 }
 
 /**
- * The slots available to the checkbox inputs even when options are not provided
+ * The slots available to the checkbox inputs even when options are not provided, these extend the base slots.
  * @public
  */
-export interface FormKitCheckboxSlots<Props extends FormKitInputs<Props>> {
+export interface FormKitCheckboxSlots<Props extends FormKitInputs<Props>> 
+  extends FormKitBaseSlots<Props> {
   decorator: FormKitSlotData<Props, OptionSlotData<Props>>
   decoratorIcon: FormKitSlotData<Props, OptionSlotData<Props>>
 }

--- a/packages/inputs/src/props.ts
+++ b/packages/inputs/src/props.ts
@@ -378,6 +378,15 @@ export interface FormKitSelectSlots<Props extends FormKitInputs<Props>>
 }
 
 /**
+ * The slots available to the checkbox inputs even when options are not provided
+ * @public
+ */
+export interface FormKitCheckboxSlots<Props extends FormKitInputs<Props>> {
+  decorator: FormKitSlotData<Props, OptionSlotData<Props>>
+  decoratorIcon: FormKitSlotData<Props, OptionSlotData<Props>>
+}
+
+/**
  * The slots available to the radio and checkbox inputs when options are
  * provided.
  * @public
@@ -479,7 +488,7 @@ export interface FormKitInputSlots<Props extends FormKitInputs<Props>> {
   file: FormKitFileSlots<Props>
   checkbox: Props['options'] extends AllReals
     ? FormKitBoxSlots<Props>
-    : FormKitBaseSlots<Props>
+    : FormKitCheckboxSlots<Props>
   submit: FormKitButtonSlots<Props>
   button: FormKitButtonSlots<Props>
 }


### PR DESCRIPTION
The `decorator` and `decoratorIcon` slots were causing Typescript errors when the checkbox inputs did not have the `options` prop