### PR TITLE
fix: normalize strict number input DOM values

### DIFF
--- a/packages/addons/__tests__/floatingLabels.spec.ts
+++ b/packages/addons/__tests__/floatingLabels.spec.ts
@@ -4,7 +4,7 @@ import { FormKit, plugin, defaultConfig, resetCount } from '@formkit/vue'
 import { createFloatingLabelsPlugin } from '../src/plugins/floatingLabels/floatingLabelsPlugin'
 import { FormKitNode, FormKitPlugin, FormKitSectionsSchema } from '@formkit/core'
 import { clone } from '@formkit/utils'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * A test plugin that adds a custom data attribute to the outer section.
@@ -132,5 +132,32 @@ describe('floatingLabels', () => {
     await new Promise((r) => setTimeout(r, 10))
     expect(wrapper.html()).toContain('data-floating-label="true"')
     wrapper.unmount()
+  })
+
+  it('clears scheduled timers on unmount', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'text',
+        label: 'Test Label',
+        floatingLabel: true,
+      },
+      attachTo: document.body,
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              plugins: [createFloatingLabelsPlugin()],
+            }),
+          ],
+        ],
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+    wrapper.unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
   })
 })

--- a/packages/addons/src/plugins/floatingLabels/floatingLabelsPlugin.ts
+++ b/packages/addons/src/plugins/floatingLabels/floatingLabelsPlugin.ts
@@ -102,7 +102,7 @@ export function createFloatingLabelsPlugin(
         // available for users who want to update the background color manually
         node.context.handlers.updateLabelBackgroundColor = () => {
           if (!node.context || !nodeEl) return
-          setBackgroundColor(node, nodeEl, 0)
+          setBackgroundColor(node, nodeEl, 0, timeouts)
         }
 
         const inputDefinition = clone(node.props.definition)

--- a/packages/addons/src/plugins/floatingLabels/floatingLabelsPlugin.ts
+++ b/packages/addons/src/plugins/floatingLabels/floatingLabelsPlugin.ts
@@ -56,11 +56,15 @@ function findParentWithBackgroundColor(element: HTMLElement): string {
 function setBackgroundColor(
   node: FormKitNode,
   nodeRoot: HTMLElement,
-  timeout: number
+  timeout: number,
+  timeouts: Set<ReturnType<typeof setTimeout>>
 ) {
-  setTimeout(() => {
+  const scheduledTimeout = setTimeout(() => {
+    timeouts.delete(scheduledTimeout)
+    if (typeof window === 'undefined' || !node.props) return
     node.props._labelBackgroundColor = findParentWithBackgroundColor(nodeRoot)
   }, timeout)
+  timeouts.add(scheduledTimeout)
 }
 
 /**
@@ -77,6 +81,8 @@ export function createFloatingLabelsPlugin(
 ): FormKitPlugin {
   const floatingLabelsPlugin = (node: FormKitNode) => {
     let nodeEl: HTMLElement | null = null
+    let observer: MutationObserver | null = null
+    const timeouts = new Set<ReturnType<typeof setTimeout>>()
     node.addProps({
       floatingLabel: {
         boolean: true,
@@ -174,28 +180,37 @@ export function createFloatingLabelsPlugin(
 
         // set a mutation observer on the nodeEl parent to refire calculateLabelOffset
         // whenever the children are changed
-        const observer = new MutationObserver(() => {
+        observer = new MutationObserver(() => {
           if (!nodeEl) return
           calculateLabelOffset(node, nodeEl)
 
           // delay the enabling of animations until after
           // initial label positions are set
-          setTimeout(() => {
+          const scheduledTimeout = setTimeout(() => {
+            timeouts.delete(scheduledTimeout)
+            if (!node.props) return
             node.props._offsetCalculated = true
           }, 100)
+          timeouts.add(scheduledTimeout)
         })
 
         whenAvailable(node.context.id, () => {
           if (!node.context) return
           nodeEl = document.getElementById(node.context?.id)
           if (!nodeEl) return
-          setBackgroundColor(node, nodeEl, 100)
-          observer.observe(nodeEl.parentNode as Node, {
+          setBackgroundColor(node, nodeEl, 100, timeouts)
+          observer?.observe(nodeEl.parentNode as Node, {
             childList: true,
             subtree: true,
             attributes: true,
           })
         })
+      })
+
+      node.on('destroyed', () => {
+        observer?.disconnect()
+        timeouts.forEach((timeout) => clearTimeout(timeout))
+        timeouts.clear()
       })
 
       function calculateLabelOffset(node: FormKitNode, nodeEl: HTMLElement) {

--- a/packages/vue/__tests__/inputs/text.spec.ts
+++ b/packages/vue/__tests__/inputs/text.spec.ts
@@ -277,6 +277,33 @@ describe('the number feature', () => {
     const node = getNode(id)!
     expect(node.value).toBe(123)
   })
+  it('normalizes the DOM value when integer casts collapse to the current number (#1704)', async () => {
+    const id = `a${token()}`
+    const wrapper = mount(FormKit, {
+      props: {
+        id,
+        type: 'number',
+        number: 'integer',
+        delay: 0,
+      },
+      attachTo: document.body,
+      ...global,
+    })
+    const input = wrapper.find('input')
+
+    input.element.value = '123'
+    await input.trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(getNode(id)!.value).toBe(123)
+    expect(input.element.value).toBe('123')
+
+    input.element.value = '123.4'
+    await input.trigger('input')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(getNode(id)!.value).toBe(123)
+    expect(input.element.value).toBe('123')
+  })
   it('forces initial values to an integer on a number input', async () => {
     const id = `a${token()}`
     const wrapper = mount(FormKit, {

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -402,6 +402,23 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
 
   node.props.definition && definedAs(node.props.definition)
 
+  function syncStrictNumericInput(payload: unknown) {
+    if (
+      typeof node.props.number === 'undefined' ||
+      !['number', 'range'].includes(node.props.type)
+    ) {
+      return
+    }
+    const input = node.props.__root?.querySelector?.(
+      `#${node.props.id}`
+    ) as HTMLInputElement | null
+    if (!input) return
+    const normalizedValue = payload === undefined ? '' : String(payload)
+    if (input.value !== normalizedValue) {
+      input.value = normalizedValue
+    }
+  }
+
   /**
    * When new props are added to the core node as "props" (ie not attrs) then
    * we automatically need to start tracking them here.
@@ -436,6 +453,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
       value.value = _value.value = payload
       triggerRef(value)
     }
+    syncStrictNumericInput(payload)
     node.emit('modelUpdated')
   })
 


### PR DESCRIPTION
## Summary
- normalize the actual DOM value for strict numeric inputs after `commitRaw`, including same-value integer casts
- add a Vue regression for number inputs that cast `123.4` back to `123` while keeping the visible input in sync
- fixes the Firefox/Nuxt repro where `number="integer"` preserved the raw float in the input element

## Testing
- pnpm exec vitest run --config /tmp/formkit-vitest-1704.mts packages/vue/__tests__/inputs/text.spec.ts -t "#1704"
- pnpm exec vitest run --config /tmp/formkit-vitest-1704.mts packages/vue/__tests__/inputs/text.spec.ts
- manual Firefox repro against https://github.com/dklaczany1/formkit-integers-bug (`/test`, type `123.4`)

Refs formkit/formkit#1704