### PR TITLE
fix: Typo in spanish translation

### DIFF
--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -31,7 +31,7 @@ const ui: FormKitLocaleMessages = {
   /**
    * Shown when all fields are not filled out correctly.
    */
-  incomplete: 'Discúlpe, los campos no fueron completados correctamente.',
+  incomplete: 'Disculpe, los campos no fueron completados correctamente.',
   /**
    * Shown in a button inside a form to submit the form.
    */


### PR DESCRIPTION
Font: https://es.wiktionary.org/wiki/disculpe