### PR TITLE
fix: defer initial multistep goTo validation

### DIFF
--- a/packages/addons/__tests__/multistep.spec.ts
+++ b/packages/addons/__tests__/multistep.spec.ts
@@ -7,6 +7,7 @@ import {
   defaultConfig,
   resetCount,
 } from '@formkit/vue'
+import { getNode } from '@formkit/core'
 import { createMultiStepPlugin } from '../src/plugins/multiStep/multiStepPlugin'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -313,6 +314,47 @@ describe('multistep', () => {
     await new Promise((r) => setTimeout(r, 15))
     // 2nd tab is active (without labels due to props)
     expect(wrapper.html()).toMatchSnapshot()
+    wrapper.unmount()
+  })
+
+  it('allows initial goTo after the current step settles (#1362)', async () => {
+    const id = 'multi-step-go-to'
+    const wrapper = mount(
+      {
+        data() {
+          return { id }
+        },
+        mounted() {
+          getNode(id)?.goTo('favorite')
+        },
+        template: `
+          <FormKit :id="id" type="multi-step" :allow-incomplete="false">
+            <FormKit type="step" name="basics">
+              <FormKit type="text" name="name" value="Ada" validation="required" />
+            </FormKit>
+            <FormKit type="step" name="favorite">
+              <FormKit type="text" name="color" />
+            </FormKit>
+          </FormKit>
+        `,
+      },
+      {
+        attachTo: document.body,
+        global: {
+          plugins: [
+            [
+              plugin,
+              defaultConfig({
+                plugins: [createMultiStepPlugin()],
+              }),
+            ],
+          ],
+        },
+      }
+    )
+
+    await new Promise((r) => setTimeout(r, 25))
+    expect(getNode(id)?.props.activeStep).toBe('favorite')
     wrapper.unmount()
   })
 

--- a/packages/addons/src/plugins/multiStep/multiStepPlugin.ts
+++ b/packages/addons/src/plugins/multiStep/multiStepPlugin.ts
@@ -282,6 +282,16 @@ async function isTargetStepAllowed(
   targetStep: FormKitFrameworkContext
 ): Promise<boolean> {
   if (currentStep === targetStep) return true
+  const nodes = [currentStep.node]
+  currentStep.node.walk((node) => {
+    nodes.push(node)
+  })
+  await Promise.all(nodes.map((node) => node.settled))
+  await Promise.all(
+    nodes
+      .filter((node) => node.ledger.value('validating'))
+      .map((node) => node.ledger.settled('validating'))
+  )
   const { allowIncomplete } = currentStep.node.parent?.props || {}
   const parentNode = currentStep.node.parent
   const currentStepIndex = parentNode?.props.steps.indexOf(currentStep)
@@ -364,6 +374,40 @@ async function setActiveStep(targetStep: FormKitFrameworkContext, e?: Event) {
       targetStep.node.parent.props.activeStep = targetStep.node.name
     }
   }
+}
+
+function findTargetStep(
+  node: FormKitNode,
+  target: number | string
+): FormKitFrameworkContext | undefined {
+  if (typeof target === 'number') {
+    return node.props.steps[target]
+  }
+  return node.props.steps.find(
+    (step: Record<string, any>) => step.node.name === target
+  )
+}
+
+function goToStep(node: FormKitNode, target: number | string) {
+  // goTo is often called during mount, before child steps and their values have
+  // finished initializing.
+  setTimeout(() => attemptGoToStep(node, target), 0)
+}
+
+function attemptGoToStep(node: FormKitNode, target: number | string) {
+  const targetStep = findTargetStep(node, target)
+  if (targetStep) {
+    setActiveStep(targetStep)
+    return
+  }
+  const receipt = node.on('child', () => {
+    const targetStep = findTargetStep(node, target)
+    if (targetStep) {
+      node.off(receipt)
+      setActiveStep(targetStep)
+    }
+  })
+  node.on('destroying', () => node.off(receipt))
 }
 
 /**
@@ -547,15 +591,7 @@ export function createMultiStepPlugin(
         })
         node.extend('goTo', {
           get: (node) => (target: number | string) => {
-            if (typeof target === 'number') {
-              const targetStep = node.props.steps[target]
-              setActiveStep(targetStep)
-            } else if (typeof target === 'string') {
-              const targetStep = node.props.steps.find(
-                (step: Record<string, any>) => step.node.name === target
-              )
-              setActiveStep(targetStep)
-            }
+            goToStep(node, target)
           },
           set: false,
         })


### PR DESCRIPTION
## What changed

- Defers `multi-step` `node.goTo()` by one tick so mount-time calls run after child steps and initial child values have started registering.
- If `goTo()` is called before the target step is present, it now waits for child registration and then applies the requested target.
- Before checking whether a target step is allowed, waits for the current step and descendants to settle and for any pending validation to finish.
- Adds a regression for #1362 where `goTo('favorite')` is called during mount and the first step has a valid default value with `allowIncomplete=false`.

## Verification

- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/multistep.spec.ts -t "#1362" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/multistep.spec.ts --reporter verbose`
- `pnpm vitest --typecheck.only --run`
- `node scripts/cli.mjs --script build addons` reached successful CJS/ESM addon bundles, then failed during DTS on the existing `@formkit/auto-animate` package exports/type resolution issue in `autoAnimatePlugin.ts`.

## Security

- No new inputs or data exposure paths. The change only adjusts multi-step navigation timing and validation gating for existing node state.

Closes #1362
