### PR TITLE
fix: stop schema tail fallback on missing props

### DIFF
--- a/packages/core/__tests__/compiler.spec.ts
+++ b/packages/core/__tests__/compiler.spec.ts
@@ -344,6 +344,17 @@ describe('logic compiler', () => {
     ).toBe('foo')
   })
 
+  it('returns undefined when a function tail accesses missing nested properties (#1657)', () => {
+    const data: Record<string, any> = {
+      get: () => ({ value: { name: 'Name' } }),
+    }
+    expect(
+      compile('$get(test).value.test.test.test.name').provide(([token]) => {
+        return { [token]: () => data[token] }
+      })()
+    ).toBe(undefined)
+  })
+
   it('can call a function on a tail', () => {
     const data: Record<string, any> = {
       add: (a: number) => ({

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -1,4 +1,4 @@
-import { isQuotedString, rmEscapes, parseArgs, getAt } from '@formkit/utils'
+import { has, isQuotedString, rmEscapes, parseArgs } from '@formkit/utils'
 import { warn, error } from './errors'
 
 /**
@@ -60,6 +60,23 @@ type LogicOperator = (
  */
 interface LogicOperators {
   [index: string]: LogicOperator
+}
+
+function getTailValue(obj: any, addr: string): unknown {
+  if (!obj || typeof obj !== 'object') return null
+  const segments = addr.split('.')
+  let current = obj
+  for (const i in segments) {
+    const segment = segments[i]
+    if (!has(current, segment)) return undefined
+    const value = current[segment]
+    if (+i === segments.length - 1) {
+      return typeof value === 'function' ? value.bind(current) : value
+    }
+    if (!value || typeof value !== 'object') return undefined
+    current = value
+  }
+  return undefined
 }
 
 /**
@@ -480,7 +497,7 @@ export function compile(expr: string): FormKitCompilerOutput {
                 (tokenSet: Record<string, any>, token: string) => {
                   const isTail = token === tail || tail?.startsWith(`${token}(`)
                   if (isTail) {
-                    const value = getAt(userFuncReturn, token)
+                    const value = getTailValue(userFuncReturn, token)
                     tokenSet[token] = () => value
                   } else {
                     tokenSet[token] = rootTokens[token]

--- a/packages/vue/__tests__/FormKitSchema.spec.ts
+++ b/packages/vue/__tests__/FormKitSchema.spec.ts
@@ -1558,6 +1558,21 @@ describe('schema $get function', () => {
     await new Promise((r) => setTimeout(r, 5))
     expect(wrapper.html()).toBe('15')
   })
+
+  it('returns undefined when a $get tail accesses missing nested properties (#1657)', () => {
+    createNode({
+      type: 'input',
+      plugins: [corePlugin],
+      props: { id: 'test' },
+      value: { name: 'Name' },
+    })
+    const wrapper = mount(FormKitSchema, {
+      props: {
+        schema: ['$get(test).value.test.test.test.name'],
+      },
+    })
+    expect(wrapper.html()).toBe('undefined')
+  })
 })
 
 describe('$reset', () => {


### PR DESCRIPTION
## Summary
- stop compiled schema tail access from falling back to the last existing object when nested properties are missing
- preserve the existing `null` behavior for unresolved `$get(id)` roots before a node is registered
- add compiler and `FormKitSchema` regressions for missing nested `$get(...).value` access

Closes #1657

## Testing
- node --input-type=module -e "import { startVitest } from 'vitest/node'; import { resolve } from 'node:path'; const alias = { '@formkit/core': resolve('packages/core/src/index.ts'), '@formkit/inputs': resolve('packages/inputs/src/index.ts'), '@formkit/utils': resolve('packages/utils/src/index.ts'), '@formkit/i18n': resolve('packages/i18n/src/index.ts'), '@formkit/validation': resolve('packages/validation/src/index.ts'), '@formkit/rules': resolve('packages/rules/src/index.ts'), '@formkit/themes': resolve('packages/themes/src/index.ts'), '@formkit/observer': resolve('packages/observer/src/index.ts'), '@formkit/dev': resolve('packages/dev/src/index.ts'), '@formkit/icons': resolve('packages/icons/src/index.ts') }; const ctx = await startVitest('test', ['packages/core/__tests__/compiler.spec.ts', 'packages/vue/__tests__/FormKitSchema.spec.ts'], { run: true }, { resolve: { alias } }); const failed = ctx?.state.getCountOfFailedTests?.() ?? 0; await ctx?.close(); process.exit(failed ? 1 : 0);"