### PR TITLE
fix: findSection always returning `[false, false]` when the target is inside a conditional section

### DIFF
--- a/packages/inputs/src/compose.ts
+++ b/packages/inputs/src/compose.ts
@@ -195,7 +195,7 @@ export function eachSection<T>(
       callbackReturn = eachSection(schema.then, callback, stopOnCallbackReturn, schema)
     }
 
-    if (schema.else && typeof schema.else !== 'string') {
+    if (!callbackReturn && schema.else && typeof schema.else !== 'string') {
       callbackReturn = eachSection(schema.else, callback, stopOnCallbackReturn, schema)
     }
 

--- a/packages/inputs/src/compose.ts
+++ b/packages/inputs/src/compose.ts
@@ -153,7 +153,7 @@ export function findSection(
  * @public
  */
 export function eachSection<T>(
-  schema: FormKitSchemaNode[] | FormKitSchemaNode,
+  schema: FormKitSchemaDefinition,
   callback: (
     section: FormKitSchemaComponent | FormKitSchemaDOMNode,
     sectionConditional: FormKitSchemaCondition,
@@ -189,12 +189,18 @@ export function eachSection<T>(
       stopOnCallbackReturn
     )
   } else if (isConditional(schema)) {
+    let callbackReturn: T | void = undefined
+
     if (schema.then && typeof schema.then !== 'string') {
-      eachSection(schema.then, callback, stopOnCallbackReturn, schema)
+      callbackReturn = eachSection(schema.then, callback, stopOnCallbackReturn, schema)
     }
 
     if (schema.else && typeof schema.else !== 'string') {
-      eachSection(schema.else, callback, stopOnCallbackReturn, schema)
+      callbackReturn = eachSection(schema.else, callback, stopOnCallbackReturn, schema)
+    }
+
+    if (callbackReturn && stopOnCallbackReturn) {
+      return callbackReturn
     }
   }
 }


### PR DESCRIPTION
`findSection` uses `eachSection` under the hood. Since https://github.com/formkit/formkit/commit/80628ad3676ae6a8616a6411940698a512087d2b, the loop iterates through conditional sections but the result is never returned: 

```ts
//...
if (schema.then && typeof schema.then !== 'string') {
    eachSection(schema.then, callback, stopOnCallbackReturn, schema) // never returned
}

if (schema.else && typeof schema.else !== 'string') {
    eachSection(schema.else, callback, stopOnCallbackReturn, schema) // never returned
}
//...
```

Therefore, `stopOnCallbackReturn` becomes useless and `findSection` always returns `[false, false]` when the `eachSection` loop follows one of these paths.

This PR returns the callback result only if `stopOnCallbackReturn` is `true`, which is the case in `findSection`. I also added two tests about `findSection` (there was none), the second (_"can find a conditional section in a schema"_) would have returned `[false, false]` before this PR.