### PR TITLE
fix: preserve child input delay defaults

### DIFF
--- a/packages/core/__tests__/node.spec.ts
+++ b/packages/core/__tests__/node.spec.ts
@@ -562,6 +562,22 @@ describe('props system', () => {
     expect(child.props.delay).toBe(50)
   })
 
+  it('does not inherit the default delay from group and list parents (#1265)', () => {
+    const groupChild = createNode({ name: 'groupChild' })
+    createNode({
+      type: 'group',
+      children: [groupChild],
+    })
+    expect(groupChild.props.delay).toBe(20)
+
+    const listChild = createNode({ name: 'listChild' })
+    createNode({
+      type: 'list',
+      children: [listChild],
+    })
+    expect(listChild.props.delay).toBe(20)
+  })
+
   it('can override a configuration value', () => {
     const child = createNode({ name: 'name', props: { delay: 500 } })
     createNode({

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -2585,6 +2585,7 @@ function walkTree(
 function resetConfig(node: FormKitNode, context: FormKitContext) {
   const parent = node.parent || undefined
   context.config = createConfig(node.config._t, parent)
+  context.config._n = node
   node.walk((n) => n.resetConfig())
 }
 
@@ -2887,6 +2888,19 @@ function createConfig(
   parent?: FormKitNode | null
 ): FormKitConfig {
   let node: FormKitNode | undefined = undefined
+  const getExplicitInheritedValue = (prop: string) => {
+    let currentParent = parent
+    while (currentParent) {
+      const parentValue = currentParent.config._t[prop]
+      if (parentValue !== undefined) return parentValue
+      currentParent = currentParent.parent
+    }
+    if (target.rootConfig) {
+      const rootValue = target.rootConfig[prop]
+      if (rootValue !== undefined) return rootValue
+    }
+    return undefined
+  }
   return new Proxy(target, {
     get(...args) {
       const prop = args[1]
@@ -2894,6 +2908,12 @@ function createConfig(
       const localValue = Reflect.get(...args)
       // Check our local values first
       if (localValue !== undefined) return localValue
+      // Input nodes default to 20ms delay unless an ancestor/root explicitly
+      // configured a different value.
+      if (prop === 'delay' && node?.type === 'input') {
+        const inheritedDelay = getExplicitInheritedValue(prop)
+        return inheritedDelay !== undefined ? inheritedDelay : 20
+      }
       // Then check our parent values next
       if (parent) {
         const parentVal = parent.config[prop as string]


### PR DESCRIPTION
## Summary
- keep plain input children under `group` and `list` on the intended 20ms default delay
- only inherit `delay` from ancestors when it was explicitly configured
- reattach nodes to rebuilt config proxies during `resetConfig()` so input-specific config defaults still apply after parenting changes

## Testing
- pnpm exec vitest run packages/core/__tests__/node.spec.ts -t "#1265"
- pnpm exec vitest run packages/core/__tests__/node.spec.ts

Closes #1265