### PR TITLE
fix: handle rejected promises in form submission

### DIFF
--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -23,6 +23,7 @@ import FloatingLabels from './vue/examples/FloatingLabels.vue'
 import LocalStoragePlugin from './vue/examples/LocalStoragePlugin.vue'
 import AutoHeightTextarea from './vue/examples/AutoHeightTextarea.vue'
 import SyncedLists from './vue/examples/SyncedLists.vue'
+import SubmitPromise from './vue/examples/SubmitPromise.vue'
 import TestAsyncFormSubmit from './vue/examples/TestAsyncFormSubmit.vue'
 import AccessibilityTest from './vue/examples/AccessibilityTest.vue'
 import Zod from './vue/examples/Zod.vue'
@@ -147,6 +148,10 @@ const router = createRouter({
     {
       path: '/synced-lists',
       component: SyncedLists,
+    },
+    {
+      path: '/submit-promise',
+      component: SubmitPromise,
     },
     {
       path: '/e2e',

--- a/examples/src/vue/Navigation.vue
+++ b/examples/src/vue/Navigation.vue
@@ -73,6 +73,9 @@
         <router-link to="/synced-lists"> Synced Lists </router-link>
       </li>
       <li>
+        <router-link to="/submit-promise">Submit Promise Error</router-link>
+      </li>
+      <li>
         <router-link to="/zod"> Zod </router-link>
       </li>
       <li>

--- a/examples/src/vue/examples/SubmitPromise.vue
+++ b/examples/src/vue/examples/SubmitPromise.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <h2>Test form blocking on error</h2>
+
+    <FormKit
+      type="form"
+      @submit="submitHandler"
+    >
+      <template #default="{ state: { loading } }">  
+        <FormKitMessages />
+        <FormKit
+          type="text"
+          name="username"
+          label="Username"
+          validation="required"
+        />
+        <FormKit
+          type="password"
+          name="password"
+          label="Password"
+          validation="required"
+        />
+        <div v-if="loading">Submitting...</div>
+      </template>
+    </FormKit>
+  </div>
+</template>
+
+<script setup>
+const submitHandler = async (formData) => {
+  // Simulate network delay
+  await new Promise(resolve => setTimeout(resolve, 1000))
+  
+  // Simulate API error
+  throw new Error('Invalid credentials. Please try again.')
+}
+</script>
+
+<style scoped>
+.formkit-form {
+  max-width: 400px;
+  margin: 0 auto;
+}
+</style>

--- a/packages/inputs/src/features/forms.ts
+++ b/packages/inputs/src/features/forms.ts
@@ -67,9 +67,14 @@ async function handleSubmit(node: FormKitNode, submitEvent: Event) {
           node.props.submitBehavior !== 'live'
         if (autoDisable) node.props.disabled = true
         node.store.set(loading)
-        await retVal
-        if (autoDisable) node.props.disabled = false
-        node.store.remove('loading')
+        try {
+          await retVal
+        } catch (error) {
+          node.setErrors([error instanceof Error ? error.message : 'Form submission error'])
+        } finally {
+          if (autoDisable) node.props.disabled = false
+          node.store.remove('loading')
+        }
       }
     } else {
       if (submitEvent.target instanceof HTMLFormElement) {

--- a/packages/vue/__tests__/inputs/form.spec.ts
+++ b/packages/vue/__tests__/inputs/form.spec.ts
@@ -216,6 +216,35 @@ describe('form submission', () => {
     expect(submitHandler).toHaveBeenCalledTimes(1)
   })
 
+  it('handles rejected promises in submit handler', async () => {
+    const errorMessage = 'Test submission error'
+    const wrapper = mount(
+      {
+        methods: {
+          async submitHandler() {
+            throw new Error(errorMessage)
+          },
+        },
+        components: {
+          FormKitMessages,
+        },
+        template: `<FormKit type="form" @submit="submitHandler">
+          <FormKitMessages />
+          <FormKit type="text" name="test" />
+        </FormKit>`,
+      },
+      global
+    )
+
+    wrapper.find('form').trigger('submit')
+    await new Promise((r) => setTimeout(r, 50))
+    await nextTick()
+    
+    expect(wrapper.html()).toContain(errorMessage)
+    expect(wrapper.find('form').element.hasAttribute('data-loading')).toBe(false)
+    expect(wrapper.find('input').element.disabled).toBe(false)
+  })
+
   it('sets submitted state when form is submitted', async () => {
     const submitHandler = vi.fn()
     const wrapper = mount(


### PR DESCRIPTION
# Fix form submission error handling

Hey! I ran into an annoying issue while working on a form with async submission - if the submit handler throws an error, the whole form gets stuck. All inputs stay disabled, and users can't do anything except reload the page. I noticed there's a similar issue (#1556) about disabled states, so I decided to fix this.

## The Problem
When something goes wrong during form submission:
- Form gets stuck loading forever
- All inputs stay disabled
- Can't submit again
- Users have no idea what went wrong
- Only way out is to reload the page

## The Fix
I've added proper error handling so now:
- Form recovers properly after an error
- All inputs become usable again
- You can retry submission
- Users see what went wrong
- Added tests to make sure it stays fixed

## Want to try it?
Check out the example I added:
1. Open the "Submit Promise Error" demo
2. Try submitting the form
3. You'll see it handles the error nicely now - shows the message and everything goes back to normal

Let me know what you think! Happy to adjust anything if needed.

Related: #1556