### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -202,7 +202,7 @@ const useFormKitPlugin = async function installNuxtPlugin(options, nuxt) {
         )
       }
 
-      return `import { defineNuxtPlugin } from '#app'
+      return `import { defineNuxtPlugin } from '#imports'
       import { plugin, defaultConfig, ssrComplete } from '@formkit/vue'
       import { resetCount } from '@formkit/core'
 

--- a/packages/nuxt/src/runtime/formkitSSRPlugin.mjs
+++ b/packages/nuxt/src/runtime/formkitSSRPlugin.mjs
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 import { ssrComplete, resetCount } from '@formkit/vue'
 
 export default defineNuxtPlugin((nuxtApp) => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.