### PR TITLE
fix(rules): allow passing unix epoch in `date_between` rule

### DIFF
--- a/packages/rules/__tests__/date_between.spec.ts
+++ b/packages/rules/__tests__/date_between.spec.ts
@@ -46,4 +46,20 @@ describe('date_between', () => {
       )
     ).toBe(true)
   })
+
+  it.each([
+    ['1970-01-01', '1960-01-01', '1980-01-01'],
+    ['1980-01-01', '1970-01-01', '1990-01-01'],
+    ['1960-01-01', '1950-01-01', '1970-01-01'],
+  ])('passes when using 1970-01-01 as an argument', (value, dateA, dateB) => {
+    expect(
+      date_between(
+        createNode({
+          value: new Date(value),
+        }),
+        new Date(dateA),
+        new Date(dateB)
+      )
+    ).toBe(true)
+  })
 })

--- a/packages/rules/src/date_between.ts
+++ b/packages/rules/src/date_between.ts
@@ -14,10 +14,10 @@ const date_between: FormKitValidationRule = function date_between(
   dateB = dateB instanceof Date ? dateB.getTime() : Date.parse(dateB)
   const compareTo =
     value instanceof Date ? value.getTime() : Date.parse(String(value))
-  if (dateA && !dateB) {
+  if (dateA && isNaN(dateB)) {
     dateB = dateA
     dateA = Date.now()
-  } else if (!dateA || !compareTo) {
+  } else if (dateA === undefined || compareTo === undefined) {
     return false
   }
   return compareTo >= dateA && compareTo <= dateB


### PR DESCRIPTION
Fixes #1525 