### PR TITLE
fix: defer multistep goTo until steps settle

### DIFF
--- a/packages/addons/__tests__/floatingLabels.spec.ts
+++ b/packages/addons/__tests__/floatingLabels.spec.ts
@@ -4,7 +4,7 @@ import { FormKit, plugin, defaultConfig, resetCount } from '@formkit/vue'
 import { createFloatingLabelsPlugin } from '../src/plugins/floatingLabels/floatingLabelsPlugin'
 import { FormKitNode, FormKitPlugin, FormKitSectionsSchema } from '@formkit/core'
 import { clone } from '@formkit/utils'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * A test plugin that adds a custom data attribute to the outer section.
@@ -43,6 +43,8 @@ describe('floatingLabels', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
     document.body.innerHTML = ''
   })
 
@@ -132,5 +134,33 @@ describe('floatingLabels', () => {
     await new Promise((r) => setTimeout(r, 10))
     expect(wrapper.html()).toContain('data-floating-label="true"')
     wrapper.unmount()
+  })
+
+  it('clears delayed background color updates when unmounted', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'text',
+        label: 'Test Label',
+        floatingLabel: true,
+      },
+      attachTo: document.body,
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              plugins: [createFloatingLabelsPlugin()],
+            }),
+          ],
+        ],
+      },
+    })
+    const getComputedStyle = vi.spyOn(window, 'getComputedStyle')
+
+    wrapper.unmount()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(getComputedStyle).not.toHaveBeenCalled()
   })
 })

--- a/packages/addons/__tests__/multistep.spec.ts
+++ b/packages/addons/__tests__/multistep.spec.ts
@@ -7,6 +7,7 @@ import {
   defaultConfig,
   resetCount,
 } from '@formkit/vue'
+import { getNode } from '@formkit/core'
 import { createMultiStepPlugin } from '../src/plugins/multiStep/multiStepPlugin'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -313,6 +314,78 @@ describe('multistep', () => {
     await new Promise((r) => setTimeout(r, 15))
     // 2nd tab is active (without labels due to props)
     expect(wrapper.html()).toMatchSnapshot()
+    wrapper.unmount()
+  })
+
+  it('allows navigation after programmatic input updates settle step conditions (#1135)', async () => {
+    const beforeStepChange = vi.fn(() => true)
+    const wrapper = mount(FormKitSchema, {
+      props: {
+        data: { beforeStepChange },
+        schema: [
+          {
+            $formkit: 'multi-step',
+            id: 'issue1135MultiStep',
+            allowIncomplete: false,
+            beforeStepChange: '$beforeStepChange',
+            children: [
+              {
+                $formkit: 'step',
+                name: 'stepOne',
+                children: [
+                  {
+                    $formkit: 'radio',
+                    id: 'issue1135Answer',
+                    name: 'answer',
+                    options: { yes: 'Yes', no: 'No' },
+                    validation: 'required',
+                  },
+                ],
+              },
+              {
+                $formkit: 'step',
+                name: 'stepTwo',
+                if: "$get(issue1135Answer).value === 'yes'",
+                children: [
+                  {
+                    $formkit: 'text',
+                    name: 'confirm',
+                    validation: 'required',
+                  },
+                ],
+              },
+              {
+                $formkit: 'step',
+                name: 'stepThree',
+              },
+            ],
+          },
+        ],
+      },
+      attachTo: document.body,
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              plugins: [createMultiStepPlugin()],
+            }),
+          ],
+        ],
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 15))
+    const multistep = getNode('issue1135MultiStep')!
+    multistep.input({
+      stepOne: { answer: 'yes' },
+      stepTwo: { confirm: 'ready' },
+    })
+    multistep.goTo('stepTwo')
+    await new Promise((r) => setTimeout(r, 15))
+
+    expect(beforeStepChange).toHaveBeenCalledTimes(1)
+    expect(multistep.props.activeStep).toBe('stepTwo')
     wrapper.unmount()
   })
 

