### PR TITLE
fix: render checkbox help slots without help prop

### DIFF
--- a/packages/inputs/src/inputs/checkbox.ts
+++ b/packages/inputs/src/inputs/checkbox.ts
@@ -76,7 +76,7 @@ export const checkbox: FormKitTypeDefinition = {
       )
     ),
     // Help text only goes under the input when it is a single.
-    $if('$options == undefined && $help', help('$help')),
+    $if('$options == undefined', help('$help')),
     messages(message('$message.value'))
   ),
   /**

--- a/packages/react/__tests__/inputs/checkbox.spec.ts
+++ b/packages/react/__tests__/inputs/checkbox.spec.ts
@@ -201,6 +201,20 @@ describe('single checkbox (react)', () => {
     expect(container.querySelector('#hello-world')).toBeTruthy()
   })
 
+  it('renders the help slot even when no help prop is provided (#1427)', () => {
+    const { container } = renderWithFormKit(
+      createElement(FormKit as any, {
+        type: 'checkbox',
+        slots: {
+          help: () => createElement('div', { id: 'help-slot' }, 'Render me anyway'),
+        },
+      }),
+      defaultConfig()
+    )
+
+    expect(container.querySelector('#help-slot')).toBeTruthy()
+  })
+
   it('does not render label when it is not provided', () => {
     const { container } = renderWithFormKit(
       createElement(FormKit as any, { type: 'checkbox' }),

--- a/packages/vue/__tests__/inputs/checkbox.spec.ts
+++ b/packages/vue/__tests__/inputs/checkbox.spec.ts
@@ -298,6 +298,22 @@ describe('multiple checkboxes', () => {
     expect(wrapper.find('li').html()).toMatchSnapshot()
   })
 
+  it('renders the help slot even when there is no help prop (#1427)', async () => {
+    const wrapper = mount(
+      {
+        template: `
+        <FormKit type="checkbox">
+          <template #help>
+            <div id="help-slot">Render me anyway</div>
+          </template>
+        </FormKit>
+      `,
+      },
+      global
+    )
+    expect(wrapper.find('#help-slot').exists()).toBe(true)
+  })
+
   it('can set the default value from a v-modeled form', () => {
     const wrapper = mount(
       {


### PR DESCRIPTION
## Summary
- allow single checkbox help slots to render even when the `help` prop is not initially set
- keep the existing behavior for empty single checkboxes by relying on the help section slot guard
- add Vue and React regressions for formkit/formkit#1427

## Testing
- pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/checkbox.spec.ts -t "#1427"
- pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/react/__tests__/inputs/checkbox.spec.ts -t "#1427"
- pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/react/__tests__/inputs/checkbox.spec.ts packages/vue/__tests__/inputs/checkbox.spec.ts

Closes #1427