### PR TITLE
test: cover sibling validation refresh

### DIFF
--- a/packages/validation/__tests__/validation.spec.ts
+++ b/packages/validation/__tests__/validation.spec.ts
@@ -560,6 +560,62 @@ describe('validation rule sequencing', () => {
     expect(foo.store).not.toHaveProperty('rule_length')
   })
 
+  it('reruns sibling-dependent rules when followed by other rules (#1348)', async () => {
+    const distinct: FormKitValidationRule = vi.fn((node) => {
+      const parent = node.at('$parent')
+      if (!parent || typeof node.name !== 'string') return true
+      const parentValue = parent.value as Record<string, unknown>
+      for (const siblingName in parentValue) {
+        if (siblingName === node.name) continue
+        if (parentValue[siblingName] === node.value) return false
+      }
+      return true
+    })
+    const length: FormKitValidationRule = vi.fn(({ value }, min, max) => {
+      const size = String(value).length
+      return size >= parseInt(min) && size <= parseInt(max)
+    })
+    const validation = createValidationPlugin({ distinct, length })
+    const form = createNode({
+      type: 'group',
+      value: { myItems: { first: 'a', second: 'b', third: 'b' } },
+      plugins: [validation],
+      children: [
+        createNode({
+          type: 'group',
+          name: 'myItems',
+          children: [
+            createNode({
+              name: 'first',
+              props: { validation: 'distinct|length:0,5' },
+            }),
+            createNode({
+              name: 'second',
+              props: { validation: 'distinct|length:0,5' },
+            }),
+            createNode({
+              name: 'third',
+              props: { validation: 'distinct|length:0,5' },
+            }),
+          ],
+        }),
+      ],
+    })
+    const second = form.at('$self.myItems.second')!
+    const third = form.at('$self.myItems.third')!
+    await nextTick()
+    expect(Boolean(second.store.rule_distinct)).toBe(true)
+    expect(Boolean(third.store.rule_distinct)).toBe(true)
+    second.input('c', false)
+    await nextTick()
+    expect(Boolean(second.store.rule_distinct)).toBe(false)
+    expect(Boolean(third.store.rule_distinct)).toBe(false)
+    second.input('b', false)
+    await nextTick()
+    expect(Boolean(second.store.rule_distinct)).toBe(true)
+    expect(Boolean(third.store.rule_distinct)).toBe(true)
+  })
+
   it('removes validation messages that come after failing rules', async () => {
     const node = createNode({
       plugins: [validationPlugin],


### PR DESCRIPTION
## What changed

- Adds a regression test for #1348 using the decoded playground scenario: nested initial form value, a custom `distinct` rule that reads `parent.value`, and a second `length:0,5` rule in the same validation stack.
- Verifies the sibling-dependent validation messages clear when one duplicate changes and return on both duplicated fields when the duplicate value is restored.
- No runtime implementation change was needed on `release/2.0.1`; the reported sequence already passes on current code, so this PR locks in the expected behavior.

## Verification

- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/validation/__tests__/validation.spec.ts -t "#1348" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/validation/__tests__/validation.spec.ts --reporter verbose`
- `pnpm vitest --typecheck.only --run`
- `for pkg in utils core observer validation; do node scripts/cli.mjs --script build "$pkg" || exit 1; done`

## Security

- Test-only change. No production validation logic, input parsing, dependency handling, or data exposure paths were changed.

Closes #1348
