### PR TITLE
build: improve type safety and stub before building

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm stub
       - run: pnpm build all
       - name: Get installed Playwright version
         id: playwright-version
@@ -45,6 +46,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm stub
       - run: pnpm build all
       - name: Get installed Playwright version
         id: playwright-version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Run Vitest
-        run: pnpm test --typecheck
+        run: pnpm -- test --typecheck
   Playwright:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "unplugin-file-url": "^0.1.1",
     "unplugin-pure": "^0.1.1",
     "vite": "^5.0.0",
-    "vitest": "1.4.0"
+    "vitest": "1.4.0",
+    "vue": "^3.4.21"
   },
   "license": "UNLICENSED",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       vitest:
         specifier: 1.4.0
         version: 1.4.0(@types/node@18.19.26)(jsdom@24.0.0)(terser@5.30.0)
+      vue:
+        specifier: ^3.4.21
+        version: 3.4.21(typescript@5.4.3)
 
   e2e:
     dependencies:
@@ -5508,8 +5511,8 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  /bare-events@2.2.2:
-    resolution: {integrity: sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==}
+  /bare-events@2.2.1:
+    resolution: {integrity: sha512-9GYPpsPFvrWBkelIhOhTWtkeZxVxZOdb3VnFTCzlOo3OjvmTvzLoZFUT8kNFACx0vJej6QPney1Cf9BvzCNE/A==}
     requiresBuild: true
     dev: true
     optional: true
@@ -12015,7 +12018,7 @@ packages:
       fast-fifo: 1.3.2
       queue-tick: 1.0.1
     optionalDependencies:
-      bare-events: 2.2.2
+      bare-events: 2.2.1
     dev: true
 
   /string-hash@1.1.3:

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -49,7 +49,7 @@ export const progress = {
   expectedLogs: 0,
   logs: [],
   warnings: {},
-  timeElapsed: 0,
+  timeElapsed: '0',
   step: '',
 }
 
