### PR TITLE
fix: preserve float input editing text

### DIFF
--- a/packages/react/__tests__/inputs/text.spec.ts
+++ b/packages/react/__tests__/inputs/text.spec.ts
@@ -184,6 +184,39 @@ describe('the number feature (react)', () => {
     expect(getNode(id)!.value).toBe(123.123)
   })
 
+  it('preserves raw float text in the DOM context while editing (#1262)', async () => {
+    const id = `a${token()}`
+
+    renderWithFormKit(
+      createElement(FormKit as any, {
+        id,
+        type: 'number',
+        number: 'float',
+        delay: 0,
+      }),
+      defaultConfig()
+    )
+    const node = getNode(id)!
+    const input = async (value: string) => {
+      node.context!.handlers.DOMInput({
+        target: { value },
+      } as unknown as Event)
+      await node.settled
+    }
+
+    await input('0.')
+    expect(node.value).toBe(0)
+    expect(node.context!._value).toBe('0.')
+
+    await input('0.0')
+    expect(node.value).toBe(0)
+    expect(node.context!._value).toBe('0.0')
+
+    await input('0.01')
+    expect(node.value).toBe(0.01)
+    expect(node.context!._value).toBe(0.01)
+  })
+
   it('forces initial values to an integer when number is integer', async () => {
     const id = `a${token()}`
 

--- a/packages/react/src/bindings.ts
+++ b/packages/react/src/bindings.ts
@@ -222,6 +222,22 @@ const reactBindings: FormKitPlugin = function reactBindings(node) {
 
   let committedValue = node.value
   let inputValue = node.value
+  let pendingDOMInputValue: string | undefined
+
+  const domInputValue = (payload: unknown) => {
+    if (
+      typeof pendingDOMInputValue === 'string' &&
+      typeof node.props.number !== 'undefined' &&
+      node.props.number !== 'integer' &&
+      typeof payload === 'number' &&
+      Number.isFinite(payload) &&
+      pendingDOMInputValue.includes('.') &&
+      pendingDOMInputValue !== String(payload)
+    ) {
+      return pendingDOMInputValue
+    }
+    return payload
+  }
 
   let contextRef: FormKitFrameworkContext | undefined
   const notifyContextMutation = () => {
@@ -261,7 +277,8 @@ const reactBindings: FormKitPlugin = function reactBindings(node) {
         )
       },
       DOMInput: (e: Event) => {
-        node.input((e.target as HTMLInputElement).value)
+        pendingDOMInputValue = (e.target as HTMLInputElement).value
+        node.input(pendingDOMInputValue)
         node.emit('dom-input-event', e)
       },
     },
@@ -450,7 +467,7 @@ const reactBindings: FormKitPlugin = function reactBindings(node) {
     if (node.type !== 'input') {
       context._value = shallowClone(payload)
     } else {
-      context._value = payload
+      context._value = domInputValue(payload)
     }
     flush()
   })
@@ -460,8 +477,9 @@ const reactBindings: FormKitPlugin = function reactBindings(node) {
       context.value = context._value = shallowClone(payload)
     } else {
       context.value = payload
-      context._value = payload
+      context._value = domInputValue(payload)
     }
+    pendingDOMInputValue = undefined
     context.state.empty = empty(payload)
     queueMicrotask(() => {
       if (node) node.emit('modelUpdated')

--- a/packages/vue/__tests__/inputs/text.spec.ts
+++ b/packages/vue/__tests__/inputs/text.spec.ts
@@ -249,6 +249,38 @@ describe('the number feature', () => {
     const node = getNode(id)!
     expect(node.value).toBe(123.123)
   })
+  it('preserves raw float text in the DOM context while editing (#1262)', async () => {
+    const id = `a${token()}`
+    mount(FormKit, {
+      props: {
+        id,
+        type: 'number',
+        number: 'float',
+        delay: 0,
+      },
+      ...global,
+    })
+    await nextTick()
+    const node = getNode(id)!
+    const input = async (value: string) => {
+      node.context!.handlers.DOMInput({
+        target: { value },
+      } as unknown as Event)
+      await node.settled
+    }
+
+    await input('0.')
+    expect(node.value).toBe(0)
+    expect(node.context!._value).toBe('0.')
+
+    await input('0.0')
+    expect(node.value).toBe(0)
+    expect(node.context!._value).toBe('0.0')
+
+    await input('0.01')
+    expect(node.value).toBe(0.01)
+    expect(node.context!._value).toBe(0.01)
+  })
   it('forces initial values to a float on a hidden input by default', async () => {
     const id = `a${token()}`
     mount(FormKit, {

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -249,6 +249,22 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
 
   const value = ref(node.value)
   const _value = ref(node.value)
+  let pendingDOMInputValue: string | undefined
+
+  const domInputValue = (payload: unknown) => {
+    if (
+      typeof pendingDOMInputValue === 'string' &&
+      typeof node.props.number !== 'undefined' &&
+      node.props.number !== 'integer' &&
+      typeof payload === 'number' &&
+      Number.isFinite(payload) &&
+      pendingDOMInputValue.includes('.') &&
+      pendingDOMInputValue !== String(payload)
+    ) {
+      return pendingDOMInputValue
+    }
+    return payload
+  }
 
   const context: FormKitFrameworkContext = reactive({
     _value,
@@ -282,7 +298,8 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
         )
       },
       DOMInput: (e: Event) => {
-        node.input((e.target as HTMLInputElement).value)
+        pendingDOMInputValue = (e.target as HTMLInputElement).value
+        node.input(pendingDOMInputValue)
         node.emit('dom-input-event', e)
       },
     },
@@ -415,7 +432,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
     if (node.type !== 'input' && !isRef(payload) && !isReactive(payload)) {
       _value.value = shallowClone(payload)
     } else {
-      _value.value = payload
+      _value.value = domInputValue(payload)
       triggerRef(_value)
     }
   })
@@ -433,9 +450,11 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
     if (node.type !== 'input' && !isRef(payload) && !isReactive(payload)) {
       value.value = _value.value = shallowClone(payload)
     } else {
-      value.value = _value.value = payload
+      value.value = payload
+      _value.value = domInputValue(payload)
       triggerRef(value)
     }
+    pendingDOMInputValue = undefined
     node.emit('modelUpdated')
   })
 


### PR DESCRIPTION
Closes #1262

## What changed
- Preserve raw DOM input text for non-canonical float edits like `0.` and `0.0` while keeping the FormKit node value numeric.
- Apply the same DOM-facing `_value` handling in both Vue and React bindings.
- Add Vue and React regressions for `type="number" number="float"` editing around the decimal separator.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/text.spec.ts packages/react/__tests__/inputs/text.spec.ts -t "#1262" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/text.spec.ts packages/react/__tests__/inputs/text.spec.ts --reporter verbose`
- `pnpm vitest --typecheck.only --run`
- `for pkg in utils core dev observer validation i18n inputs rules themes vue react; do node scripts/cli.mjs --script build "$pkg" || exit 1; done`

## Security
- No new user-controlled HTML, script execution, network access, or dependency changes.