### PR TITLE
fix: prevent multistep invalid style leakage

### DIFF
--- a/packages/addons/__tests__/multistep.spec.ts
+++ b/packages/addons/__tests__/multistep.spec.ts
@@ -257,6 +257,63 @@ describe('multistep', () => {
     wrapper.unmount()
   })
 
+  it('does not expose aggregate invalid state on structural containers (#1208)', async () => {
+    const wrapper = mount(
+      {
+        template: `
+          <FormKit type="form" id="multistep-form">
+            <FormKit type="multi-step" name="steps" allow-incomplete>
+              <FormKit type="step" name="stepOne">
+                <FormKit
+                  type="text"
+                  name="name"
+                  validation="required"
+                  value="Riki"
+                />
+              </FormKit>
+              <FormKit type="step" name="stepTwo">
+                <FormKit type="text" name="email" validation="required" />
+              </FormKit>
+            </FormKit>
+          </FormKit>
+        `,
+      },
+      {
+        attachTo: document.body,
+        global: {
+          plugins: [
+            [
+              plugin,
+              defaultConfig({
+                plugins: [createMultiStepPlugin()],
+              }),
+            ],
+          ],
+        },
+      }
+    )
+
+    await new Promise((r) => setTimeout(r, 15))
+    await wrapper.find('.formkit-step-next button').trigger('click')
+    await new Promise((r) => setTimeout(r, 15))
+    await wrapper.find('button[type="submit"]').trigger('click')
+    await new Promise((r) => setTimeout(r, 15))
+
+    expect(
+      wrapper.find('.formkit-outer[data-type="multi-step"]').attributes()
+    ).not.toHaveProperty('data-invalid')
+    wrapper.findAll('.formkit-step').forEach((step) => {
+      expect(step.attributes()).not.toHaveProperty('data-invalid')
+    })
+    expect(
+      wrapper.find('.formkit-outer[data-type="text"]').attributes()
+    ).not.toHaveProperty('data-invalid')
+    expect(
+      wrapper.findAll('.formkit-outer[data-type="text"]')[1].attributes()
+    ).toHaveProperty('data-invalid')
+    wrapper.unmount()
+  })
+
   it('Does not allow step advancement when current step is invalid', async () => {
     const wrapper = mount(FormKitSchema, {
       props: {

--- a/packages/addons/src/plugins/multiStep/sections/multiStepOuter.ts
+++ b/packages/addons/src/plugins/multiStep/sections/multiStepOuter.ts
@@ -17,9 +17,6 @@ export const multiStepOuter = createSection('multiStepOuter', () => ({
     'data-multiple':
       '$attrs.multiple || ($type != "select" && $options != undefined) || undefined',
     'data-disabled': '$disabled || undefined',
-    'data-invalid':
-      '$state.valid === false && $state.validationVisible || undefined',
-    'data-errors': '$state.errors || undefined',
     'data-submitted': '$state.submitted || undefined',
   },
 }))

--- a/packages/addons/src/plugins/multiStep/sections/stepOuter.ts
+++ b/packages/addons/src/plugins/multiStep/sections/stepOuter.ts
@@ -12,9 +12,6 @@ export const stepOuter = createSection('stepOuter', () => ({
     key: '$id',
     'data-type': 'step',
     'data-disabled': '$disabled || undefined',
-    'data-invalid':
-      '$state.valid === false && $state.validationVisible || undefined',
-    'data-errors': '$state.errors || undefined',
     'data-submitted': '$state.submitted || undefined',
     id: '$id',
     role: 'tabpanel',


### PR DESCRIPTION
Fixes #1208.

## What changed
- Stops structural `multi-step` and `step` containers from exposing aggregate `data-invalid`/`data-errors` attributes.
- Keeps invalid state on the actual invalid child inputs, preventing parent multistep state from activating descendant invalid variants on valid fields.
- Adds a regression test that submits an invalid multistep form and verifies valid child inputs do not inherit parent invalid styling state.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/multistep.spec.ts -t "#1208" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/multistep.spec.ts --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__ --reporter verbose`
- `pnpm vitest --typecheck.only --run`

## Local build note
- `node scripts/cli.mjs --script build addons` still fails during DTS generation on the existing local `@formkit/auto-animate` package exports/type-resolution issue.

## Security
- No new user-controlled execution paths or HTML injection surfaces; this only removes aggregate state attributes from structural addon containers.