### PR TITLE
fix: preserve auto-import named slots

### DIFF
--- a/packages/nuxt/__tests__/autoImport.spec.ts
+++ b/packages/nuxt/__tests__/autoImport.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { formKitAutoImportPlugin } from '../src/autoImport'
+
+describe('auto-import transform', () => {
+  it('wraps root components instead of their named slots (#1300)', async () => {
+    const plugin = formKitAutoImportPlugin({
+      defaultConfig: true,
+      configFile: '/missing/formkit.config',
+    })
+    const result = await plugin.transform(
+      `<template>
+  <Dialog>
+    <template #header>
+      <h1>Create event</h1>
+    </template>
+    <template #default>
+      <FormKit type="text" />
+    </template>
+    <template #footer>
+      <button>Create</button>
+    </template>
+  </Dialog>
+</template>`,
+      '/components/MyWrapperComponent.vue'
+    )
+
+    expect(result?.code).toMatch(
+      /<template>\s*<FormKitLazyProvider[^>]*>\s*<Dialog>/
+    )
+    expect(result?.code).toMatch(
+      /<\/Dialog>\s*<\/FormKitLazyProvider>\s*<\/template>/
+    )
+    expect(result?.code).not.toMatch(
+      /<Dialog>\s*<FormKitLazyProvider[^>]*>\s*<template #header>/
+    )
+  })
+})

--- a/packages/nuxt/src/autoImport.ts
+++ b/packages/nuxt/src/autoImport.ts
@@ -1,0 +1,104 @@
+import { existsSync } from 'fs'
+import { resolve } from 'pathe'
+
+const CONTAINS_FORMKIT_RE = /<FormKit|<form-kit/
+const FORMKIT_CONFIG_RE = /(\/\*\s?@__formkit\.config\.ts__\s?\*\/(?:.|\n)+?)\)/g
+
+function scriptLangAttr(code: string): string {
+  const scriptOpen = code.match(/<script\b([^>]*)>/)
+  if (!scriptOpen) return ''
+  const lang = scriptOpen[1].match(/\blang=(["'])(.*?)\1/)
+  return lang?.[2] ? ` lang="${lang[2]}"` : ''
+}
+
+function injectProviderImport(code: string): string {
+  const importStatement = `import { FormKitLazyProvider } from '@formkit/vue'`
+  const setupScript = code.match(/<script\b([^>]*)\bsetup\b([^>]*)>/)
+  if (!setupScript || setupScript.index === undefined) {
+    return `<script setup${scriptLangAttr(code)}>${importStatement}</script>
+${code}`
+  }
+  const startAt = setupScript.index + setupScript[0].length
+  return `${code.substring(0, startAt)}
+${importStatement}${code.substring(startAt)}`
+}
+
+function injectProviderComponent(
+  code: string,
+  id: string,
+  config: boolean,
+  defaultConfig?: boolean
+) {
+  const templateOpen = code.match(/<template\b[^>]*>/)
+  const endInsertAt = code.lastIndexOf('</template>')
+  if (!templateOpen || templateOpen.index === undefined || endInsertAt === -1) {
+    console.warn(
+      `No <template> block found in ${id}. Skipping FormKitLazyProvider injection.`
+    )
+    return { code, map: null }
+  }
+  const open = `<FormKitLazyProvider${config ? ' config-file="true"' : ''}${
+    defaultConfig === false ? ' :default-config="false"' : ''
+  }>`
+  const close = '</FormKitLazyProvider>'
+  const startInsertAt = templateOpen.index + templateOpen[0].length
+  code = `${code.substring(0, startInsertAt)}
+${open}
+${code.substring(startInsertAt, endInsertAt)}
+${close}
+${code.substring(endInsertAt)}`
+  return { code, map: null }
+}
+
+function resolveConfig(configFile: string): string | undefined {
+  const exts = ['ts', 'mjs', 'js']
+  const dir = configFile.startsWith('.') ? process.cwd() : ''
+  const paths = exts.some((ext) => configFile.endsWith(ext))
+    ? [resolve(dir, configFile)]
+    : exts.map((ext) => resolve(dir, `${configFile}.${ext}`))
+  return paths.find((path) => existsSync(path))
+}
+
+export function formKitAutoImportPlugin(options: {
+  configFile?: string
+  defaultConfig?: boolean
+}) {
+  const configPath = resolveConfig(options.configFile || './formkit.config')
+  return {
+    name: 'unplugin-formkit',
+    enforce: 'pre' as const,
+    vite: {
+      config() {
+        return {
+          optimizeDeps: {
+            exclude: ['@formkit/vue'],
+          },
+        }
+      },
+    },
+    transformInclude() {
+      return true
+    },
+    async transform(code: string, id: string) {
+      if (configPath && FORMKIT_CONFIG_RE.test(code)) {
+        code = code.replace(FORMKIT_CONFIG_RE, `"${configPath}")`)
+        if (options.defaultConfig === false) {
+          code = code.replace(
+            /\/\* @__default-config__ \*\/(?:.|\n)+?\/\* @__default-config__ \*\//gi,
+            ''
+          )
+        }
+        return { code, map: null }
+      }
+      if (id.endsWith('.vue') && CONTAINS_FORMKIT_RE.test(code)) {
+        return injectProviderComponent(
+          injectProviderImport(code),
+          id,
+          !!configPath,
+          options.defaultConfig
+        )
+      }
+      return
+    },
+  }
+}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -14,7 +14,7 @@ import {
 } from '@nuxt/kit'
 import { createUnplugin } from 'unplugin'
 import type { NuxtModule } from '@nuxt/schema'
-import { unpluginFactory as unpluginFormKit } from 'unplugin-formkit'
+import { formKitAutoImportPlugin } from './autoImport'
 
 /**
  * Optional FormKit packages that should have their types registered if installed.
@@ -199,13 +199,10 @@ const useAutoImport = async function installLazy(options, nuxt) {
 
   addBuildPlugin(
     createUnplugin(
-      unpluginFormKit.bind(
-        {},
-        {
-          defaultConfig: options.defaultConfig,
-          configFile: configBase,
-        }
-      ) as unknown as typeof unpluginFormKit
+      formKitAutoImportPlugin.bind(null, {
+        defaultConfig: options.defaultConfig,
+        configFile: configBase,
+      })
     )
   )
 } satisfies NuxtModule<ModuleOptions>


### PR DESCRIPTION
Closes #1300

## What changed
- Moves the Nuxt auto-import transform into `@formkit/nuxt` so the injected `FormKitLazyProvider` wraps the full template content.
- Prevents root component named slots from being captured by `FormKitLazyProvider` instead of the wrapped component.
- Adds a transform regression for a root component with `#header`, `#default`, and `#footer` slots.

## Verification
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/nuxt/__tests__/autoImport.spec.ts --reporter verbose`
- `pnpm vitest --typecheck.only --run`

## Local environment notes
- `pnpm -C packages/nuxt test -- --run` is blocked in this worktree by a missing package-local Vitest binary under `.node_modules_tmp`.
- `node scripts/cli.mjs --script build nuxt` is blocked in this worktree by a missing package-local `@nuxt/module-builder` binary.

## Security
- No new user-controlled HTML execution, network access, or dependency changes. The transform only changes where the existing provider wrapper is inserted.