### PR TITLE
feat(rules) add modifiers for the lowercase rule

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -252,9 +252,14 @@ export const validation: FormKitValidationMessages = {
    * The value is not lowercase
    * @see {@link https://formkit.com/essentials/validation#lowercase}
    */
-  lowercase({ name }) {
+  lowercase({ name, args }) {
+    let postfix = ''
+    if(Array.isArray(args)) {
+      if (args[0] === 'allow_non_alpha') postfix = ', numbers and symbols'
+      if (args[0] === 'allow_numeric') postfix = ' and numbers'
+    }
     /* <i18n case="Shown when the user-provided value contains non-alphabetical-lowercase characters."> */
-    return `${s(name)} can only contain lowercase letters.`
+    return `${s(name)} can only contain lowercase letters${postfix}.`
     /* </i18n> */
   },
 

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -257,6 +257,7 @@ export const validation: FormKitValidationMessages = {
     if(Array.isArray(args)) {
       if (args[0] === 'allow_non_alpha') postfix = ', numbers and symbols'
       if (args[0] === 'allow_numeric') postfix = ' and numbers'
+      if (args[0] === 'allow_numeric_dashes') postfix = ', numbers and dashes'
     }
     /* <i18n case="Shown when the user-provided value contains non-alphabetical-lowercase characters."> */
     return `${s(name)} can only contain lowercase letters${postfix}.`

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -254,7 +254,7 @@ export const validation: FormKitValidationMessages = {
    */
   lowercase({ name, args }) {
     let postfix = ''
-    if(Array.isArray(args)) {
+    if(Array.isArray(args) && args.length) {
       if (args[0] === 'allow_non_alpha') postfix = ', numbers and symbols'
       if (args[0] === 'allow_numeric') postfix = ' and numbers'
       if (args[0] === 'allow_numeric_dashes') postfix = ', numbers and dashes'

--- a/packages/rules/__tests__/lowercase.spec.ts
+++ b/packages/rules/__tests__/lowercase.spec.ts
@@ -28,6 +28,18 @@ describe('lowercase', () => {
   it('passes with lots of accented characters if invalid set', () =>
     expect(lowercase(createNode({ value: 'àáâäïíôöæ' }), 'russian')).toBe(true))
 
+  it('passes with numbers & symbols when using allow_non_alpha modifier', () =>
+    expect(lowercase(createNode({ value: 'abc1234567890#$%^&*((&^((&^$@!:"><?' }), 'allow_non_alpha')).toBe(true))
+
+  it('passes with numbers when using allow_numeric modifier', () =>
+    expect(lowercase(createNode({ value: 'abc1234567890' }), 'allow_non_alpha')).toBe(true))
+
+  it('passes with numbers and dashes when using allow_numeric modifier', () =>
+    expect(lowercase(createNode({ value: 'abc1234567890-' }), 'allow_numeric_dashes')).toBe(true))
+
+  it('passes with numbers and many dashes when using allow_numeric modifier', () =>
+    expect(lowercase(createNode({ value: '-abc12-34-56-78-90-' }), 'allow_numeric_dashes')).toBe(true))
+
   it('fails with lots of accented characters if latin', () =>
     expect(lowercase(createNode({ value: 'àáâäïíôöæ' }), 'latin')).toBe(false))
 
@@ -39,4 +51,16 @@ describe('lowercase', () => {
 
   it('fails with symbot only', () =>
     expect(lowercase(createNode({ value: '-56&54' }))).toBe(false))
+
+  it('fails with uppercase allow_non_alpha modifier', () =>
+    expect(lowercase(createNode({ value: 'Aabc1234567890#$%^&*((&^((&^$@!:"><?' }), 'allow_non_alpha')).toBe(false))
+
+  it('fails with uppercase when using allow_numeric modifier', () =>
+    expect(lowercase(createNode({ value: 'aBc1234567890' }), 'allow_non_alpha')).toBe(false))
+
+  it('fails with uppercase when using allow_numeric modifier', () =>
+    expect(lowercase(createNode({ value: 'AbC1234567890-' }), 'allow_numeric_dashes')).toBe(false))
+
+  it('fails with uppercase when using allow_numeric modifier', () =>
+    expect(lowercase(createNode({ value: '-aBcmArtin12-34-56-78-90-' }), 'allow_numeric_dashes')).toBe(false))
 })

--- a/packages/rules/src/lowercase.ts
+++ b/packages/rules/src/lowercase.ts
@@ -11,9 +11,10 @@ const lowercase: FormKitValidationRule = function ({ value }, set = 'default') {
     default: /^\p{Ll}+$/u,
     allow_non_alpha: /^[0-9\p{Ll}!-/:-@[-`{-~]+$/u,
     allow_numeric: /^[0-9\p{Ll}]+$/u,
+    allow_numeric_dashes: /^[0-9\p{Ll}-]+$/u,
     latin: /^[a-z]+$/,
   }
-  const selectedSet: 'default' | 'allow_non_alpha' | 'allow_numeric' | 'latin' = has(sets, set) ? set : 'default'
+  const selectedSet: 'default' | 'allow_non_alpha' | 'allow_numeric' | 'allow_numeric_dashes' | 'latin' = has(sets, set) ? set : 'default'
   return sets[selectedSet].test(String(value))
 }
 

--- a/packages/rules/src/lowercase.ts
+++ b/packages/rules/src/lowercase.ts
@@ -9,9 +9,11 @@ import { FormKitValidationRule } from '@formkit/validation'
 const lowercase: FormKitValidationRule = function ({ value }, set = 'default') {
   const sets = {
     default: /^\p{Ll}+$/u,
+    allow_non_alpha: /^[0-9\p{Ll}!-/:-@[-`{-~]+$/u,
+    allow_numeric: /^[0-9\p{Ll}]+$/u,
     latin: /^[a-z]+$/,
   }
-  const selectedSet: 'default' | 'latin' = has(sets, set) ? set : 'default'
+  const selectedSet: 'default' | 'allow_non_alpha' | 'allow_numeric' | 'latin' = has(sets, set) ? set : 'default'
   return sets[selectedSet].test(String(value))
 }
 


### PR DESCRIPTION
Adds modifiers to the lowercase validation rule:
* allow_non_alpha (allows numbers & the regex from the existing symbols)
* allow_numeric (allows numbers)
* allow_numeric_dashes (allows numbers and dashes)

Also update the messaging in the en locale for lowercase. Running tests locally passed.