### PR TITLE
fix: clear unchanged radio selections

### DIFF
--- a/packages/vue/__tests__/inputs/radio.spec.ts
+++ b/packages/vue/__tests__/inputs/radio.spec.ts
@@ -115,6 +115,40 @@ describe('radios', () => {
     ).toStrictEqual([true, false, false])
   })
 
+  it('clears the checked state when resetting an unchanged initial value (#1637)', async () => {
+    const id = token()
+    const wrapper = mount(
+      {
+        data() {
+          return {
+            value: 'B',
+          }
+        },
+        template: `<FormKit id="${id}" :delay="0" v-model="value" type="radio" :options="[
+          'A',
+          'B',
+          'C'
+        ]" />`,
+      },
+      {
+        ...global,
+      }
+    )
+
+    const radios = wrapper.get('div').findAll('input[type="radio"]')
+    expect(
+      radios.map((radio) => (radio.element as HTMLInputElement).checked)
+    ).toStrictEqual([false, true, false])
+
+    wrapper.vm.value = undefined
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(
+      radios.map((radio) => (radio.element as HTMLInputElement).checked)
+    ).toStrictEqual([false, false, false])
+    expect(getNode(id)?.value).toBe(undefined)
+  })
+
   it('can have an object value', async () => {
     const id = token()
     const wrapper = mount(

--- a/packages/vue/src/composables/useInput.ts
+++ b/packages/vue/src/composables/useInput.ts
@@ -438,7 +438,7 @@ export function useInput<
 
   // let inputTimeout: number | undefined
 
-  let clonedValueBeforeVmodel: unknown = undefined
+  let clonedValueBeforeVmodel: unknown = cloneAny(value)
   /**
    * Explicitly watch the input value, and emit changes (lazy)
    */


### PR DESCRIPTION
## Summary
- initialize the Vue v-model echo guard from the initial model value instead of `undefined`
- allow parent-driven clears back to `undefined` even when a radio selection never changed after mount
- add a radio regression for clearing an unchanged initial selection

Closes #1637

## Testing
- node --input-type=module -e "import { startVitest } from 'vitest/node'; import { resolve } from 'node:path'; const alias = { '@formkit/core': resolve('packages/core/src/index.ts'), '@formkit/inputs': resolve('packages/inputs/src/index.ts'), '@formkit/utils': resolve('packages/utils/src/index.ts'), '@formkit/i18n': resolve('packages/i18n/src/index.ts'), '@formkit/validation': resolve('packages/validation/src/index.ts'), '@formkit/rules': resolve('packages/rules/src/index.ts'), '@formkit/themes': resolve('packages/themes/src/index.ts'), '@formkit/observer': resolve('packages/observer/src/index.ts'), '@formkit/dev': resolve('packages/dev/src/index.ts'), '@formkit/icons': resolve('packages/icons/src/index.ts') }; const ctx = await startVitest('test', ['packages/vue/__tests__/inputs/radio.spec.ts', 'packages/vue/__tests__/FormKit.spec.ts'], { run: true }, { resolve: { alias } }); const failed = ctx?.state.getCountOfFailedTests?.() ?? 0; await ctx?.close(); process.exit(failed ? 1 : 0);"