### PR TITLE
feat(themes): allow arrays in `generateClasses` function

### DIFF
--- a/packages/themes/__tests__/generateClasses.spec.ts
+++ b/packages/themes/__tests__/generateClasses.spec.ts
@@ -22,7 +22,8 @@ describe('generateClasses', () => {
     })
 
     const node = createNode({
-      props: { type: 'text' }
+      props: { type: 'text' },
+      value: 'text'
     })
 
     expect(classes).toEqual({

--- a/packages/themes/__tests__/generateClasses.spec.ts
+++ b/packages/themes/__tests__/generateClasses.spec.ts
@@ -1,4 +1,4 @@
-import { createNode } from '../../core/src/node'
+import { createNode } from '@formkit/core'
 import { generateClasses } from '../src'
 import { describe, expect, it } from 'vitest'
 
@@ -22,8 +22,7 @@ describe('generateClasses', () => {
     })
 
     const node = createNode({
-      props: { type: 'text' },
-      value: 'text'
+      props: { type: 'text' }
     })
 
     expect(classes).toEqual({

--- a/packages/themes/__tests__/generateClasses.spec.ts
+++ b/packages/themes/__tests__/generateClasses.spec.ts
@@ -22,9 +22,8 @@ describe('generateClasses', () => {
     })
 
     const node = createNode({
-      props: {
-        type: 'text'
-      }
+      name: 'text',
+      props: { type: 'text' }
     })
 
     expect(classes).toEqual({

--- a/packages/themes/__tests__/generateClasses.spec.ts
+++ b/packages/themes/__tests__/generateClasses.spec.ts
@@ -1,0 +1,38 @@
+import { createNode } from '../../core'
+import { generateClasses } from '../src'
+import { describe, expect, it } from 'vitest'
+
+describe('generateClasses', () => {
+  it('generates classes from an object', () => {
+    const classes = generateClasses({
+      global: {
+        outer: 'outerGlobal',
+        wrapper: 'wrapperGlobal'
+      },
+      text: {
+        outer: 'outerText',
+        wrapper: [
+          'wrapperTextA wrapperTextB',
+          'wrapperTextC wrapperTextD'
+        ]
+      },
+      email: {
+        outer: 'not_used'
+      }
+    })
+
+    const node = createNode({
+      props: {
+        type: 'text'
+      }
+    })
+
+    expect(classes).toEqual({
+      outer: expect.any(Function),
+      wrapper: expect.any(Function)
+    })
+
+    expect(classes.outer(node, 'outer')).toBe('outerGlobal outerText')
+    expect(classes.wrapper(node, 'wrapper')).toBe('wrapperGlobal wrapperTextA wrapperTextB wrapperTextC wrapperTextD')
+  })
+})

--- a/packages/themes/__tests__/generateClasses.spec.ts
+++ b/packages/themes/__tests__/generateClasses.spec.ts
@@ -1,4 +1,4 @@
-import { createNode } from '../../core'
+import { createNode } from '../../core/src/node'
 import { generateClasses } from '../src'
 import { describe, expect, it } from 'vitest'
 
@@ -22,7 +22,6 @@ describe('generateClasses', () => {
     })
 
     const node = createNode({
-      name: 'text',
       props: { type: 'text' }
     })
 

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -48,18 +48,13 @@ export function generateClasses(
   Object.keys(classes).forEach((type) => {
     Object.keys(classes[type]).forEach((sectionKey) => {
       classesBySectionKey[sectionKey] = classesBySectionKey[sectionKey] || {}
-
-      const sectionClasses = classes[type][sectionKey]
-
-      if(typeof sectionClasses === 'string') {
-        classesBySectionKey[sectionKey][type] = sectionClasses
-        return
-      }
+      let sectionClasses = classes[type][sectionKey]
 
       if(Array.isArray(sectionClasses)) {
-        classesBySectionKey[sectionKey][type] = sectionClasses.join(' ')
-        return
+        sectionClasses = sectionClasses.join(' ')
       }
+
+      classesBySectionKey[sectionKey][type] = sectionClasses
     })
   })
 


### PR DESCRIPTION
Currently it is only allowed to pass a `Record<string, Record<string, string>>` to `generateClasses`.

I often tell myself it would be nice to be able to pass the classes in an array instead of a string, since it allows a better code structure when you have a lot of classes.

Of course, it's still possible to convert the arrays to strings before using `generateClasses`, but that's an additional step that I though could be handled directly by FormKit.

I also fixed some minor type errors and added a test for `generateClasses`.

Have a nice day!