### PR TITLE
Fix: allow any v-model Type for custom inputs

### DIFF
--- a/packages/inputs/src/props.ts
+++ b/packages/inputs/src/props.ts
@@ -244,7 +244,7 @@ export type PropType<
   T extends keyof FormKitInputs<Props>
 > = Extract<
   FormKitInputs<Props>,
-  { type: Props['type'] extends string ? Props['type'] : 'text' }
+  { type: Props['type'] extends string ? Props['type'] : 'meta' }
 >[T]
 
 /**


### PR DESCRIPTION
This line forces any custom input (i.e. where the 'type' prop is not a string) to take on the prop types of a 'text' input.

The 'text' input requires the v-model prop to be a string, which might not be appropriate.

The 'meta' input has a v-model type of 'any', so that is a more versatile fallback for custom inputs.

This fix should prevent a warning from showing in the formkit example of a custom input:
examples/src/vue/examples/custom-input/CustomInput.vue (line 3)
where v-model is an object, not a string.

(although the parent tsconfig.json excludes .vue files, so perhaps it is not visible).