### PR TITLE
fix: emit reset events to descendants

### DIFF
--- a/packages/core/src/reset.ts
+++ b/packages/core/src/reset.ts
@@ -94,6 +94,7 @@ export function reset(
     node._e.play(node)
     clearState(node)
     node.emit('reset', node)
+    node.walk((child) => child.emit('reset', child))
     return node
   }
   warn(152, id)

--- a/packages/vue/__tests__/inputs/file.spec.ts
+++ b/packages/vue/__tests__/inputs/file.spec.ts
@@ -144,6 +144,41 @@ describe('file inputs', () => {
     await new Promise((r) => setTimeout(r, 20))
     expect(wrapper.find('.formkit-no-files').exists()).toBe(true)
   })
+  it('clears the native file input value when its parent form resets (#1249)', async () => {
+    const formId = 'file-reset-form'
+    const fileId = 'file-reset-input'
+    const wrapper = mount(
+      {
+        template: `
+          <FormKit id="${formId}" type="form">
+            <FormKit
+              id="${fileId}"
+              type="file"
+              name="file"
+            />
+          </FormKit>
+      `,
+      },
+      {
+        attachTo: document.body,
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+    const fileInput = wrapper.find(`#${fileId}`).element as HTMLInputElement
+    Object.defineProperty(fileInput, 'value', {
+      configurable: true,
+      writable: true,
+      value: 'C:\\fakepath\\test.jpg',
+    })
+
+    getNode(formId)!.reset()
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(fileInput.value).toBe('')
+    wrapper.unmount()
+  })
   it('always renders data-multiple="true" when the multiple attribute exists and is not false', () => {
     const wrapper = mount(
       {


### PR DESCRIPTION
Fixes #1249.

## What changed
- Emits `reset` events on descendant nodes after a parent/group/form reset completes.
- This lets file inputs run their existing DOM clear logic when the parent form is reset, so the native file input value is cleared along with FormKit state.
- Adds a Vue regression test that sets a fake native file input value, resets the parent form, and verifies the DOM value is emptied.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/file.spec.ts -t "#1249" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/file.spec.ts packages/react/__tests__/inputs/file.spec.ts --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/core/__tests__/node.spec.ts packages/core/__tests__/store.spec.ts --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/form.spec.ts packages/react/__tests__/inputs/form.spec.ts --reporter verbose`
- `pnpm vitest --typecheck.only --run`
- `for pkg in utils core dev observer validation i18n inputs rules themes vue react; do node scripts/cli.mjs --script build "$pkg" || exit 1; done`

## Security
- No new user-controlled execution paths or HTML injection surfaces; this propagates existing reset lifecycle events to already-owned descendant nodes.