### PR TITLE
fix(core): preserve reset invalid state

### DIFF
--- a/packages/core/src/reset.ts
+++ b/packages/core/src/reset.ts
@@ -10,6 +10,9 @@ import { getNode } from './registry'
  */
 function clearState(node: FormKitNode) {
   const clear = (n: FormKitNode) => {
+    const hasValidationMessages = Object.values(n.store).some(
+      (message) => message.type === 'validation'
+    )
     for (const key in n.store) {
       const message = n.store[key]
       if (
@@ -18,7 +21,10 @@ function clearState(node: FormKitNode) {
       ) {
         n.store.remove(key)
       } else if (message.type === 'state') {
-        n.store.set({ ...message, value: false })
+        n.store.set({
+          ...message,
+          value: key === 'failing' ? hasValidationMessages : false,
+        })
       }
     }
   }

--- a/packages/vue/__tests__/inputs/form.spec.ts
+++ b/packages/vue/__tests__/inputs/form.spec.ts
@@ -1168,6 +1168,39 @@ describe('programmatic submission', () => {
 })
 
 describe('resetting', () => {
+  it('restores invalid state after reset and resubmission (#1630)', async () => {
+    const formId = token()
+    const wrapper = mount(
+      defineComponent({
+        template: `
+        <FormKit type="form" id="${formId}" :actions="false">
+          <FormKit type="text" name="first" validation="required" :delay="0" />
+          <FormKit type="text" name="second" validation="required" :delay="0" />
+        </FormKit>`,
+      }),
+      global
+    )
+
+    const outers = () => wrapper.findAll('.formkit-outer')
+    const inputs = () => wrapper.findAll('input')
+
+    inputs()[0].setValue('abc')
+    await new Promise((r) => setTimeout(r, 10))
+    wrapper.find('form').trigger('submit')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(outers()[0].attributes('data-invalid')).toBe(undefined)
+    expect(outers()[1].attributes('data-invalid')).toBe('true')
+
+    getNode(formId)!.reset()
+    await new Promise((r) => setTimeout(r, 10))
+    wrapper.find('form').trigger('submit')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(outers()[0].attributes('data-invalid')).toBe('true')
+    expect(outers()[1].attributes('data-invalid')).toBe('true')
+  })
+
   it('can be reset to a specific value', async () => {
     const submitHandler = vi.fn()
     const formId = token()


### PR DESCRIPTION
## Summary
- preserve the `failing` state for nodes that still have validation messages after reset
- add a Vue regression for resubmitting a reset form and restoring both invalid wrappers
- keep reset behavior unchanged for other state flags while ensuring invalid DOM state can recover on the next submit

## Testing
- node --input-type=module -e "import { startVitest } from "vitest/node"; import { resolve } from "node:path"; const alias = { "@formkit/core": resolve("packages/core/src/index.ts"), "@formkit/inputs": resolve("packages/inputs/src/index.ts"), "@formkit/utils": resolve("packages/utils/src/index.ts"), "@formkit/i18n": resolve("packages/i18n/src/index.ts"), "@formkit/validation": resolve("packages/validation/src/index.ts"), "@formkit/rules": resolve("packages/rules/src/index.ts"), "@formkit/themes": resolve("packages/themes/src/index.ts"), "@formkit/observer": resolve("packages/observer/src/index.ts"), "@formkit/dev": resolve("packages/dev/src/index.ts") }; const ctx = await startVitest("test", ["packages/vue/__tests__/inputs/form.spec.ts"], { run: true }, { resolve: { alias } }); const failed = ctx?.state.getCountOfFailedTests?.() ?? 0; await ctx?.close(); process.exit(failed ? 1 : 0);"
- pnpm exec vitest run packages/core/__tests__/node.spec.ts

Refs #1630