--- a/packages/addons/src/plugins/floatingLabels/floatingLabelsPlugin.ts
+++ b/packages/addons/src/plugins/floatingLabels/floatingLabelsPlugin.ts
@@ -21,6 +21,9 @@ export interface FloatingLabelsOptions {
  */
 function findParentWithBackgroundColor(element: HTMLElement): string {
   let backgroundColor = 'white'
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return backgroundColor
+  }
   while (backgroundColor === 'white' && element.parentElement) {
     element = element.parentElement
     const style = window.getComputedStyle(element)
@@ -38,7 +41,8 @@ function findParentWithBackgroundColor(element: HTMLElement): string {
     if (opacityMatch) {
       const opacityVar = opacityMatch[1]
       const opacity =
-        getComputedStyle(document.documentElement)
+        window
+          .getComputedStyle(document.documentElement)
           .getPropertyValue(opacityVar)
           .trim() || '1'
       backgroundColor = `rgba(${bgColor}, ${opacity})`
@@ -55,12 +59,11 @@ function findParentWithBackgroundColor(element: HTMLElement): string {
  */
 function setBackgroundColor(
   node: FormKitNode,
-  nodeRoot: HTMLElement,
-  timeout: number
-) {
-  setTimeout(() => {
-    node.props._labelBackgroundColor = findParentWithBackgroundColor(nodeRoot)
-  }, timeout)
+  nodeRoot: HTMLElement
+): void {
+  if (typeof window === 'undefined' || !node.context || !nodeRoot.isConnected)
+    return
+  node.props._labelBackgroundColor = findParentWithBackgroundColor(nodeRoot)
 }
 
 /**
@@ -77,6 +80,25 @@ export function createFloatingLabelsPlugin(
 ): FormKitPlugin {
   const floatingLabelsPlugin = (node: FormKitNode) => {
     let nodeEl: HTMLElement | null = null
+    let observer: MutationObserver | null = null
+    const timeouts = new Set<ReturnType<typeof setTimeout>>()
+
+    const setManagedTimeout = (callback: () => void, delay: number) => {
+      const timeout = setTimeout(() => {
+        timeouts.delete(timeout)
+        callback()
+      }, delay)
+      timeouts.add(timeout)
+      return timeout
+    }
+
+    const clearTimeouts = () => {
+      for (const timeout of timeouts) {
+        clearTimeout(timeout)
+      }
+      timeouts.clear()
+    }
+
     node.addProps({
       floatingLabel: {
         boolean: true,
@@ -96,7 +118,8 @@ export function createFloatingLabelsPlugin(
         // available for users who want to update the background color manually
         node.context.handlers.updateLabelBackgroundColor = () => {
           if (!node.context || !nodeEl) return
-          setBackgroundColor(node, nodeEl, 0)
+          const nodeRoot = nodeEl
+          setManagedTimeout(() => setBackgroundColor(node, nodeRoot), 0)
         }
 
         const inputDefinition = clone(node.props.definition)
@@ -174,13 +197,14 @@ export function createFloatingLabelsPlugin(
 
         // set a mutation observer on the nodeEl parent to refire calculateLabelOffset
         // whenever the children are changed
-        const observer = new MutationObserver(() => {
+        observer = new MutationObserver(() => {
           if (!nodeEl) return
           calculateLabelOffset(node, nodeEl)
 
           // delay the enabling of animations until after
           // initial label positions are set
-          setTimeout(() => {
+          setManagedTimeout(() => {
+            if (!node.context) return
             node.props._offsetCalculated = true
           }, 100)
         })
@@ -189,8 +213,9 @@ export function createFloatingLabelsPlugin(
           if (!node.context) return
           nodeEl = document.getElementById(node.context?.id)
           if (!nodeEl) return
-          setBackgroundColor(node, nodeEl, 100)
-          observer.observe(nodeEl.parentNode as Node, {
+          const nodeRoot = nodeEl
+          setManagedTimeout(() => setBackgroundColor(node, nodeRoot), 100)
+          observer?.observe(nodeEl.parentNode as Node, {
             childList: true,
             subtree: true,
             attributes: true,
@@ -209,6 +234,13 @@ export function createFloatingLabelsPlugin(
           node.props._labelOffset = `calc(${offset}px - 0.25em)`
         }
       }
+
+      node.on('destroyed', () => {
+        clearTimeouts()
+        observer?.disconnect()
+        observer = null
+        nodeEl = null
+      })
     }
   }
   return floatingLabelsPlugin

--- a/packages/addons/src/plugins/multiStep/multiStepPlugin.ts
+++ b/packages/addons/src/plugins/multiStep/multiStepPlugin.ts
@@ -366,6 +366,24 @@ async function setActiveStep(targetStep: FormKitFrameworkContext, e?: Event) {
   }
 }
 
+async function goToStep(node: FormKitNode, target: number | string) {
+  await node.settled
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  const targetStep = getTargetStep(node, target)
+  if (targetStep) return setActiveStep(targetStep)
+  node.props._pendingStepTarget = target
+}
+
+function getTargetStep(node: FormKitNode, target: number | string) {
+  if (typeof target === 'number') {
+    return node.props.steps[target]
+  } else if (typeof target === 'string') {
+    return node.props.steps.find(
+      (step: Record<string, any>) => step.node.name === target
+    )
+  }
+}
+
 /**
  * Changes the current step by the delta value if the target step is allowed.
  *
@@ -493,7 +511,7 @@ export function createMultiStepPlugin(
       if (!node.context) return
 
       isFirstStep = true // reset variable, next step will be first step in multistep
-      node.addProps(['steps', 'tabs', 'activeStep'])
+      node.addProps(['steps', 'tabs', 'activeStep', '_pendingStepTarget'])
 
       node.context.fns.preRenderSteps = createPreRenderStepsFunction(node)
       node.context.fns.getStepCount = () => {
@@ -547,15 +565,7 @@ export function createMultiStepPlugin(
         })
         node.extend('goTo', {
           get: (node) => (target: number | string) => {
-            if (typeof target === 'number') {
-              const targetStep = node.props.steps[target]
-              setActiveStep(targetStep)
-            } else if (typeof target === 'string') {
-              const targetStep = node.props.steps.find(
-                (step: Record<string, any>) => step.node.name === target
-              )
-              setActiveStep(targetStep)
-            }
+            void goToStep(node, target)
           },
           set: false,
         })
@@ -595,6 +605,13 @@ export function createMultiStepPlugin(
           : node.props.steps[0]
           ? node.props.steps[0].node.name
           : ''
+        if (node.props._pendingStepTarget !== undefined) {
+          const targetStep = getTargetStep(node, node.props._pendingStepTarget)
+          if (targetStep) {
+            node.props._pendingStepTarget = undefined
+            void setActiveStep(targetStep)
+          }
+        }
       })
 
       node.on('prop:activeStep', ({ payload }) => {


### PR DESCRIPTION
## Summary
- defer programmatic multi-step `goTo` until the multistep node and framework step conditions have settled
- remember a pending target when a conditional step is not registered yet, then retry when child steps are added
- add regression coverage for `form.input(...)` followed immediately by `goTo` with `beforeStepChange` and conditional steps

## Security
- No security-sensitive surface change; this only changes client-side multistep navigation timing/state reconciliation.

## Tests
- pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/multistep.spec.ts -t "#1135" --reporter verbose
- pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/multistep.spec.ts --reporter verbose

## Build note
- The broader local build chain reaches `addons` but fails during DTS generation on the existing `@formkit/auto-animate` package exports/type-resolution issue, before any multistep-specific type error is reported.

Closes #1135