### PR TITLE
fix: render plugin-assigned icon props

### DIFF
--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -137,6 +137,14 @@ export const iconRegistry: Record<string, string | undefined> = {}
  * A collection of existing icon requests to avoid duplicate fetching
  */
 const iconRequests: Record<string, any> = {}
+const iconPattern = /^[a-zA-Z-]+(?:-icon|Icon)$/
+const observedIconProps = new WeakMap<FormKitNode, Set<string>>()
+
+function normalizeIconProp(sectionKey: string): string {
+  return sectionKey.replace(/-([a-zA-Z])/g, (_, char: string) =>
+    char.toUpperCase()
+  )
+}
 
 /**
  * Creates the theme plugin based on a given theme name.
@@ -184,6 +192,21 @@ export function createThemePlugin(
       node.props?.iconLoaderUrl ? node.props.iconLoaderUrl : iconLoaderUrl
     )
     loadIconPropIcons(node, node.props.iconHandler)
+    node.on('added-props', ({ payload }) => {
+      if (!node.props.iconHandler) return
+      const props = Array.isArray(payload) ? payload : Object.keys(payload ?? {})
+      props.forEach((prop) => {
+        if (typeof prop === 'string' && iconPattern.test(prop)) {
+          observeIconProp(node, node.props.iconHandler, prop)
+        }
+      })
+    })
+    node.on('prop', ({ payload }) => {
+      if (!node.props.iconHandler || typeof payload?.prop !== 'string') return
+      if (iconPattern.test(payload.prop)) {
+        observeIconProp(node, node.props.iconHandler, payload.prop)
+      }
+    })
 
     node.on('created', () => {
       // set up the `-icon` click handlers
@@ -400,13 +423,27 @@ function loadIconPropIcons(
   node: FormKitNode,
   iconHandler: FormKitIconLoader
 ): void {
-  const iconRegex = /^[a-zA-Z-]+(?:-icon|Icon)$/
   const iconProps = Object.keys(node.props).filter((prop) => {
-    return iconRegex.test(prop)
+    return iconPattern.test(prop)
   })
   iconProps.forEach((sectionKey) => {
-    return loadPropIcon(node, iconHandler, sectionKey)
+    return observeIconProp(node, iconHandler, sectionKey)
   })
+}
+
+function observeIconProp(
+  node: FormKitNode,
+  iconHandler: FormKitIconLoader,
+  sectionKey: string
+): void {
+  const normalizedSectionKey = normalizeIconProp(sectionKey)
+  if (!observedIconProps.has(node)) {
+    observedIconProps.set(node, new Set())
+  }
+  const observedProps = observedIconProps.get(node)!
+  if (observedProps.has(normalizedSectionKey)) return
+  observedProps.add(normalizedSectionKey)
+  loadPropIcon(node, iconHandler, normalizedSectionKey)
 }
 
 /**

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1678,6 +1678,30 @@ describe('icons', () => {
     await new Promise((r) => setTimeout(r, 10))
     expect(iconClick).toHaveBeenCalledTimes(1)
   })
+
+  it('renders icons assigned by a plugin after theme setup (#1695)', async () => {
+    const assignPrefixIcon = (node: FormKitNode) => {
+      if (node.props.type === 'password') {
+        node.props.prefixIcon = 'star'
+      }
+    }
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'password',
+        plugins: [assignPrefixIcon],
+      },
+      global: {
+        plugins: [[plugin, defaultConfig({ icons: { star } })]],
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.html()).toContain(
+      `<label class="formkit-prefix-icon formkit-icon"`
+    )
+    expect(wrapper.html()).toContain(`data-prefix-icon="true"`)
+  })
 })
 
 describe('prefix and suffix', () => {
@@ -2702,6 +2726,7 @@ describe('naked attributes', () => {
       props: {
         type: 'text',
         name: 'table_stakes',
+        id: 'clickable-icon-accessibility',
         suffixIcon: 'star',
         onSuffixIconClick: handler,
       },

--- a/packages/vue/__tests__/__snapshots__/FormKit.spec.ts.snap
+++ b/packages/vue/__tests__/__snapshots__/FormKit.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`naked attributes > outputs accessibility attributes on clickable icons 
     <!---->
     <div class="formkit-inner">
       <!---->
-      <!----><input class="formkit-input" type="text" name="table_stakes" id="input_121">
+      <!----><input class="formkit-input" type="text" name="table_stakes" id="clickable-icon-accessibility">
       <!----><span class="formkit-suffix-icon formkit-icon" role="button" tabindex="0"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 15"><path fill="currentColor" d="M11.41,8.41h0l1.14-.93,1.14-.93c.48-.39,.37-.74-.25-.77l-1.58-.09-2.5-.14-.41-1.05s0,0,0,0l-.53-1.38-.53-1.38c-.22-.58-.59-.58-.81,0l-1.07,2.75s0,0,0,0l-.41,1.05-2.5,.14-1.58,.09c-.62,.03-.73,.38-.25,.77l1.14,.93,1.14,.93h0l.87,.71-.57,2.15-.47,1.79c-.16,.6,.14,.81,.66,.48l2.48-1.6h0s.94-.61,.94-.61l.94,.61h0s1.24,.8,1.24,.8l1.24,.8c.52,.33,.82,.12,.66-.48l-.47-1.79-.57-2.15,.87-.71Z"></path></svg></span>
     </div>
   </div>

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -383,6 +383,8 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
       'preserveErrors',
       'id',
       'dirtyBehavior',
+      'prefixIcon',
+      'suffixIcon',
     ]
     const iconPattern = /^[a-zA-Z-]+(?:-icon|Icon)$/
     const matchingProps = Object.keys(node.props).filter((prop) => {


### PR DESCRIPTION
## Summary
- observe built-in icon props even when plugins assign them after node creation
- lazily register icon prop loaders in the theme plugin when icon props appear later
- add a Vue regression for plugin-assigned `prefixIcon` and stabilize the clickable icon snapshot id

Closes #1695

## Testing
- node --input-type=module -e "import { startVitest } from 'vitest/node'; import { resolve } from 'node:path'; const alias = { '@formkit/core': resolve('packages/core/src/index.ts'), '@formkit/inputs': resolve('packages/inputs/src/index.ts'), '@formkit/utils': resolve('packages/utils/src/index.ts'), '@formkit/i18n': resolve('packages/i18n/src/index.ts'), '@formkit/validation': resolve('packages/validation/src/index.ts'), '@formkit/rules': resolve('packages/rules/src/index.ts'), '@formkit/themes': resolve('packages/themes/src/index.ts'), '@formkit/observer': resolve('packages/observer/src/index.ts'), '@formkit/dev': resolve('packages/dev/src/index.ts'), '@formkit/icons': resolve('packages/icons/src/index.ts') }; const ctx = await startVitest('test', ['packages/vue/__tests__/FormKit.spec.ts', 'packages/vue/__tests__/plugin.spec.ts'], { run: true }, { resolve: { alias } }); const failed = ctx?.state.getCountOfFailedTests?.() ?? 0; await ctx?.close(); process.exit(failed ? 1 : 0);"