### PR TITLE
Fix numeric comparison

### DIFF
--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -356,8 +356,8 @@ const validation: FormKitValidationMessages = {
    * @see {@link https://formkit.com/essentials/validation#length}
    */
   length({ name, args: [first = 0, second = Infinity] }) {
-    const min = first <= second ? first : second
-    const max = second >= first ? second : first
+    const min = Number(first) <= Number(second) ? first : second
+    const max = Number(second) >= Number(first) ? second : first
     if (min == 1 && max === Infinity) {
       /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
       return `${s(name)} muss mindestens ein Zeichen enthalten.`

--- a/packages/i18n/src/locales/fa.ts
+++ b/packages/i18n/src/locales/fa.ts
@@ -357,8 +357,8 @@ const validation: FormKitValidationMessages = {
    * @see {@link https://formkit.com/essentials/validation#length}
    */
   length({ name, args: [first = 0, second = Infinity] }) {
-    const min = first <= second ? first : second
-    const max = second >= first ? second : first
+    const min = Number(first) <= Number(second) ? first : second
+    const max = Number(second) >= Number(first) ? second : first
     if (min == 1 && max === Infinity) {
       /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
       return `${s(name)} باید حداقل یک کاراکتر باشد.`

--- a/packages/i18n/src/locales/hr.ts
+++ b/packages/i18n/src/locales/hr.ts
@@ -352,8 +352,8 @@ const validation: FormKitValidationMessages = {
    * @see {@link https://formkit.com/essentials/validation#length}
    */
   length({ name, args: [first = 0, second = Infinity] }) {
-    const min = first <= second ? first : second
-    const max = second >= first ? second : first
+    const min = Number(first) <= Number(second) ? first : second
+    const max = Number(second) >= Number(first) ? second : first
     if (min == 1 && max === Infinity) {
       /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
       return `${s(name)} mora sadržavati barem jedan znak.`

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -357,8 +357,8 @@ const validation: FormKitValidationMessages = {
    * @see {@link https://formkit.com/essentials/validation#length}
    */
   length({ name, args: [first = 0, second = Infinity] }) {
-    const min = first <= second ? first : second
-    const max = second >= first ? second : first
+    const min = Number(first) <= Number(second) ? first : second
+    const max = Number(second) >= Number(first) ? second : first
     if (min == 1 && max === Infinity) {
       /* <i18n case="Shown when the length of the user-provided value is not at least one character."> */
       return `${s(name)} precisa conter ao menos um caractere.`


### PR DESCRIPTION
This is a consolidation PR that adds the same logic for comparing the min and max values as in all other languages.

### Underlying bug
When you have a validation of `required|length:5,10` the validation error message in e.g. German stated that the field value has to be between MAX and MIN. Expected is ..."between MIN and MAX".