### PR TITLE
fix: bubble synced list destroying events

### DIFF
--- a/packages/core/__tests__/lists.spec.ts
+++ b/packages/core/__tests__/lists.spec.ts
@@ -114,6 +114,30 @@ describe('lists', () => {
     expect(commitListener).toHaveBeenCalledTimes(1)
   })
 
+  it('bubbles destroying events for synced list children removed by value (#1291)', async () => {
+    const removed = createNode({ value: 'remove@example.com' })
+    const kept = createNode({ value: 'keep@example.com' })
+    const repeater = createNode({
+      type: 'list',
+      value: ['remove@example.com', 'keep@example.com'],
+      sync: true,
+      children: [removed, kept],
+    })
+    const destroying = vi.fn()
+    repeater.on('destroying.deep', destroying)
+
+    repeater.input(['keep@example.com'], false)
+    await repeater.settled
+
+    expect(repeater.children).toHaveLength(1)
+    expect(repeater.children[0]?.uid).toBe(kept.uid)
+    expect(removed.parent).toBeNull()
+    expect(destroying).toHaveBeenCalledTimes(1)
+    const [event] = destroying.mock.calls[0]
+    expect(event.origin.uid).toBe(removed.uid)
+    expect(event.payload.uid).toBe(removed.uid)
+  })
+
   it('emits a singe commit event for type list', () => {
     const commitEvent = vi.fn()
     const lib = function libraryPlugin() {}

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -2127,9 +2127,11 @@ function syncListNodes(node: FormKitNode, context: FormKitContext) {
       if (!('__FKP' in child)) {
         const parent = child._c.parent
         if (!parent || isPlaceholder(parent)) return
+        // Emit before detaching so deep listeners on ancestors can observe it.
+        child.emit('destroying', child)
         parent.ledger.unmerge(child)
         child._c.parent = null
-        child.destroy()
+        destroy(child, child._c, false)
       }
     })
   }
@@ -2202,8 +2204,12 @@ function calm(
  *
  * @internal
  */
-function destroy(node: FormKitNode, context: FormKitContext) {
-  node.emit('destroying', node)
+function destroy(
+  node: FormKitNode,
+  context: FormKitContext,
+  emitDestroying = true
+) {
+  if (emitDestroying) node.emit('destroying', node)
   // flush all messages out
   node.store.filter(() => false)
   if (node.parent) {


### PR DESCRIPTION
Closes #1291

## What changed
- Emit `destroying` for synced-list children before detaching them from their parent so ancestor `destroying.deep` listeners can observe removals.
- Continue the existing synced-list cleanup path without re-removing values or emitting a duplicate local `destroying` event.
- Add a core synced-list regression for value-driven child removal.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/core/__tests__/lists.spec.ts -t "#1291" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/core/__tests__/lists.spec.ts packages/core/__tests__/node.spec.ts packages/core/__tests__/ledger.spec.ts --reporter verbose`
- `for pkg in utils core; do node scripts/cli.mjs --script build "$pkg" || exit 1; done`
- `pnpm vitest --typecheck.only --run`

## Security
- No new user-controlled HTML, script execution, network access, or dependency changes.