### PR TITLE
fix(core): avoid repeated reset input hooks

### DIFF
--- a/packages/core/__tests__/node.spec.ts
+++ b/packages/core/__tests__/node.spec.ts
@@ -1570,6 +1570,20 @@ describe('resetting', () => {
     expect(user!.props._init).toEqual({ name: 'abc' })
   })
 
+  it('calls input hooks once with the final value during deep reset (#1699)', () => {
+    const node = createNode({
+      type: 'group',
+      children: [createNode({ name: 'name', value: 'old value' })],
+    })
+    const inputHook = vi.fn((value, next) => next(value))
+
+    node.at('name')!.hook.input(inputHook)
+    node.reset({ name: 'new value' })
+
+    expect(inputHook.mock.calls.map(([value]) => value)).toEqual(['new value'])
+    expect(node.value).toEqual({ name: 'new value' })
+  })
+
   it('can reset to initial value false', async () => {
     const node = createNode({ value: false })
     node.reset()

--- a/packages/core/src/reset.ts
+++ b/packages/core/src/reset.ts
@@ -26,6 +26,26 @@ function clearState(node: FormKitNode) {
   node.walk(clear)
 }
 
+const missingResetValue = Symbol('missingResetValue')
+
+function valueAtResetAddress(
+  value: unknown,
+  address: Array<string | number>
+): unknown | typeof missingResetValue {
+  let current = value
+  for (const segment of address) {
+    if (
+      current === null ||
+      typeof current !== 'object' ||
+      !(segment in current)
+    ) {
+      return missingResetValue
+    }
+    current = (current as Record<string | number, unknown>)[segment]
+  }
+  return current
+}
+
 /**
  * Resets an input to its "initial" value. If the input is a group or list it
  * resets all the children as well.
@@ -55,12 +75,24 @@ export function reset(
     node._e.pause(node)
     // Set it back to basics
     const resetValue = cloneAny(resetTo)
-    if (resetTo && !empty(resetTo)) {
+    const isDeepReset =
+      node.type !== 'input' && resetTo && !empty(resetTo) && isObject(resetTo)
+    if (isDeepReset) {
       node.props.initial = isObject(resetValue) ? init(resetValue) : resetValue
       node.props._init = node.props.initial
+      node.walk((child) => {
+        const resetAddress = child.address.slice(node.address.length)
+        const childResetValue = valueAtResetAddress(resetValue, resetAddress)
+        const nextInitial =
+          childResetValue === missingResetValue
+            ? initial(child)
+            : cloneAny(childResetValue)
+        child.props.initial = isObject(nextInitial)
+          ? init(nextInitial)
+          : nextInitial
+        child.props._init = child.props.initial
+      })
     }
-
-    node.input(initial(node), false)
 
     // Set children back to basics in case they were additive (had their own value for example)
     node.walk((child) => {
@@ -77,8 +109,6 @@ export function reset(
 
     // If this is a deep reset, we need to make sure the "initial" state of all
     // children are also reset. Fixes https://github.com/formkit/formkit/issues/791#issuecomment-1651213253
-    const isDeepReset =
-      node.type !== 'input' && resetTo && !empty(resetTo) && isObject(resetTo)
     if (isDeepReset) {
       node.walk((child) => {
         // Clone the value so deep comparisons (e.g., dirty checks) work correctly.


### PR DESCRIPTION
## Summary
- remove the redundant first reset pass that caused deep resets to send transient values through child input hooks
- pre-seed deep-reset child initials before resetting so reset hooks observe the final value
- add a core regression that reproduces the reported `new -> old -> new` hook sequence

## Testing
- pnpm exec vitest run packages/core/__tests__/node.spec.ts
- programmatic Vitest run of packages/vue/__tests__/inputs/form.spec.ts with workspace aliases

Refs #1699