### PR TITLE
WIP: fix: cyclic dependencies in the workspace packages

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -41,8 +41,5 @@
   "dependencies": {
     "@formkit/core": "1.6.9",
     "@formkit/utils": "1.6.9"
-  },
-  "devDependencies": {
-    "@formkit/vue": "workspace:^"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@formkit/core": "1.6.9",
-    "@formkit/dev": "1.6.9",
     "@formkit/i18n": "1.6.9",
     "@formkit/inputs": "1.6.9",
     "@formkit/observer": "1.6.9",
@@ -56,6 +55,7 @@
     "vue": "^3.4.0"
   },
   "devDependencies": {
+    "@formkit/dev": "workspace:^",
     "@formkit/icons": "workspace:^"
   }
 }


### PR DESCRIPTION
After upgrading pnpm I have noticed a warn:

`WARN  There are cyclic workspace dependencies: /formkit/packages/dev, /formkit/packages/vue`