### PR TITLE
fix(vue): allow $cmp children to access parent scope data

### DIFF
--- a/packages/vue/__tests__/FormKitSchema.spec.ts
+++ b/packages/vue/__tests__/FormKitSchema.spec.ts
@@ -837,6 +837,45 @@ describe('parsing dom elements', () => {
     expect(wrapper.text()).not.toContain('options') // Should not contain the objects
   })
 
+  it('can access parent scope data in $cmp children (issue #1481)', async () => {
+    const SlotWrapper = defineComponent({
+      template: '<div class="wrapper"><slot /></div>',
+    })
+
+    const data = reactive({
+      value: { foo: 'bar' },
+    })
+
+    const wrapper = mount(FormKitSchema, {
+      props: {
+        data,
+        library: { SlotWrapper: markRaw(SlotWrapper) },
+        schema: [
+          {
+            $el: 'div',
+            attrs: { 'data-direct': true },
+            children: '$value.foo', // Should work
+          },
+          {
+            $cmp: 'SlotWrapper',
+            children: [
+              {
+                $el: 'div',
+                attrs: { 'data-in-cmp': true },
+                children: '$value.foo', // Bug: shows undefined
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    // Direct child should work
+    expect(wrapper.find('[data-direct]').text()).toBe('bar')
+    // Child inside $cmp should also work (currently fails)
+    expect(wrapper.find('[data-in-cmp]').text()).toBe('bar')
+  })
+
   it('can render functional data reactively', async () => {
     const data = reactive({
       price: 10,

--- a/packages/vue/src/FormKitSchema.ts
+++ b/packages/vue/src/FormKitSchema.ts
@@ -512,6 +512,14 @@ function parseSchema(
               // originally called this component's render function.
               const currentKey = instanceKey
               if (key) instanceKey = key
+              // Get parent scope and add it to new instance's scope so children
+              // can access parent scope data like $value (issue #1481)
+              const parentScope = instanceScopes.get(currentKey) || []
+              // Push parent scope items in reverse order to maintain priority
+              // (parent scope should have lowest priority)
+              for (let i = parentScope.length - 1; i >= 0; i--) {
+                instanceScopes.get(instanceKey)?.unshift(parentScope[i])
+              }
               if (iterationData)
                 instanceScopes.get(instanceKey)?.unshift(iterationData)
               if (slotData) instanceScopes.get(instanceKey)?.unshift(slotData)
@@ -519,6 +527,10 @@ function parseSchema(
               // Ensure our instance key never changed during runtime
               if (slotData) instanceScopes.get(instanceKey)?.shift()
               if (iterationData) instanceScopes.get(instanceKey)?.shift()
+              // Clean up: remove parent scope data
+              for (let i = 0; i < parentScope.length; i++) {
+                instanceScopes.get(instanceKey)?.shift()
+              }
               instanceKey = currentKey
               return c as RenderableList
             },


### PR DESCRIPTION
Fixes issue where children rendered inside a $cmp component's slot could not access parent scope variables like $value. The issue was that when switching instanceKey for slot rendering, the parent's scope data was not propagated to the new instance's scope.

Now parent scope data is properly copied to the slot's instance scope, allowing children to access variables like $value while maintaining proper scope priority (slotData > iterationData > parentScope).

Fixes #1481