### PR TITLE
fix(nuxt): remove an any

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -141,10 +141,7 @@ const useAutoImport = async function installLazy(options, nuxt) {
     const plugin = unpluginFormKit({
       defaultConfig: options.defaultConfig,
       configFile: configBase,
-    }) as any
-    // ☝️ Unfortunately we have this declaration as any right here, this seems
-    // to do with unplugin having a different vite dependency than nuxt, however
-    // this shouldn’t affect runtime.
+    })
     if (Array.isArray(config.plugins)) {
       config.plugins?.unshift(plugin)
     } else {


### PR DESCRIPTION
This seems to be no longer needed; if it recurs in future maybe we can use `resolutions` within the repo here to pin a vite version.