### PR TITLE
Fix casing for the `type` prop of `datetime-local` input

### DIFF
--- a/packages/inputs/src/props.ts
+++ b/packages/inputs/src/props.ts
@@ -75,7 +75,7 @@ export interface FormKitInputProps<Props extends FormKitInputs<Props>> {
   }
   color: { type: 'color'; value?: string }
   date: { type: 'date'; value?: string }
-  'datetime-local': { type: 'datetimeLocal'; value?: string }
+  'datetime-local': { type: 'datetime-local'; value?: string }
   email: {
     type: 'email'
     value?: string


### PR DESCRIPTION
**Changes list**
- Changed the prop type for `datetime-local` input from camelCase to kebab-case as per the [example usages](https://github.com/formkit/formkit/blob/6b4542a3e013bfff810e126eb20eb2fbce6f25af/examples/src/vue/TextClassifications.vue#L16)

**Additional context**
I've seen [this](https://github.com/formkit/formkit/issues/1129) related issue but we've been still having this problem in the latest version of FormKit (1.6.5). 

Before:
<img width="881" alt="Screenshot 2024-08-26 at 15 45 46" src="https://github.com/user-attachments/assets/a6307ae7-6300-4747-b422-b35a8c9b17bb">

After:
<img width="531" alt="Screenshot 2024-08-26 at 15 46 31" src="https://github.com/user-attachments/assets/eb452c97-f600-4849-9327-7573a8d5fa63">

