### PR TITLE
build: fixes windows build script

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -18,7 +18,7 @@ import cac from 'cac'
 import prompts from 'prompts'
 import fs from 'fs/promises'
 import { execa } from 'execa'
-import { dirname, resolve } from 'path'
+import path, { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { readFileSync } from 'fs'
 import {
@@ -206,7 +206,7 @@ export async function inputsBuildExtras() {
   const tsData = JSON.parse(
     tsConfigStr.replace(
       './types/globals.d.ts',
-      resolve(rootDir, './types/globals.d.ts')
+      resolve(rootDir, './types/globals.d.ts').split(path.sep).join(path.posix.sep)
     )
   )
   tsData.compilerOptions.outDir = './'
@@ -314,8 +314,8 @@ function buildComplete() {
   }
   msg.success(
     'build complete (' +
-      ((performance.now() - startTime) / 1000).toFixed(2) +
-      's)'
+    ((performance.now() - startTime) / 1000).toFixed(2) +
+    's)'
   )
 }
 

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -22,8 +22,8 @@ const makeAllPackagesExternalPlugin = {
         }
       })
     } else {
-      const NON_NODE_MODULE_RE = /^[A-Z]:[\\\/]|^\.{0,2}[\/]|^\.{1,2}$/
-      build.onResolve({ filter: /.* / }, (args) => {
+      const NON_NODE_MODULE_RE = /^[A-Z]:[\\/]|^\.{0,2}[/]|^\.{1,2}$/
+      build.onResolve({ filter: /.*/ }, (args) => {
         if (!NON_NODE_MODULE_RE.test(args.path)) return {
           path: args.path,
           external: true,

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -22,11 +22,13 @@ const makeAllPackagesExternalPlugin = {
         }
       })
     } else {
-      const filter = /^[^./]|^\.[^./]|^\.\.[^/]/ // Must not start with "/" or "./" or "../"
-      build.onResolve({ filter }, (args) => ({
-        path: args.path,
-        external: true,
-      }))
+      const NON_NODE_MODULE_RE = /^[A-Z]:[\\\/]|^\.{0,2}[\/]|^\.{1,2}$/
+      build.onResolve({ filter: /.* / }, (args) => {
+        if (!NON_NODE_MODULE_RE.test(args.path)) return {
+          path: args.path,
+          external: true,
+        }
+      })
     }
   },
 }


### PR DESCRIPTION
fixes separator for windows, using posix sep.
fixes non node module filter by adding windows `D:` relative path.