### PR TITLE
fix: avoid step validation on back navigation

### DIFF
--- a/packages/addons/__tests__/multistep.spec.ts
+++ b/packages/addons/__tests__/multistep.spec.ts
@@ -65,6 +65,36 @@ const multiStepSchemaBasicWithProps = [
   },
 ]
 
+const multiStepSchemaWithRequiredSecondStep = [
+  {
+    $formkit: 'multi-step',
+    children: [
+      {
+        $formkit: 'step',
+        name: 'stepOne',
+        children: [
+          {
+            $formkit: 'text',
+            name: 'firstName',
+            validation: 'required',
+          },
+        ],
+      },
+      {
+        $formkit: 'step',
+        name: 'stepTwo',
+        children: [
+          {
+            $formkit: 'text',
+            name: 'lastName',
+            validation: 'required',
+          },
+        ],
+      },
+    ],
+  },
+]
+
 describe('multistep', () => {
   beforeEach(() => {
     resetCount()
@@ -376,6 +406,47 @@ describe('multistep', () => {
       'Step Bravo<',
       'Step Charlie<',
     ])
+    wrapper.unmount()
+  })
+
+  it('does not show validation on a later step after navigating back (#1696)', async () => {
+    const wrapper = mount(FormKitSchema, {
+      props: {
+        schema: multiStepSchemaWithRequiredSecondStep,
+      },
+      attachTo: document.body,
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              plugins: [createMultiStepPlugin()],
+            }),
+          ],
+        ],
+      },
+    })
+
+    const lastNameOuter = () =>
+      wrapper
+        .find('input[name="lastName"]')
+        .element.closest('.formkit-outer') as HTMLElement
+
+    await new Promise((r) => setTimeout(r, 15))
+    await wrapper.find('input[name="firstName"]').setValue('Ada')
+    wrapper.find('.formkit-step-next button').trigger('click')
+    await new Promise((r) => setTimeout(r, 15))
+    expect(lastNameOuter().getAttribute('data-invalid')).toBe(null)
+    expect(lastNameOuter().getAttribute('data-submitted')).toBe(null)
+
+    wrapper.find('.formkit-step-previous button').trigger('click')
+    await new Promise((r) => setTimeout(r, 15))
+    await wrapper.find('input[name="firstName"]').setValue('')
+    wrapper.find('.formkit-step-next button').trigger('click')
+    await new Promise((r) => setTimeout(r, 15))
+
+    expect(lastNameOuter().getAttribute('data-invalid')).toBe(null)
+    expect(lastNameOuter().getAttribute('data-submitted')).toBe(null)
     wrapper.unmount()
   })
 })

--- a/packages/addons/src/plugins/multiStep/multiStepPlugin.ts
+++ b/packages/addons/src/plugins/multiStep/multiStepPlugin.ts
@@ -287,13 +287,11 @@ async function isTargetStepAllowed(
   const currentStepIndex = parentNode?.props.steps.indexOf(currentStep)
   const targetStepIndex = parentNode?.props.steps.indexOf(targetStep)
 
-  // show the current step errors because this step has
-  // been visited.
-  const currentStepIsValid = triggerStepValidations(currentStep)
-  currentStep.showStepErrors = true
-
   // if we are navigating forward, check our current step is complete
   if (targetStepIndex >= currentStepIndex) {
+    // show the current step errors because the user is advancing past it.
+    const currentStepIsValid = triggerStepValidations(currentStep)
+    currentStep.showStepErrors = true
     // if the current step is invalid and we do not allow incomplete
     // then prevent navigation
     if (!currentStepIsValid && !allowIncomplete) {


### PR DESCRIPTION
## Summary
- only trigger step validations when users move forward in the multistep flow
- avoid marking the current step as submitted when navigating backward
- add a regression for revisiting a later required step after moving back and changing an earlier step

Closes #1696

## Testing
- node --input-type=module -e "import { startVitest } from 'vitest/node'; import { resolve } from 'node:path'; const alias = { '@formkit/core': resolve('packages/core/src/index.ts'), '@formkit/inputs': resolve('packages/inputs/src/index.ts'), '@formkit/utils': resolve('packages/utils/src/index.ts'), '@formkit/i18n': resolve('packages/i18n/src/index.ts'), '@formkit/validation': resolve('packages/validation/src/index.ts'), '@formkit/rules': resolve('packages/rules/src/index.ts'), '@formkit/themes': resolve('packages/themes/src/index.ts'), '@formkit/observer': resolve('packages/observer/src/index.ts'), '@formkit/dev': resolve('packages/dev/src/index.ts'), '@formkit/icons': resolve('packages/icons/src/index.ts'), '@formkit/vue': resolve('packages/vue/src/index.ts'), '@formkit/addons': resolve('packages/addons/src/index.ts') }; const ctx = await startVitest('test', ['packages/addons/__tests__/multistep.spec.ts'], { run: true }, { resolve: { alias } }); const failed = ctx?.state.getCountOfFailedTests?.() ?? 0; await ctx?.close(); process.exit(failed ? 1 : 0);"