### PR TITLE
Fix: enforce v-model type for custom inputs

### DIFF
--- a/examples/src/vue/examples/custom-input/CustomInput.vue
+++ b/examples/src/vue/examples/custom-input/CustomInput.vue
@@ -14,6 +14,7 @@ import { ref } from 'vue'
 import { createInput } from '@formkit/vue'
 import CurrencyInput from './CurrencyInput.vue'
 
-const value = ref({ currency: '$', amount: '2.99' })
-const currencyInput = createInput(CurrencyInput, { props: ['currency'] })
+interface CurrencyAmount { currency: string, amount: string }
+const value = ref<CurrencyAmount>({ currency: '$', amount: '2.99' })
+const currencyInput = createInput<CurrencyAmount>(CurrencyInput, { props: ['currency'] })
 </script>

--- a/packages/inputs/src/props.ts
+++ b/packages/inputs/src/props.ts
@@ -633,7 +633,7 @@ export interface FormKitRuntimeProps<
   /**
    * The dynamic value of the input.
    */
-  modelValue: PropType<Props, 'value'>
+  modelValue: Props['type'] extends FormKitTypeDefinition<infer T> ? T : PropType<Props, 'value'>
   /**
    * The name of the input.
    */


### PR DESCRIPTION
This change ensures that v-model has the same type as is passed to createInput, when creating a custom input.

It fixes a Typescript error in the example, in which v-model is expected to be passed (a reference to) a string.