@@ -65,7 +65,7 @@ const multiStepFile = readFileSync(
 const matches = multiStepFile.match(
   /\/\* <declare> \*\/(.*?)\/\* <\/declare> \*\//gmsu
 )
-if (matches.length !== 2) {
+if (matches?.length !== 2) {
   process.exit()
 }
 
@@ -140,10 +140,7 @@ export async function buildPackage(p) {
     const icons = getIcons()
     await fs.mkdir(
       resolve(packagesDir, 'icons/dist/icons'),
-      { recursive: true },
-      (err) => {
-        if (err) throw err
-      }
+      { recursive: true }
     )
     Object.keys(icons).forEach(async (icon) => {
       await fs.writeFile(
@@ -242,9 +239,6 @@ async function addonsBuildExtras() {
   await fs.mkdir(
     resolve(packagesDir, 'addons/dist/css'),
     { recursive: true },
-    (err) => {
-      if (err) throw err
-    }
   )
   addonsCSS.forEach(async (css) => {
     await fs.copyFile(
@@ -256,8 +250,8 @@ async function addonsBuildExtras() {
 
 /**
  * Create a new bundle of a certain format for a certain package.
- * @param p package name
- * @param format the format to create (cjs, esm, umd, etc...)
+ * @param {string} p package name
+ * @param {string | undefined} subPackage the subPackage to build
  */
 async function bundle(p, subPackage, showLogs = false) {
   if (subPackage && p === 'themes') {
@@ -270,6 +264,7 @@ async function bundle(p, subPackage, showLogs = false) {
   await createBundle(p, subPackage, showLogs)
 }
 
+/** @returns {Promise<void>} */
 async function buildNuxtModule() {
   progress.step = `Bundling Nuxt module`
   return new Promise((resolve, reject) => {
@@ -334,7 +329,9 @@ function estimatedLogs(p) {
 
 /**
  * Adds the build command.
- * @param {typeof import('cac').default} cli
+ * @template {string} T
+ * @typedef {T extends new (...args: any[]) => infer R ? R : never} InstanceOf<T>
+ * @param {InstanceOf<import('cac').default>} cli
  */
 export default function (cli) {
   cli

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -8,13 +8,13 @@ import transformPipe from './transform-pipe.mjs'
 import { progress } from './build.mjs'
 
 /**
- * @type {import('tsup').Options['esbuildPlugins'][number]']}
+ * @type {NonNullable<import('tsup').Options['esbuildPlugins']>[number]}
  */
 const makeAllPackagesExternalPlugin = {
   name: 'make-all-packages-external',
   setup(build) {
     // iife files should be fully bundled.
-    if (build.initialOptions.outExtension['.js'].startsWith('.iife.js')) {
+    if (build.initialOptions.outExtension?.['.js'].startsWith('.iife.js')) {
       const filter = /^vue$/
       build.onResolve({ filter }, () => {
         return {
@@ -38,7 +38,7 @@ const makeAllPackagesExternalPlugin = {
 /**
  * Create a new bundle of a certain format for a certain package.
  * @param {string} pkg the package to create a bundle for
- * @param {string} format the format to create (cjs, esm, umd, etc...)
+ * @param {string | undefined} plugin the package to build
  */
 export async function createBundle(pkg, plugin, showLogs = false) {
   const __filename = fileURLToPath(import.meta.url)
@@ -69,6 +69,7 @@ export async function createBundle(pkg, plugin, showLogs = false) {
     return entry
   }
 
+  /** @returns {Array<'iife' | 'cjs' | 'esm' | 'esm'>} */
   function createFormats() {
     if (pkg === 'vue') {
       return ['iife', 'cjs', 'esm', 'esm']
@@ -92,6 +93,7 @@ export async function createBundle(pkg, plugin, showLogs = false) {
     )
   }
 
+  /** @type {NonNullable<import('tsup').Options['esbuildPlugins']>} */
   const esbuildPlugins = [
     makeAllPackagesExternalPlugin,
     {
@@ -99,7 +101,7 @@ export async function createBundle(pkg, plugin, showLogs = false) {
       setup(ctx, ...args) {
         const plugin = transformPipe.esbuild({
           replace: {
-            __DEV__: ctx.initialOptions.outExtension['.js'].startsWith('.dev')
+            __DEV__: ctx.initialOptions.outExtension?.['.js'].startsWith('.dev')
               ? 'true'
               : 'false',
           },
@@ -119,6 +121,7 @@ export async function createBundle(pkg, plugin, showLogs = false) {
     format: createFormats(),
     entry: [createEntry()],
     outDir,
+    external: [/@formkit/],
     outExtension: (ctx) => {
       const prefix = devBuild ? '.dev' : ''
       if (ctx.format === 'cjs') return { js: `${prefix}.cjs` }
@@ -134,12 +137,7 @@ export async function createBundle(pkg, plugin, showLogs = false) {
     globalName: `FormKit${pkg[0].toUpperCase()}${pkg.substring(1)}`,
     target: tsconfig.compilerOptions.target,
     dts: {
-      output: {
-        exports: 'named',
-        globals: {
-          vue: 'Vue',
-        },
-      },
+      resolve: true
     },
     treeshake: true,
     esbuildOptions: (options) => {

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -121,7 +121,6 @@ export async function createBundle(pkg, plugin, showLogs = false) {
     format: createFormats(),
     entry: [createEntry()],
     outDir,
-    external: [/@formkit/],
     outExtension: (ctx) => {
       const prefix = devBuild ? '.dev' : ''
       if (ctx.format === 'cjs') return { js: `${prefix}.cjs` }
@@ -136,9 +135,7 @@ export async function createBundle(pkg, plugin, showLogs = false) {
     clean: true,
     globalName: `FormKit${pkg[0].toUpperCase()}${pkg.substring(1)}`,
     target: tsconfig.compilerOptions.target,
-    dts: {
-      resolve: true
-    },
+    dts: {},
     treeshake: true,
     esbuildOptions: (options) => {
       options.charset = 'utf8'


### PR DESCRIPTION
Looking into [this failure](https://github.com/formkit/formkit/actions/runs/8491876473/job/23264288414) I improved some type safety for build/bundle scripts, and enabled stubbing the build in CI.

My hypothesis is that it is related to the inability of the dts plugin to resolve types for imports that are not yet stubbed/built ...