### PR TITLE
Update Dutch localization to use proper terms for next/previous

### DIFF
--- a/packages/i18n/src/locales/nl.ts
+++ b/packages/i18n/src/locales/nl.ts
@@ -59,11 +59,11 @@ const ui: FormKitLocaleMessages = {
   /**
    * Shown on buttons that navigate state forward
    */
-  next: 'Vervolgens',
+  next: 'Volgende',
   /**
    * Shown on buttons that navigate state backward
    */
-  prev: 'Voorgaand',
+  prev: 'Vorige',
   /**
    * Shown when adding all values.
    */


### PR DESCRIPTION
Hi!

Thanks for this awesome library :)

I noticed that in the Dutch localization, the terminology used for next & previous (as used in a multi-step form to navigate between steps) are not appropriate for this context. They are basically a very formal way of indicating this, not what a native Dutch person would be used to in this context.
I feel the [commit](https://github.com/formkit/formkit/commit/b79463ca9a195f22a132e4968afd28b36203d32a) introducing this is using machine translation, because it adds next/previous for a lot of languages in one go ;)