### PR TITLE
fix: fixes issue where multistep tabs and tab schema was not overridable

### DIFF
--- a/examples/src/vue/examples/MultiStep.vue
+++ b/examples/src/vue/examples/MultiStep.vue
@@ -9,6 +9,15 @@ const multiStepFormSchema = [
     $formkit: 'multi-step',
     beforeStepChange: '$log',
     allowIncomplete: false,
+    sectionsSchema: {
+      // schema overrides!
+      tabs: {
+        $el: 'ul',
+      },
+      tab: {
+        $el: 'li',
+      },
+    },
     children: [
       {
         $formkit: 'step',

--- a/packages/addons/src/plugins/multiStep/schema.ts
+++ b/packages/addons/src/plugins/multiStep/schema.ts
@@ -1,13 +1,7 @@
 import { FormKitTypeDefinition } from '@formkit/core'
+import { $if, defaultIcon, localize, disablesChildren } from '@formkit/inputs'
 import {
-  $if,
   wrapper,
-  defaultIcon,
-  $extend,
-  localize,
-  disablesChildren,
-} from '@formkit/inputs'
-import {
   badge,
   stepPrevious,
   stepNext,
@@ -27,32 +21,24 @@ export const multiStep: FormKitTypeDefinition = {
    * The actual schema of the input, or a function that returns the schema.
    */
   schema: multiStepOuter(
-    $extend(
-      wrapper(
-        tabs(
-          tab(
-            $if(
-              '$tabStyle === "tab" || ($tabStyle === "progress" && $hideProgressLabels === false)',
-              tabLabel('$step.stepName')
-            ),
-            $if(
-              '($step.totalErrorCount > 0) && $step.showStepErrors',
-              badge('$step.totalErrorCount')
-            ),
-            $if(
-              '$step.isValid && $step.hasBeenVisited',
-              badge(stepIcon('validStep'))
-            )
+    wrapper(
+      tabs(
+        tab(
+          $if(
+            '$tabStyle === "tab" || ($tabStyle === "progress" && $hideProgressLabels === false)',
+            tabLabel('$step.stepName')
+          ),
+          $if(
+            '($step.totalErrorCount > 0) && $step.showStepErrors',
+            badge('$step.totalErrorCount')
+          ),
+          $if(
+            '$step.isValid && $step.hasBeenVisited',
+            badge(stepIcon('validStep'))
           )
-        ),
-        steps('$slots.default')
+        )
       ),
-      {
-        attrs: {
-          'data-tab-style': '$tabStyle',
-          'data-hide-labels': '$hideProgressLabels',
-        },
-      }
+      steps('$slots.default')
     )
   ),
   /**

--- a/packages/addons/src/plugins/multiStep/sections/index.ts
+++ b/packages/addons/src/plugins/multiStep/sections/index.ts
@@ -1,3 +1,4 @@
+export { wrapper } from './wrapper'
 export { badge } from './badge'
 export { stepActions } from './stepActions'
 export { stepInner } from './stepInner'

--- a/packages/addons/src/plugins/multiStep/sections/wrapper.ts
+++ b/packages/addons/src/plugins/multiStep/sections/wrapper.ts
@@ -1,0 +1,14 @@
+import { createSection } from '@formkit/inputs'
+
+/**
+ * Wrapper section, wraps the entire multi-step form
+ *
+ * @public
+ */
+export const wrapper = createSection('wrapper', () => ({
+  $el: 'div',
+  attrs: {
+    'data-tab-style': '$tabStyle',
+    'data-hide-labels': '$hideProgressLabels',
+  },
+}))


### PR DESCRIPTION
Fixes #1110

Using `$extend` here was unnecessary and for some reason prevented `sections-schema` prop overrides from being applied to children.