### PR TITLE
Remove hidden textarea element from a11y tree

### DIFF
--- a/packages/addons/src/plugins/autoHeightTextarea.ts
+++ b/packages/addons/src/plugins/autoHeightTextarea.ts
@@ -51,9 +51,14 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
             'style',
             'height: 0; min-height: 0; pointer-events: none; opacity: 0;  left: -9999px; padding-top: 0; padding-bottom: 0; position: absolute; display: block; top: 0; z-index: -1; scrollbar-width: none;'
           )
+
+          hiddenTextarea.setAttribute('aria-hidden', 'true')
+          hiddenTextarea.setAttribute('tabindex', '-1')
+
           hiddenTextarea.removeAttribute('name')
           hiddenTextarea.removeAttribute('id')
           hiddenTextarea.removeAttribute('aria-describedby')
+
           const isBorderBox =
             getComputedStyle(inputElement).boxSizing === 'border-box'
           const paddingY =


### PR DESCRIPTION
Removes the hidden textarea element from the accessibility tree. 

The element violates the following a11y rule from the axe-core tool without removing it from the a11y tree:
["Ensures every form element has a label"](https://dequeuniversity.com/rules/axe/4.8/label?application=axeAPI).