### PR TITLE
chore: use relative path for nuxt module playground

### DIFF
--- a/packages/nuxt/playground/nuxt.config.ts
+++ b/packages/nuxt/playground/nuxt.config.ts
@@ -1,7 +1,7 @@
 import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
-  modules: ['@formkit/nuxt', '@nuxtjs/tailwindcss'],
+  modules: ['../src/module', '@nuxtjs/tailwindcss'],
   formkit: {
     autoImport: true,
   },


### PR DESCRIPTION
oops - sorry!

reverts regression from https://github.com/formkit/formkit/pull/1185