### PR TITLE
test: cover default input overrides

### DIFF
--- a/packages/react/__tests__/defaultConfig.spec.ts
+++ b/packages/react/__tests__/defaultConfig.spec.ts
@@ -62,6 +62,24 @@ describe('defaultConfig (react)', () => {
     expect(container.innerHTML).toBe('<h1>Fooey world</h1>')
   })
 
+  it('allows default input overrides (#1188)', () => {
+    const { container } = renderWithFormKit(
+      createElement(FormKit as any, {
+        type: 'button',
+      }),
+      defaultConfig({
+        inputs: {
+          button: {
+            type: 'input',
+            schema: [{ $el: 'h1', children: 'Custom button' }],
+          },
+        },
+      })
+    )
+
+    expect(container.innerHTML).toBe('<h1>Custom button</h1>')
+  })
+
   it('allows single message overrides', () => {
     const t = token()
     const { container } = renderWithFormKit(

--- a/packages/vue/__tests__/defaultConfig.spec.ts
+++ b/packages/vue/__tests__/defaultConfig.spec.ts
@@ -69,6 +69,30 @@ describe('defaultConfig', () => {
     expect(wrapper.html()).toEqual('<h1>Fooey world</h1>')
   })
 
+  it('allows default input overrides (#1188)', () => {
+    const wrapper = mount(FormKit, {
+      props: {
+        type: 'button',
+      },
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              inputs: {
+                button: {
+                  type: 'input',
+                  schema: [{ $el: 'h1', children: 'Custom button' }],
+                },
+              },
+            }),
+          ],
+        ],
+      },
+    })
+    expect(wrapper.html()).toEqual('<h1>Custom button</h1>')
+  })
+
   it('allows single message overrides', () => {
     const t = token()
     const wrapper = mount(FormKit, {


### PR DESCRIPTION
Covers #1188.

## What changed
- Adds Vue and React regression coverage proving `defaultConfig({ inputs })` can override built-in inputs such as `button`.
- No runtime change was needed: this behavior already passes on the current `release/2.0.1` branch, so the PR locks in the fixed behavior reported against FormKit 1.5.5.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/defaultConfig.spec.ts packages/react/__tests__/defaultConfig.spec.ts --reporter verbose`
- `pnpm vitest --typecheck.only --run`

## Security
- Test-only change; no runtime behavior or user-controlled execution paths changed.