### PR TITLE
fix: keep placeholder for null or undefined as well

### DIFF
--- a/packages/inputs/src/sections/noFiles.ts
+++ b/packages/inputs/src/sections/noFiles.ts
@@ -7,5 +7,5 @@ import { createSection } from '../createSection'
  */
 export const noFiles = createSection('noFiles', () => ({
   $el: 'span',
-  if: '$value.length == 0',
+  if: '$value == null || $value.length == 0',
 }))


### PR DESCRIPTION
I noticed that if initial value for file type is null or undefined, placeholder is hidden.

Expected:

<img width="352" alt="image" src="https://github.com/user-attachments/assets/e6669b5d-51a5-4e2d-988c-0cbfa2f67999">

Received:

<img width="352" alt="image" src="https://github.com/user-attachments/assets/9524b305-0adf-4e78-b8ff-3d42ecf1b912">
