### PR TITLE
feat: add min/max auto height that respects css

### DIFF
--- a/examples/src/vue/examples/AutoHeightTextarea.vue
+++ b/examples/src/vue/examples/AutoHeightTextarea.vue
@@ -22,9 +22,20 @@ function changeProgramatically(node: FormKitNode) {
 
   <FormKit
     type="textarea"
-    label="I have an auto-height plugin with a max auto height of 200px"
+    label="I have an auto-height plugin with a max auto height of 300px"
     help="This textarea will grow as you type"
     auto-height
+    :max-auto-height="300"
+    :plugins="[createAutoHeightTextareaPlugin()]"
+    :value="value"
+  />
+
+  <FormKit
+    type="textarea"
+    label="I have an auto-height plugin with a min min/max auto height of 100px/300px"
+    help="This textarea will grow as you type"
+    auto-height
+    :min-auto-height="100"
     :max-auto-height="300"
     :plugins="[createAutoHeightTextareaPlugin()]"
     :value="value"

--- a/packages/addons/src/plugins/autoHeightTextarea.ts
+++ b/packages/addons/src/plugins/autoHeightTextarea.ts
@@ -11,15 +11,67 @@ import { undefine, whenAvailable } from '@formkit/utils'
 export function createAutoHeightTextareaPlugin(): FormKitPlugin {
   const autoHeightTextareaPlugin = (node: FormKitNode) => {
     if (node.props.type !== 'textarea') return
-    node.addProps(['autoHeight', 'maxAutoHeight'])
+    node.addProps(['autoHeight', 'minAutoHeight', 'maxAutoHeight'])
 
     node.on('mounted', () => {
       const autoHeight = undefine(node.props.autoHeight)
-      const maxAutoHeight = Number.isFinite(node.props.maxAutoHeight)
-        ? parseInt(node.props.maxAutoHeight)
-        : undefined
-      if (!autoHeight || !node.context) return
       let inputElement: HTMLElement | undefined | null = null
+      let showScrollbars = false
+
+      const getMinAutoHeight = () => {
+        if (!inputElement) return 0
+
+        if (typeof node.props.minAutoHeight === 'number') {
+          return Math.max(0, node.props.minAutoHeight)
+        }
+
+        if (
+          node.props.minAutoHeight === true ||
+          node.props.minAutoHeight === ''
+        ) {
+          const computedStyle = getComputedStyle(inputElement as HTMLElement)
+          const minHeight = parseInt(computedStyle.minHeight) || 0
+
+          if (__DEV__ && ['auto', '0px'].includes(computedStyle.minHeight)) {
+            console.warn(
+              'No minHeight CSS property set for textarea with min-auto-height'
+            )
+          }
+          return minHeight
+        }
+        return 0
+      }
+
+      const getMaxAutoHeight = () => {
+        if (!inputElement) return Infinity
+
+        if (typeof node.props.maxAutoHeight === 'number') {
+          return Math.max(0, node.props.maxAutoHeight)
+        }
+
+        if (
+          node.props.maxAutoHeight === true ||
+          node.props.maxAutoHeight === ''
+        ) {
+          const computedStyle = getComputedStyle(inputElement as HTMLElement)
+          const maxHeight = parseInt(computedStyle.maxHeight) || 0
+
+          if (__DEV__ && ['none', '0px'].includes(computedStyle.maxHeight)) {
+            console.warn(
+              'No maxHeight CSS property set for textarea with max-auto-height'
+            )
+          }
+          xx
+
+          showScrollbars = maxHeight !== 0
+          return maxHeight || Infinity
+        }
+
+        showScrollbars = true
+        return Infinity
+      }
+
+      if (!autoHeight || !node.context) return
 
       whenAvailable(
         node.context.id,
@@ -28,6 +80,9 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
             node?.context?.id ? node.context.id : ''
           )
           if (!(inputElement instanceof HTMLTextAreaElement)) return
+
+          const minAutoHeight = getMinAutoHeight()
+          const maxAutoHeight = getMaxAutoHeight()
 
           if (!document.getElementById('formkit-auto-height-textarea-style')) {
             const scrollbarStyle = document.createElement('style')
@@ -43,7 +98,7 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
             false
           ) as HTMLTextAreaElement
           hiddenTextarea.classList.add('formkit-auto-height-textarea')
-          if (!maxAutoHeight) {
+          if (!showScrollbars) {
             inputElement.classList.add('formkit-auto-height-textarea')
           }
 
@@ -91,7 +146,12 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
 
             const scrollHeight = hiddenTextarea.scrollHeight
             const height = isBorderBox ? scrollHeight + paddingY : scrollHeight
-            const h = maxAutoHeight ? Math.min(height, maxAutoHeight) : height
+
+            const h = Math.min(
+              Math.max(height, minAutoHeight),
+              maxAutoHeight || Infinity
+            )
+
             if (!inputElement.style.height) {
               inputElement.style.height = `0px`
             }


### PR DESCRIPTION
- Adds new `min-auto-height` prop.
- Keeps 'max-auto-height' backward compatible with a `number`, but both the min & max can also be passed as a `boolean` which then uses the min/max css values.
- No min/max prop returns the default `auto-height` value.