### PR TITLE
🔨 added option to not overwrite all data on form commit

### DIFF
--- a/packages/addons/src/plugins/localStoragePlugin.ts
+++ b/packages/addons/src/plugins/localStoragePlugin.ts
@@ -150,6 +150,9 @@ export function createLocalStoragePlugin(
           let saveData = {}
           if (localStorageData)
             saveData = { ...JSON.parse(localStorageData).data, ...savePayload }
+          else {
+            saveData = savePayload
+          }
           localStorage.setItem(
             storageKey,
             JSON.stringify({

--- a/packages/addons/src/plugins/localStoragePlugin.ts
+++ b/packages/addons/src/plugins/localStoragePlugin.ts
@@ -12,7 +12,7 @@ import { undefine } from '@formkit/utils'
  * @param beforeSave - A function to call for modifying data before saving to localStorage
  * @param beforeLoad - A function to call for modifying data before loading from localStorage
  * @param clearOnSubmit - On submission of the form clear the local storage key. Defaults to true.
- * @param overwriteOnCommit - On commit of the form overwrite the current local storage key. Defaults to true
+ * @param overwriteOnCommit - On commit of the form overwrite the matching local storage key value. Defaults to true
  *
  * @public
  */

--- a/packages/addons/src/plugins/localStoragePlugin.ts
+++ b/packages/addons/src/plugins/localStoragePlugin.ts
@@ -12,7 +12,7 @@ import { undefine } from '@formkit/utils'
  * @param beforeSave - A function to call for modifying data before saving to localStorage
  * @param beforeLoad - A function to call for modifying data before loading from localStorage
  * @param clearOnSubmit - On submission of the form clear the local storage key. Defaults to true.
- * @param overwriteStorage - On commit of the form overwrite the current local storage key. Defaults to true
+ * @param overwriteOnCommit - On commit of the form overwrite the current local storage key. Defaults to true
  *
  * @public
  */


### PR DESCRIPTION
added option to not overwrite all data on form commit when data has changed for the match key in local storage