### PR TITLE
fix: refresh floating label background

### DIFF
--- a/packages/addons/__tests__/floatingLabels.spec.ts
+++ b/packages/addons/__tests__/floatingLabels.spec.ts
@@ -2,9 +2,14 @@ import { h } from 'vue'
 import { mount } from '@vue/test-utils'
 import { FormKit, plugin, defaultConfig, resetCount } from '@formkit/vue'
 import { createFloatingLabelsPlugin } from '../src/plugins/floatingLabels/floatingLabelsPlugin'
-import { FormKitNode, FormKitPlugin, FormKitSectionsSchema } from '@formkit/core'
+import {
+  FormKitNode,
+  FormKitPlugin,
+  FormKitSectionsSchema,
+  getNode,
+} from '@formkit/core'
 import { clone } from '@formkit/utils'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * A test plugin that adds a custom data attribute to the outer section.
@@ -43,6 +48,8 @@ describe('floatingLabels', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.className = ''
     document.body.innerHTML = ''
   })
 
@@ -131,6 +138,52 @@ describe('floatingLabels', () => {
 
     await new Promise((r) => setTimeout(r, 10))
     expect(wrapper.html()).toContain('data-floating-label="true"')
+    wrapper.unmount()
+  })
+
+  it('updates label background color when an ancestor theme class changes (#1243)', async () => {
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
+      const backgroundColor =
+        element === document.body
+          ? document.body.classList.contains('dark')
+            ? 'rgb(0, 0, 0)'
+            : 'rgb(255, 255, 255)'
+          : 'rgba(0, 0, 0, 0)'
+
+      return {
+        backgroundColor,
+        getPropertyValue: () => '1',
+        paddingLeft: '0px',
+      } as unknown as CSSStyleDeclaration
+    })
+    const wrapper = mount(FormKit, {
+      props: {
+        id: 'floating-theme',
+        type: 'text',
+        label: 'Test Label',
+        floatingLabel: true,
+      },
+      attachTo: document.body,
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              plugins: [createFloatingLabelsPlugin()],
+            }),
+          ],
+        ],
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 110))
+    const node = getNode('floating-theme')!
+    expect(node.props._labelBackgroundColor).toBe('rgb(255, 255, 255)')
+
+    document.body.classList.add('dark')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(node.props._labelBackgroundColor).toBe('rgb(0, 0, 0)')
     wrapper.unmount()
   })
 })

--- a/packages/addons/src/plugins/floatingLabels/floatingLabelsPlugin.ts
+++ b/packages/addons/src/plugins/floatingLabels/floatingLabelsPlugin.ts
@@ -63,6 +63,23 @@ function setBackgroundColor(
   }, timeout)
 }
 
+function observeBackgroundAncestors(
+  nodeRoot: HTMLElement,
+  callback: () => void
+): MutationObserver | undefined {
+  if (typeof MutationObserver === 'undefined') return
+  const observer = new MutationObserver(callback)
+  let element: HTMLElement | null = nodeRoot
+  while (element) {
+    observer.observe(element, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    })
+    element = element.parentElement
+  }
+  return observer
+}
+
 /**
  * Creates a new floating label plugin.
  *
@@ -77,6 +94,7 @@ export function createFloatingLabelsPlugin(
 ): FormKitPlugin {
   const floatingLabelsPlugin = (node: FormKitNode) => {
     let nodeEl: HTMLElement | null = null
+    let backgroundObserver: MutationObserver | undefined
     node.addProps({
       floatingLabel: {
         boolean: true,
@@ -190,6 +208,10 @@ export function createFloatingLabelsPlugin(
           nodeEl = document.getElementById(node.context?.id)
           if (!nodeEl) return
           setBackgroundColor(node, nodeEl, 100)
+          backgroundObserver = observeBackgroundAncestors(nodeEl, () => {
+            if (!node.context || !nodeEl) return
+            setBackgroundColor(node, nodeEl, 0)
+          })
           observer.observe(nodeEl.parentNode as Node, {
             childList: true,
             subtree: true,
@@ -209,6 +231,11 @@ export function createFloatingLabelsPlugin(
           node.props._labelOffset = `calc(${offset}px - 0.25em)`
         }
       }
+
+      node.on('destroyed', () => {
+        backgroundObserver?.disconnect()
+        backgroundObserver = undefined
+      })
     }
   }
   return floatingLabelsPlugin


### PR DESCRIPTION
Fixes #1243.

## What changed
- Watches the floating-label input and its ancestors for class/style mutations.
- Re-runs the existing label background calculation when an ancestor theme class changes, covering common light/dark-mode strategies on containers, `body`, or `html`.
- Adds a regression test that toggles a `body.dark` class and verifies the node label background color updates.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/floatingLabels.spec.ts -t "#1243" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__ --reporter verbose`
- `pnpm vitest --typecheck.only --run`

## Local build note
- `node scripts/cli.mjs --script build addons` still fails during DTS generation on the existing local `@formkit/auto-animate` package exports/type-resolution issue.

## Security
- No new user-controlled execution paths or HTML injection surfaces; this only observes ancestor class/style mutations and updates an internal background-color prop.