### PR TITLE
fix(inputs): preserve partial negative number input

### DIFF
--- a/packages/inputs/src/features/casts.ts
+++ b/packages/inputs/src/features/casts.ts
@@ -12,6 +12,19 @@ export default function casts(node: FormKitNode): void {
   const strict = ['number', 'range', 'hidden'].includes(node.props.type)
   node.hook.input((value, next) => {
     if (value === '') return next(undefined)
+    if (
+      strict &&
+      typeof value === 'string' &&
+      (value === '-' ||
+        value === '+' ||
+        value === '.' ||
+        value === '-.' ||
+        value === '+.' ||
+        value === '-0' ||
+        value.endsWith('.'))
+    ) {
+      return next(value)
+    }
     const numericValue =
       node.props.number === 'integer' ? parseInt(value) : parseFloat(value)
     if (!Number.isFinite(numericValue))

--- a/packages/vue/__tests__/inputs/text.spec.ts
+++ b/packages/vue/__tests__/inputs/text.spec.ts
@@ -294,6 +294,36 @@ describe('the number feature', () => {
     const node = getNode(id)!
     expect(node.value).toBe(12345)
   })
+  it('allows negative decimals to be typed on number inputs (#1671)', async () => {
+    const id = `a${token()}`
+    mount(FormKit, {
+      props: {
+        id,
+        type: 'number',
+        number: true,
+        delay: 0,
+      },
+      ...global,
+    })
+    const node = getNode(id)!
+    const domInput = node.context!.handlers.DOMInput
+
+    domInput({ target: { value: '-' } } as unknown as Event)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(node.value).toBe('-')
+
+    domInput({ target: { value: '-0' } } as unknown as Event)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(node.value).toBe('-0')
+
+    domInput({ target: { value: '-0.' } } as unknown as Event)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(node.value).toBe('-0.')
+
+    domInput({ target: { value: '-0.5' } } as unknown as Event)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(node.value).toBe(-0.5)
+  })
   it('knows when it is mounted', async () => {
     const wrapper = mount(FormKit, {
       props: {


### PR DESCRIPTION
## Summary
- preserve transient numeric strings like `-`, `-0`, and values ending in `.` on strict number inputs
- keep final committed values numeric once the user completes the decimal entry
- add a Vue regression that reproduces the negative-decimal typing path through the DOM input handler

## Testing
- node --input-type=module -e "import { startVitest } from "vitest/node"; import { resolve } from "node:path"; const alias = { "@formkit/core": resolve("packages/core/src/index.ts"), "@formkit/inputs": resolve("packages/inputs/src/index.ts"), "@formkit/utils": resolve("packages/utils/src/index.ts"), "@formkit/i18n": resolve("packages/i18n/src/index.ts"), "@formkit/validation": resolve("packages/validation/src/index.ts"), "@formkit/rules": resolve("packages/rules/src/index.ts"), "@formkit/themes": resolve("packages/themes/src/index.ts"), "@formkit/observer": resolve("packages/observer/src/index.ts"), "@formkit/dev": resolve("packages/dev/src/index.ts") }; const ctx = await startVitest("test", ["packages/vue/__tests__/inputs/text.spec.ts"], { run: true }, { resolve: { alias } }); const failed = ctx?.state.getCountOfFailedTests?.() ?? 0; await ctx?.close(); process.exit(failed ? 1 : 0);"
- node --input-type=module -e "import { startVitest } from "vitest/node"; import { resolve } from "node:path"; const alias = { "@formkit/core": resolve("packages/core/src/index.ts"), "@formkit/inputs": resolve("packages/inputs/src/index.ts"), "@formkit/utils": resolve("packages/utils/src/index.ts"), "@formkit/i18n": resolve("packages/i18n/src/index.ts"), "@formkit/validation": resolve("packages/validation/src/index.ts"), "@formkit/rules": resolve("packages/rules/src/index.ts"), "@formkit/themes": resolve("packages/themes/src/index.ts"), "@formkit/observer": resolve("packages/observer/src/index.ts"), "@formkit/dev": resolve("packages/dev/src/index.ts") }; const ctx = await startVitest("test", ["packages/vue/__tests__/inputs/form.spec.ts"], { run: true }, { resolve: { alias } }); const failed = ctx?.state.getCountOfFailedTests?.() ?? 0; await ctx?.close(); process.exit(failed ? 1 : 0);"

Refs #1671