### PR TITLE
fix: pass radio change handlers to options

### DIFF
--- a/packages/inputs/src/inputs/radio.ts
+++ b/packages/inputs/src/inputs/radio.ts
@@ -59,6 +59,7 @@ export const radio: FormKitTypeDefinition = {
                   bind: '$option.attrs',
                   attrs: {
                     id: '$option.attrs.id',
+                    onChange: '$attrs.onChange',
                     value: '$option.value',
                     checked: '$fns.isChecked($option.value)',
                   },

--- a/packages/vue/__tests__/inputs/radio.spec.ts
+++ b/packages/vue/__tests__/inputs/radio.spec.ts
@@ -79,6 +79,25 @@ describe('radios', () => {
     expect(warning).toHaveBeenCalledTimes(1)
   })
 
+  it('passes onChange handlers through to option radios (#1612)', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'radio',
+        options: ['A', 'B', 'C'],
+        onChange,
+      },
+      ...global,
+    })
+
+    const radios = wrapper.get('fieldset').findAll('input[type="radio"]')
+    radios[1].element.checked = true
+    radios[1].trigger('change')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
   it('changes the selected radios when value is set on node', async () => {
     const id = token()
     const wrapper = mount(


### PR DESCRIPTION
## Summary
- pass root `onChange` handlers through to multi-option radio inputs
- keep the existing single-radio `$attrs` path unchanged
- add a regression covering `onChange` on radio options, which is the path used by merge-strategy radio setups

Closes #1612

## Testing
- node --input-type=module -e "import { startVitest } from 'vitest/node'; import { resolve } from 'node:path'; const alias = { '@formkit/core': resolve('packages/core/src/index.ts'), '@formkit/inputs': resolve('packages/inputs/src/index.ts'), '@formkit/utils': resolve('packages/utils/src/index.ts'), '@formkit/i18n': resolve('packages/i18n/src/index.ts'), '@formkit/validation': resolve('packages/validation/src/index.ts'), '@formkit/rules': resolve('packages/rules/src/index.ts'), '@formkit/themes': resolve('packages/themes/src/index.ts'), '@formkit/observer': resolve('packages/observer/src/index.ts'), '@formkit/dev': resolve('packages/dev/src/index.ts'), '@formkit/icons': resolve('packages/icons/src/index.ts') }; const ctx = await startVitest('test', ['packages/vue/__tests__/inputs/radio.spec.ts', 'packages/vue/__tests__/FormKit.spec.ts'], { run: true }, { resolve: { alias } }); const failed = ctx?.state.getCountOfFailedTests?.() ?? 0; await ctx?.close(); process.exit(failed ? 1 : 0);"