### PR TITLE
fix: load default icons with custom loaders

### DIFF
--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -292,47 +292,60 @@ export function createIconHandler(
       return iconName
     }
 
-    // is this a default icon that should only load from a stylesheet?
+    // Default icons use stylesheet values first, then a custom loader if one is
+    // configured, but never fall back to the CDN loader.
     const isDefault = iconName.startsWith('default:')
     iconName = isDefault ? iconName.split(':')[1] : iconName
 
     // check if we've already loaded the icon before
-    const iconWasAlreadyLoaded = iconName in iconRegistry
+    const defaultRegistryKey = `default:${iconName}`
+    const iconWasAlreadyLoaded =
+      iconName in iconRegistry ||
+      (isDefault && defaultRegistryKey in iconRegistry)
+    const iconRequestKey =
+      isDefault && typeof iconLoader !== 'function'
+        ? defaultRegistryKey
+        : iconName
 
     let loadedIcon: string | undefined | Promise<string | undefined> = undefined
 
     if (iconWasAlreadyLoaded) {
-      return iconRegistry[iconName]
-    } else if (!iconRequests[iconName]) {
+      return iconRegistry[iconName] ?? iconRegistry[defaultRegistryKey]
+    } else if (!iconRequests[iconRequestKey]) {
       loadedIcon = getIconFromStylesheet(iconName)
       loadedIcon =
         isClient && typeof loadedIcon === 'undefined'
           ? Promise.resolve(loadedIcon)
           : loadedIcon
       if (loadedIcon instanceof Promise) {
-        iconRequests[iconName] = loadedIcon
+        iconRequests[iconRequestKey] = loadedIcon
           .then((iconValue) => {
-            if (!iconValue && typeof iconName === 'string' && !isDefault) {
-              return (loadedIcon =
-                typeof iconLoader === 'function'
-                  ? iconLoader(iconName)
-                  : getRemoteIcon(iconName, iconLoaderUrl))
+            if (!iconValue && typeof iconName === 'string') {
+              if (typeof iconLoader === 'function') {
+                return (loadedIcon = iconLoader(iconName))
+              } else if (!isDefault) {
+                return (loadedIcon = getRemoteIcon(iconName, iconLoaderUrl))
+              }
             }
             return iconValue
           })
           .then((finalIcon) => {
             if (typeof iconName === 'string') {
-              iconRegistry[isDefault ? `default:${iconName}` : iconName] =
+              iconRegistry[
+                isDefault && typeof iconLoader !== 'function'
+                  ? defaultRegistryKey
+                  : iconName
+              ] =
                 finalIcon
             }
             return finalIcon
           })
       } else if (typeof loadedIcon === 'string') {
-        iconRegistry[isDefault ? `default:${iconName}` : iconName] = loadedIcon
+        iconRegistry[isDefault ? defaultRegistryKey : iconName] = loadedIcon
         return loadedIcon
       }
     }
-    return iconRequests[iconName]
+    return iconRequests[iconRequestKey]
   }
 }
 

--- a/packages/vue/__tests__/inputs/checkbox-icons.spec.ts
+++ b/packages/vue/__tests__/inputs/checkbox-icons.spec.ts
@@ -1,0 +1,60 @@
+import FormKit from '../../src/FormKit'
+import FormKitIcon from '../../src/FormKitIcon'
+import { plugin } from '../../src/plugin'
+import { defaultConfig } from '../../src'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('checkbox icons', () => {
+  it('loads its default decorator icon with a custom iconLoader (#1301)', async () => {
+    const iconLoader = vi.fn((iconName: string) => {
+      return `<svg data-loaded-icon="${iconName}" viewBox="0 0 1 1"></svg>`
+    })
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'checkbox',
+      },
+      global: {
+        plugins: [[plugin, defaultConfig({ iconLoader })]],
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(iconLoader).toHaveBeenCalledWith('checkboxDecorator')
+    expect(
+      wrapper.find('svg[data-loaded-icon="checkboxDecorator"]').exists()
+    ).toBe(true)
+  })
+
+  it('does not let an unresolved default icon block later custom loading (#1301)', async () => {
+    mount(FormKitIcon, {
+      props: {
+        icon: 'default:formkit1301Missing',
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const iconLoader = vi.fn((iconName: string) => {
+      return `<svg data-loaded-icon="${iconName}" viewBox="0 0 1 1"></svg>`
+    })
+    const wrapper = mount(FormKitIcon, {
+      props: {
+        icon: 'formkit1301Missing',
+      },
+      global: {
+        plugins: [[plugin, defaultConfig({ iconLoader })]],
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(iconLoader).toHaveBeenCalledWith('formkit1301Missing')
+    expect(
+      wrapper.find('svg[data-loaded-icon="formkit1301Missing"]').exists()
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- allow `default:` icons to resolve through a configured custom `iconLoader` after stylesheet lookup misses
- avoid unresolved default icon requests poisoning later non-default icon requests for the same icon name
- add Vue regressions for checkbox decorator icons and default icon request caching

Closes #1301

## Testing
- pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/checkbox-icons.spec.ts
- pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/FormKitIcon.spec.ts packages/vue/__tests__/inputs/checkbox-icons.spec.ts packages/vue/__tests__/inputs/checkbox.spec.ts
- pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/react/__tests__/FormKitIcon.spec.ts
- pnpm build themes