### PR TITLE
fix: clear form loading after submit rejection

### DIFF
--- a/packages/inputs/src/features/forms.ts
+++ b/packages/inputs/src/features/forms.ts
@@ -67,9 +67,12 @@ async function handleSubmit(node: FormKitNode, submitEvent: Event) {
           node.props.submitBehavior !== 'live'
         if (autoDisable) node.props.disabled = true
         node.store.set(loading)
-        await retVal
-        if (autoDisable) node.props.disabled = false
-        node.store.remove('loading')
+        try {
+          await retVal
+        } finally {
+          if (autoDisable) node.props.disabled = false
+          node.store.remove('loading')
+        }
       }
     } else {
       if (submitEvent.target instanceof HTMLFormElement) {

--- a/packages/vue/__tests__/inputs/form.spec.ts
+++ b/packages/vue/__tests__/inputs/form.spec.ts
@@ -953,6 +953,45 @@ describe('form submission', () => {
     expect(button.element.disabled).toBe(false)
   })
 
+  it('re-enables the form when an async submit handler rejects (#1415)', async () => {
+    let rejectSubmit!: (error: Error) => void
+    const wrapper = mount(
+      {
+        methods: {
+          doSave() {
+            return new Promise((_, reject) => {
+              rejectSubmit = reject
+            })
+          },
+        },
+        template: `<FormKit id="rejecting-form" type="form" @submit="doSave">
+          <FormKit type="text" name="foo" />
+        </FormKit>`,
+      },
+      {
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+    const node = getNode('rejecting-form')!
+    const event = new Event('submit', { cancelable: true, bubbles: true })
+    Object.defineProperty(event, 'target', {
+      value: wrapper.find('form').element,
+    })
+    const submit = node.context?.handlers.submit(event) as Promise<void>
+    await new Promise((r) => setTimeout(r, 10))
+    expect(wrapper.find('form').element.hasAttribute('data-loading')).toBe(true)
+    expect(wrapper.find('input').element.disabled).toBe(true)
+    rejectSubmit(new Error('submit failed'))
+    await expect(submit).rejects.toThrow('submit failed')
+    await nextTick()
+    expect(wrapper.find('form').element.hasAttribute('data-loading')).toBe(
+      false
+    )
+    expect(wrapper.find('input').element.disabled).toBe(false)
+  })
+
   it('the form remains enabled if submit-behavior is live', async () => {
     const wrapper = mount(
       {


### PR DESCRIPTION
## What changed

- Wraps awaited async form submit handlers in `try/finally` so FormKit always removes the loading message and restores auto-disabled form state when the handler rejects.
- Preserves existing rejection propagation from the submit handler; this only guarantees FormKit cleanup runs.
- Adds a Vue regression test that verifies a rejecting async submit handler no longer leaves the form/input disabled or stuck with `data-loading`.

## Verification

- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/form.spec.ts -t "#1415" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/vue/__tests__/inputs/form.spec.ts --reporter verbose`
- `pnpm vitest --typecheck.only --run`
- `for pkg in utils core inputs vue; do node scripts/cli.mjs --script build "$pkg" || exit 1; done`

## Security

- No new inputs, parsing, or data exposure paths. The change only ensures internal loading/disabled cleanup runs after rejected user-provided submit promises.

Closes #1415
