### PR TITLE
fix(core): preserve buffered reset events

### DIFF
--- a/packages/core/__tests__/events.spec.ts
+++ b/packages/core/__tests__/events.spec.ts
@@ -2,6 +2,7 @@ import { createNode } from '../src/node'
 import { createShippingTree } from '../../../.tests/helpers'
 import { describe, expect, it, vi } from 'vitest'
 import { FormKitEvent } from '../src/events'
+import { createMessage } from '../src/store'
 
 describe('emitting and listening to events', () => {
   it('can emit an arbitrary event', () => {
@@ -114,6 +115,56 @@ describe('emitting and listening to events', () => {
     expect(foo).toHaveBeenCalledTimes(1)
     expect(bar).toHaveBeenCalledTimes(1)
     expect(foo).toHaveBeenCalledWith(expect.objectContaining({ payload: 223 }))
+  })
+
+  it('replays paused events separately for each origin', () => {
+    const parent = createNode({
+      type: 'group',
+      children: [createNode({ name: 'child' })],
+    })
+    const child = parent.at('child')!
+    const local = vi.fn()
+    const deep = vi.fn()
+
+    parent.on('foo', local)
+    parent.on('foo.deep', deep)
+
+    parent._e.pause(parent)
+    parent.emit('foo', 'parent')
+    child.emit('foo', 'child')
+    parent._e.play(parent)
+
+    expect(local).toHaveBeenCalledTimes(1)
+    expect(local).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: 'parent', origin: parent })
+    )
+    expect(deep).toHaveBeenCalledTimes(2)
+    expect(deep.mock.calls.map(([event]) => event.payload)).toEqual([
+      'parent',
+      'child',
+    ])
+  })
+
+  it('replays paused message events separately for each message key', () => {
+    const node = createNode()
+    const listener = vi.fn()
+
+    node.on('message-added', listener)
+
+    node._e.pause()
+    node.store.set(
+      createMessage({ key: 'first', value: true, visible: false }, node)
+    )
+    node.store.set(
+      createMessage({ key: 'second', value: true, visible: false }, node)
+    )
+    node._e.play()
+
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener.mock.calls.map(([event]) => event.payload.key)).toEqual([
+      'first',
+      'second',
+    ])
   })
 
   it('can emit an event with custom meta', () => {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -65,11 +65,28 @@ export interface FormKitEventEmitter {
 export function createEmitter(): FormKitEventEmitter {
   const listeners = new Map<string, FormKitEventListenerWrapper[]>()
   const receipts = new Map<string, string[]>()
+  const originIds = new WeakMap<FormKitNode, number>()
+  let originCounter = 0
   let buffer: undefined | Map<string, [FormKitNode, FormKitEvent]> = undefined
+
+  const eventKey = (event: FormKitEvent) => {
+    let originId = originIds.get(event.origin)
+    if (originId === undefined) {
+      originId = ++originCounter
+      originIds.set(event.origin, originId)
+    }
+    const payloadKey =
+      event.payload &&
+      typeof event.payload === 'object' &&
+      'key' in event.payload
+        ? `:${String(event.payload.key)}`
+        : ''
+    return `${event.name}:${originId}${payloadKey}`
+  }
 
   const emitter = (node: FormKitNode, event: FormKitEvent) => {
     if (buffer) {
-      buffer.set(event.name, [node, event])
+      buffer.set(eventKey(event), [node, event])
       return
     }
     if (listeners.has(event.name)) {

--- a/packages/vue/__tests__/inputs/form.spec.ts
+++ b/packages/vue/__tests__/inputs/form.spec.ts
@@ -747,6 +747,56 @@ describe('form submission', () => {
     expect(isDirty(id)).toBe(false)
   })
 
+  it('updates nested group dirty state after resetting with a new value (#1687)', async () => {
+    const formId = `form_${token()}`
+    const groupId = `group_${token()}`
+    const inputId = `input_${token()}`
+    const config = defaultConfig({
+      props: {
+        dirtyBehavior: 'compare',
+      },
+    })
+    mount(
+      {
+        template: /* html */ `<FormKit id="${formId}" type="form">
+        <FormKit id="${groupId}" type="group" name="user">
+          <FormKit type="text" name="name" id="${inputId}" value="123" :delay="0" />
+        </FormKit>
+      </FormKit>`,
+      },
+      {
+        global: {
+          plugins: [[plugin, config]],
+        },
+      }
+    )
+
+    const isDirty = (id: string) => getNode(id)?.context?.state.dirty
+    const form = getNode(formId)!
+    const input = getNode(inputId)!
+
+    form.reset({ user: { name: 'reset' } })
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(isDirty(formId)).toBe(false)
+    expect(isDirty(groupId)).toBe(false)
+    expect(isDirty(inputId)).toBe(false)
+
+    await input.input('changed', false)
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(isDirty(formId)).toBe(true)
+    expect(isDirty(groupId)).toBe(true)
+    expect(isDirty(inputId)).toBe(true)
+
+    await input.input('reset', false)
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(isDirty(formId)).toBe(false)
+    expect(isDirty(groupId)).toBe(false)
+    expect(isDirty(inputId)).toBe(false)
+  })
+
   it('keeps data with preserve prop', async () => {
     const wrapper = mount(
       defineComponent({


### PR DESCRIPTION
## Summary
- preserve paused core events per origin/message key instead of collapsing everything by event name
- add regressions for paused event replay in core
- add a Vue regression for nested group dirty state after reset payload changes

## Testing
- pnpm exec vitest run packages/core/__tests__/events.spec.ts
- programmatic Vitest run of packages/vue/__tests__/inputs/form.spec.ts with workspace aliases

Refs #1687
Related to #1648