### PR TITLE
feat(rules): implements "date_after_node" rule

### DIFF
--- a/packages/rules/__tests__/date_after_node.spec.ts
+++ b/packages/rules/__tests__/date_after_node.spec.ts
@@ -1,0 +1,39 @@
+
+import { createNode } from '@formkit/core'
+import after_node from '../src/date_after_node'
+import { describe, expect, it } from 'vitest'
+
+describe('date_after_node rule', () => {
+  it('passes when comparing to a field with a non valid date', () => {
+    const form = createNode({ type: 'group' })
+    const node = createNode({ name: 'final_date', parent: form, value: 'January 15, 2999' })
+    createNode({ name: 'start_date', parent: form, value: '' })
+    expect(after_node(node, 'start_date')).toBe(true)
+  })
+
+  it('passes when compare to a field with previous date', () => {
+    const form = createNode({ type: 'group' })
+    const node = createNode({ name: 'final_date', parent: form, value: 'January 15, 2999' })
+    createNode({ name: 'start_date', parent: form, value: 'January 14, 2999' })
+    expect(after_node(node, 'start_date')).toBe(true)
+  })
+
+  it('fails when comparing field is not provided', () => {
+    const node = createNode({ name: 'final_date', value: 'January 15, 2999' })
+    expect(after_node(node)).toBe(false)
+  })
+
+  it('fails when comparing to a field with equals date', () => {
+    const form = createNode({ type: 'group' })
+    const node = createNode({ name: 'final_date', parent: form, value: 'January 15, 2999' })
+    createNode({ name: 'start_date', parent: form, value: 'January 15, 2999' })
+    expect(after_node(node, 'start_date')).toBe(false)
+  })
+
+  it('fails when comparing to a field with future date', () => {
+    const form = createNode({ type: 'group' })
+    const node = createNode({ name: 'final_date', parent: form, value: 'January 13, 2999' })
+    createNode({ name: 'start_date', parent: form, value: 'January 15, 2999' })
+    expect(after_node(node, 'start_date')).toBe(false)
+  })
+})

--- a/packages/rules/src/date_after_node.ts
+++ b/packages/rules/src/date_after_node.ts
@@ -1,0 +1,25 @@
+import { FormKitValidationRule } from '@formkit/validation'
+
+/**
+ * Determine if the given input's value is after a given date.
+ * Defaults to current time.
+ * @param context - The FormKitValidationContext
+ * @public
+ */
+const date_after_node: FormKitValidationRule = function (
+  node,
+  address: string
+) {
+  if (!address) return false
+
+  const fieldValue = Date.parse(String(node.value))
+  const foreignValue = Date.parse(String(node.at(address)?.value))
+
+  if (isNaN(foreignValue)) return true
+
+  return isNaN(fieldValue)
+    ? false
+    : fieldValue > foreignValue
+}
+
+export default date_after_node


### PR DESCRIPTION
Hi, everyone

This PR introduce a new validation to be used with date fields.

The proposal is be able to use `validation="date_after_node:someOtherNode"` in the rules, I faced a problem with it recently and this inspired me to bring a solution that could be used by everyone