### PR TITLE
Fix FormKit HMR listener cleanup

### DIFF
--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -63,6 +63,23 @@ describe('hmr', () => {
       afterUpdate
     )
   })
+
+  it('does not require test HMR stubs to implement off', () => {
+    const hot = {
+      on: vi.fn(),
+    }
+    let cleanup = () => {}
+    registerHotReload(
+      { props: { preserve: false } } as FormKitNode,
+      { proxy: { $forceUpdate: vi.fn() } } as any,
+      hot,
+      (handler) => {
+        cleanup = handler
+      }
+    )
+
+    expect(() => cleanup()).not.toThrow()
+  })
 })
 
 describe('props', () => {

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -21,11 +21,49 @@ import { describe, expect, it, vi } from 'vitest'
 import { FormKitFrameworkContext } from '@formkit/core'
 import { changeLocale, de } from '@formkit/i18n'
 import { createInput } from '../src'
-import { componentSymbol } from '../src/FormKit'
+import { componentSymbol, registerHotReload } from '../src/FormKit'
 import { FormKitMessages } from '../src/FormKitMessages'
 import { star } from '@formkit/icons'
 
 // Object.assign(defaultConfig.nodeOptions, { validationVisibility: 'live' })
+
+describe('hmr', () => {
+  it('unregisters Vite HMR listeners on unmount (formkit/formkit#1068)', () => {
+    const hot = {
+      on: vi.fn(),
+      off: vi.fn(),
+    }
+    let cleanup = () => {}
+    const forceUpdate = vi.fn()
+    const node = { props: { preserve: false } } as FormKitNode
+    registerHotReload(
+      node,
+      { proxy: { $forceUpdate: forceUpdate } } as any,
+      hot,
+      (handler) => {
+        cleanup = handler
+      }
+    )
+    const beforeUpdate = hot.on.mock.calls[0][1]
+    const afterUpdate = hot.on.mock.calls[1][1]
+    beforeUpdate()
+    expect(node.props.preserve).toBe(true)
+    afterUpdate()
+    expect(forceUpdate).toHaveBeenCalledTimes(1)
+    expect(node.props.preserve).toBe(false)
+    cleanup()
+    expect(hot.off).toHaveBeenNthCalledWith(
+      1,
+      'vite:beforeUpdate',
+      beforeUpdate
+    )
+    expect(hot.off).toHaveBeenNthCalledWith(
+      2,
+      'vite:afterUpdate',
+      afterUpdate
+    )
+  })
+})
 
 describe('props', () => {
   it('loads input definition props before the plugins are executed', () => {

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -25,7 +25,7 @@ import {
   InputType,
   runtimeProps,
 } from '@formkit/inputs'
-import { getCurrentInstance } from 'vue'
+import { getCurrentInstance, onBeforeUnmount } from 'vue'
 
 /**
  * The type definition for the FormKit’s slots, this is not intended to be used
@@ -107,6 +107,46 @@ let currentSchemaNode: FormKitNode | null = null
  * @public
  */
 export const getCurrentSchemaNode = () => currentSchemaNode
+
+type HotReloadAPI = {
+  on: (
+    event: 'vite:beforeUpdate' | 'vite:afterUpdate',
+    handler: () => void
+  ) => void
+  off: (
+    event: 'vite:beforeUpdate' | 'vite:afterUpdate',
+    handler: () => void
+  ) => void
+}
+
+/**
+ * Registers Vite HMR handlers for a FormKit component instance.
+ *
+ * @internal
+ */
+export function registerHotReload(
+  node: FormKitNode,
+  instance: ReturnType<typeof getCurrentInstance>,
+  hot: HotReloadAPI,
+  cleanup: (handler: () => void) => void = onBeforeUnmount
+) {
+  let initPreserve: boolean | undefined
+  const beforeUpdate = () => {
+    initPreserve = node.props.preserve
+    node.props.preserve = true
+  }
+  const afterUpdate = () => {
+    instance?.proxy?.$forceUpdate()
+    node.props.preserve = initPreserve
+  }
+  hot.on('vite:beforeUpdate', beforeUpdate)
+  hot.on('vite:afterUpdate', afterUpdate)
+  cleanup(() => {
+    hot.off('vite:beforeUpdate', beforeUpdate)
+    hot.off('vite:afterUpdate', afterUpdate)
+  })
+}
+
 /**
  * The actual runtime setup function for the FormKit component.
  *
@@ -130,16 +170,7 @@ function FormKit<Props extends FormKitInputs<Props>>(
       )
   }
   if (__DEV__ && import.meta.hot) {
-    const instance = getCurrentInstance()
-    let initPreserve: boolean | undefined
-    import.meta.hot?.on('vite:beforeUpdate', () => {
-      initPreserve = node.props.preserve
-      node.props.preserve = true
-    })
-    import.meta.hot?.on('vite:afterUpdate', () => {
-      instance?.proxy?.$forceUpdate()
-      node.props.preserve = initPreserve
-    })
+    registerHotReload(node, getCurrentInstance(), import.meta.hot)
   }
   const schema = ref<FormKitSchemaDefinition>([])
   let memoKey: string | undefined = node.props.definition.schemaMemoKey

--- a/packages/vue/src/FormKit.ts
+++ b/packages/vue/src/FormKit.ts
@@ -113,7 +113,7 @@ type HotReloadAPI = {
     event: 'vite:beforeUpdate' | 'vite:afterUpdate',
     handler: () => void
   ) => void
-  off: (
+  off?: (
     event: 'vite:beforeUpdate' | 'vite:afterUpdate',
     handler: () => void
   ) => void
@@ -142,8 +142,8 @@ export function registerHotReload(
   hot.on('vite:beforeUpdate', beforeUpdate)
   hot.on('vite:afterUpdate', afterUpdate)
   cleanup(() => {
-    hot.off('vite:beforeUpdate', beforeUpdate)
-    hot.off('vite:afterUpdate', afterUpdate)
+    hot.off?.('vite:beforeUpdate', beforeUpdate)
+    hot.off?.('vite:afterUpdate', afterUpdate)
   })
 }
 


### PR DESCRIPTION
Fixes #1068.

## What changed
- Unregister Vite HMR listeners when a FormKit component unmounts so stale handlers cannot force-update destroyed instances.
- Added a regression for HMR listener cleanup.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/FormKit.spec.ts -t "#1068|hmr" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/FormKit.spec.ts --reporter verbose`
- Browser HMR repro against local source: repeated child-component updates under `<FormKit type="form" #default="{ value }">` produced no Vue warnings/page errors after the fix.
- `for pkg in utils core dev observer validation i18n inputs rules themes vue; do node scripts/cli.mjs --script build "$pkg" || exit 1; done`

## Security
- Development-time HMR listener cleanup only; no production trust boundary or user-data handling changed.