### PR TITLE
fix: recalculate autoheight after resize

### DIFF
--- a/packages/addons/__tests__/autoHeightTextarea.spec.ts
+++ b/packages/addons/__tests__/autoHeightTextarea.spec.ts
@@ -1,0 +1,134 @@
+import { mount } from '@vue/test-utils'
+import { FormKit, plugin, defaultConfig, resetCount } from '@formkit/vue'
+import { createAutoHeightTextareaPlugin } from '../src/plugins/autoHeightTextarea'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('autoHeightTextarea', () => {
+  let offsetWidthDescriptor: PropertyDescriptor | undefined
+  let scrollHeightDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    resetCount()
+    offsetWidthDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'offsetWidth'
+    )
+    scrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'scrollHeight'
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+    if (offsetWidthDescriptor) {
+      Object.defineProperty(
+        HTMLTextAreaElement.prototype,
+        'offsetWidth',
+        offsetWidthDescriptor
+      )
+    } else {
+      delete (HTMLTextAreaElement.prototype as { offsetWidth?: number })
+        .offsetWidth
+    }
+    if (scrollHeightDescriptor) {
+      Object.defineProperty(
+        HTMLTextAreaElement.prototype,
+        'scrollHeight',
+        scrollHeightDescriptor
+      )
+    } else {
+      delete (HTMLTextAreaElement.prototype as { scrollHeight?: number })
+        .scrollHeight
+    }
+  })
+
+  it('recalculates height when a hidden textarea becomes visible (#1164)', async () => {
+    vi.useFakeTimers()
+    const textareaWidths = new WeakMap<HTMLTextAreaElement, number>()
+    let resizeCallback: ResizeObserverCallback | undefined
+
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return textareaWidths.get(this) ?? 0
+      },
+    })
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        const width = Number.parseInt(this.style.width, 10) || 0
+        return width > 0 ? 64 : 20
+      },
+    })
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback
+        }
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(
+        () =>
+          ({
+            boxSizing: 'border-box',
+            maxHeight: 'none',
+            minHeight: '0px',
+            paddingBottom: '0px',
+            paddingTop: '0px',
+          }) as CSSStyleDeclaration
+      )
+    )
+
+    const wrapper = mount(
+      {
+        data: () => ({
+          isVisible: false,
+          value: 'Line one\nLine two\nLine three',
+        }),
+        template: `
+          <section v-show="isVisible">
+            <FormKit type="textarea" auto-height v-model="value" />
+          </section>
+          <button @click="isVisible = true">Show</button>
+        `,
+      },
+      {
+        attachTo: document.body,
+        global: {
+          plugins: [
+            [
+              plugin,
+              defaultConfig({
+                plugins: [createAutoHeightTextareaPlugin()],
+              }),
+            ],
+          ],
+        },
+      }
+    )
+    const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
+    textareaWidths.set(textarea, 0)
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(textarea.style.minHeight).toBe('20px')
+
+    textareaWidths.set(textarea, 240)
+    await wrapper.find('button').trigger('click')
+    resizeCallback?.([], {} as ResizeObserver)
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(textarea.style.minHeight).toBe('64px')
+    wrapper.unmount()
+  })
+})

--- a/packages/addons/src/plugins/autoHeightTextarea.ts
+++ b/packages/addons/src/plugins/autoHeightTextarea.ts
@@ -16,6 +16,10 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
     node.on('mounted', () => {
       const autoHeight = undefine(node.props.autoHeight)
       let inputElement: HTMLElement | undefined | null = null
+      let hiddenTextarea: HTMLTextAreaElement | undefined
+      let inputReceipt: string | undefined
+      let isDestroyed = false
+      let resizeObserver: ResizeObserver | undefined
       let showScrollbars = false
 
       const getMinAutoHeight = () => {
@@ -75,6 +79,7 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
       whenAvailable(
         node.context.id,
         () => {
+          if (isDestroyed) return
           inputElement = node.props.__root?.getElementById(
             node?.context?.id ? node.context.id : ''
           )
@@ -93,7 +98,7 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
             document.body.appendChild(scrollbarStyle)
           }
 
-          const hiddenTextarea = inputElement.cloneNode(
+          hiddenTextarea = inputElement.cloneNode(
             false
           ) as HTMLTextAreaElement
           hiddenTextarea.classList.add('formkit-auto-height-textarea')
@@ -127,14 +132,20 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
           inputElement.after(hiddenTextarea)
           calculateHeight({ payload: node._value as string })
 
-          node.on('input', calculateHeight)
+          inputReceipt = node.on('input', calculateHeight)
+          if (typeof ResizeObserver !== 'undefined') {
+            resizeObserver = new ResizeObserver(() => {
+              void calculateHeight({ payload: lastValue as string })
+            })
+            resizeObserver.observe(inputElement)
+          }
           async function calculateHeight({ payload }: { payload: string }) {
             lastValue = payload
-            if (!inputElement) return
+            if (!inputElement || !hiddenTextarea) return
             await new Promise((r) => setTimeout(r, 10))
 
             // If the current value is not the one we enqueued, just ignore.
-            if (lastValue !== payload) return
+            if (isDestroyed || lastValue !== payload) return
 
             hiddenTextarea.value = payload
 
@@ -159,6 +170,16 @@ export function createAutoHeightTextareaPlugin(): FormKitPlugin {
         },
         node.props.__root
       )
+
+      node.on('destroyed', () => {
+        isDestroyed = true
+        if (inputReceipt) node.off(inputReceipt)
+        resizeObserver?.disconnect()
+        hiddenTextarea?.remove()
+        inputElement?.classList.remove('formkit-auto-height-textarea')
+        hiddenTextarea = undefined
+        inputElement = null
+      })
     })
   }
 


### PR DESCRIPTION
Fixes #1164.

## What changed
- Recalculates auto-height textarea sizing from `ResizeObserver` notifications so textareas mounted while hidden can resize correctly once visible.
- Cleans up the resize observer, cloned hidden textarea, class changes, and input listener when the node is destroyed.
- Adds a regression test for a `v-show` hidden textarea that changes from zero width to a visible width.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/autoHeightTextarea.spec.ts --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__ --reporter verbose`
- `pnpm vitest --typecheck.only --run`

## Local build note
- `node scripts/cli.mjs --script build addons` still fails during DTS generation on the existing local `@formkit/auto-animate` package exports/type-resolution issue.

## Security
- No new user-controlled execution paths or HTML injection surfaces; the observer only schedules the existing height calculation for the textarea node.