### PR TITLE
fix: refresh config class cache

### DIFF
--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1,6 +1,7 @@
 import {
   nextTick,
   h,
+  computed,
   reactive,
   ref,
   PropType,
@@ -2761,5 +2762,47 @@ describe('naked attributes', () => {
     expect(
       wrapper.find('[data-family="text"]').attributes('data-invalid')
     ).toBe(undefined)
+  })
+})
+
+describe('config classes', () => {
+  it('reacts to updated classes in the config prop (#1146)', async () => {
+    const wrapper = mount(
+      {
+        setup() {
+          const altTheme = ref(false)
+          const config = computed(() => ({
+            classes: {
+              label: altTheme.value ? 'text-orange-700' : '',
+            },
+          }))
+          function toggleTheme() {
+            altTheme.value = true
+          }
+          return { config, toggleTheme }
+        },
+        template: `
+        <FormKit
+          type="text"
+          label="Config label"
+          :config="config"
+        />
+        <button @click="toggleTheme">Toggle theme</button>`,
+      },
+      {
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+
+    expect(wrapper.find('.formkit-label').attributes('class')).toBe(
+      'formkit-label'
+    )
+    wrapper.find('button').trigger('click')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.find('.formkit-label').attributes('class')).toBe(
+      'formkit-label text-orange-700'
+    )
   })
 })

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -228,12 +228,16 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
     },
   })
 
-  node.on('prop:rootClasses', () => {
+  const resetClasses = () => {
     const keys = Object.keys(cachedClasses)
     for (const key of keys) {
       delete cachedClasses[key]
     }
-  })
+  }
+
+  node.on('prop:rootClasses', resetClasses)
+  node.on('config:rootClasses', resetClasses)
+  node.on('config:classes', resetClasses)
 
   const describedBy = computed<string | undefined>(() => {
     if (!node) return undefined


### PR DESCRIPTION
Fixes #1146.

## What changed
- Clears the Vue binding class cache when reactive `config.classes` or `config.rootClasses` updates, not only when the `rootClasses` prop changes.
- Adds a regression test covering a computed `config.classes.label` value updating after a reactive toggle.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/FormKit.spec.ts -t "#1146" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/FormKit.spec.ts --reporter verbose`
- `for pkg in utils core dev observer validation i18n inputs rules themes vue; do node scripts/cli.mjs --script build "$pkg" || exit 1; done`

## Security
- No new user-controlled execution paths or HTML injection surfaces; this only invalidates cached class strings when trusted FormKit config changes.