### PR TITLE
feat(rules): add "or_equal" date alternative

### DIFF
--- a/packages/rules/__tests__/date_after_or_equal.spec.ts
+++ b/packages/rules/__tests__/date_after_or_equal.spec.ts
@@ -1,0 +1,32 @@
+import { createNode } from '@formkit/core'
+import afterOrEqual from '../src/date_after_or_equal'
+import { describe, expect, it } from 'vitest'
+
+describe('date_after rule', () => {
+  const today = new Date()
+  const tomorrow = new Date()
+  const yesterday = new Date()
+  tomorrow.setDate(today.getDate() + 1)
+  yesterday.setDate(today.getDate() - 1)
+
+  it('passes with today’s date object', () =>
+    expect(afterOrEqual(createNode({ value: today }))).toBe(true))
+
+  it('passes with tomorrow’s date object', () =>
+    expect(afterOrEqual(createNode({ value: tomorrow }))).toBe(true))
+
+  it('passes with future date', () =>
+    expect(afterOrEqual(createNode({ value: 'January 15, 2999' }))).toBe(true))
+
+  it('passes with long past date', () =>
+    expect(afterOrEqual(createNode({ value: yesterday }), 'Jan 15, 2000')).toBe(true))
+
+  it('fails with yesterday’s date', () =>
+    expect(afterOrEqual(createNode({ value: yesterday }))).toBe(false))
+
+  it('fails with old date string', () =>
+    expect(afterOrEqual(createNode({ value: 'January, 2000' }))).toBe(false))
+
+  it('fails with invalid value', () =>
+    expect(afterOrEqual(createNode({ value: '' }))).toBe(false))
+})

--- a/packages/rules/__tests__/date_before_or_equal.spec.ts
+++ b/packages/rules/__tests__/date_before_or_equal.spec.ts
@@ -1,0 +1,34 @@
+import { createNode } from '@formkit/core'
+import beforeOrEqual from '../src/date_before_or_equal'
+import { describe, expect, it } from 'vitest'
+
+describe('before or equal rule', () => {
+  const today = new Date()
+  const tomorrow = new Date()
+  const yesterday = new Date()
+  tomorrow.setDate(today.getDate() + 1)
+  yesterday.setDate(today.getDate() - 1)
+
+  it('passes with today’s date object', () =>
+    expect(beforeOrEqual(createNode({ value: today }))).toBe(true))
+
+  it('fails with tomorrow’s date object', () =>
+    expect(beforeOrEqual(createNode({ value: tomorrow }))).toBe(false))
+
+  it('fails with future date', () =>
+    expect(beforeOrEqual(createNode({ value: 'January 15, 2999' }))).toBe(false))
+
+  it('fails with long past date', () =>
+    expect(beforeOrEqual(createNode({ value: yesterday }), 'Jan 15, 2000')).toBe(
+      false
+    ))
+
+  it('passes with yesterday’s date', () =>
+    expect(beforeOrEqual(createNode({ value: yesterday }))).toBe(true))
+
+  it('passes with old date string', () =>
+    expect(beforeOrEqual(createNode({ value: 'January, 2000' }))).toBe(true))
+
+  it('fails with invalid value', () =>
+    expect(beforeOrEqual(createNode({ value: '' }))).toBe(false))
+})

--- a/packages/rules/src/date_after_or_equal.ts
+++ b/packages/rules/src/date_after_or_equal.ts
@@ -1,0 +1,18 @@
+import { FormKitValidationRule } from '@formkit/validation'
+
+/**
+ * Determine if the given input's value is after or equal to a given date.
+ * Defaults to current time.
+ * @param context - The FormKitValidationContext
+ * @public
+ */
+const date_after_or_equal: FormKitValidationRule = function (
+  { value },
+  compare = false
+) {
+  const timestamp = Date.parse(compare || new Date())
+  const fieldValue = Date.parse(String(value))
+  return isNaN(fieldValue) ? false : fieldValue > timestamp || fieldValue === timestamp
+}
+
+export default date_after_or_equal

--- a/packages/rules/src/date_before_or_equal.ts
+++ b/packages/rules/src/date_before_or_equal.ts
@@ -1,0 +1,17 @@
+import { FormKitValidationRule } from '@formkit/validation'
+
+/**
+ * Determine if the given input's value is before or equal to a given date.
+ * @param context - The FormKitValidationContext
+ * @public
+ */
+const date_before_or_equal: FormKitValidationRule = function (
+  { value },
+  compare = false
+) {
+  const timestamp = Date.parse(compare || new Date())
+  const fieldValue = Date.parse(String(value))
+  return isNaN(fieldValue) ? false : fieldValue < timestamp || fieldValue === timestamp
+}
+
+export default date_before_or_equal


### PR DESCRIPTION
Hey there! 👋🏻

This PR introduces two new date validation rules.

Currently, we can’t check if a date is either before or after a specific date and include the option for it to be equal. These new rules address this need, which is a common requirement in many forms.

By adding these rules, we can ensure more accurate validation errors when a date falls outside the allowed range.

