### PR TITLE
Feature/auto animate fix

### DIFF
--- a/packages/addons/src/plugins/autoAnimatePlugin.ts
+++ b/packages/addons/src/plugins/autoAnimatePlugin.ts
@@ -95,11 +95,7 @@ function observeIds() {
  */
 export function createAutoAnimatePlugin(
   options?: AutoAnimateOptions,
-  animationTargets: Record<string, string[]> = {
-    global: ['outer', 'inner'],
-    form: ['form'],
-    repeater: ['items'],
-  }
+  animationTargets: Record<string, string[]> = {}
 ): FormKitPlugin {
   return (node: FormKitNode) => {
     node.on('created', () => {

--- a/packages/inputs/src/compose.ts
+++ b/packages/inputs/src/compose.ts
@@ -192,11 +192,21 @@ export function eachSection<T>(
     let callbackReturn: T | void = undefined
 
     if (schema.then && typeof schema.then !== 'string') {
-      callbackReturn = eachSection(schema.then, callback, stopOnCallbackReturn, schema)
+      callbackReturn = eachSection(
+        schema.then,
+        callback,
+        stopOnCallbackReturn,
+        schema
+      )
     }
 
     if (!callbackReturn && schema.else && typeof schema.else !== 'string') {
-      callbackReturn = eachSection(schema.else, callback, stopOnCallbackReturn, schema)
+      callbackReturn = eachSection(
+        schema.else,
+        callback,
+        stopOnCallbackReturn,
+        schema
+      )
     }
 
     if (callbackReturn && stopOnCallbackReturn) {

--- a/packages/inputs/src/createSection.ts
+++ b/packages/inputs/src/createSection.ts
@@ -98,6 +98,8 @@ export function createSection(
       if (isDOM(node) || isComponent(node)) {
         if (!node.meta) {
           node.meta = { section }
+        } else {
+          node.meta.section = section
         }
         if (children.length && !node.children) {
           node.children = [

--- a/packages/inputs/src/sections/formInput.ts
+++ b/packages/inputs/src/sections/formInput.ts
@@ -8,6 +8,9 @@ import { createSection } from '../createSection'
 export const formInput = createSection('form', () => ({
   $el: 'form',
   bind: '$attrs',
+  meta: {
+    autoAnimate: true,
+  },
   attrs: {
     id: '$id',
     name: '$node.name',

--- a/packages/inputs/src/sections/outer.ts
+++ b/packages/inputs/src/sections/outer.ts
@@ -7,6 +7,9 @@ import { createSection } from '../createSection'
  */
 export const outer = createSection('outer', () => ({
   $el: 'div',
+  meta: {
+    autoAnimate: true,
+  },
   attrs: {
     key: '$id',
     'data-family': '$family || undefined',


### PR DESCRIPTION
Fixes #1191 and #1336 

- Removes global `inner` section from default animation target
- converts all remaining sections to use schema `meta` to trigger autoAnimate
- fixes issue in `createSection` where `section` meta would not be applied if any `meta` already existed