### PR TITLE
fix: omit file values from local storage

### DIFF
--- a/packages/addons/__tests__/localStorage.spec.ts
+++ b/packages/addons/__tests__/localStorage.spec.ts
@@ -1,0 +1,91 @@
+import { getNode } from '@formkit/core'
+import { defaultConfig, plugin } from '@formkit/vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createLocalStoragePlugin } from '../src/plugins/localStoragePlugin'
+
+const global = {
+  global: {
+    plugins: [
+      [
+        plugin,
+        defaultConfig({
+          plugins: [
+            createLocalStoragePlugin({
+              debounce: 0,
+              key: 'local-storage-test',
+            }),
+          ],
+        }),
+      ],
+    ],
+  },
+}
+
+describe('localStorage plugin', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('does not save file input values (#1363)', async () => {
+    const wrapper = mount(
+      {
+        template: `
+          <FormKit type="form" name="resumeForm" use-local-storage>
+            <FormKit type="text" name="name" value="Ada" />
+            <FormKit id="attachment-save" type="file" name="attachment" />
+          </FormKit>
+        `,
+      },
+      global
+    )
+    await new Promise((r) => setTimeout(r, 10))
+    await getNode('attachment-save')!.input(
+      [
+        {
+          name: 'resume.pdf',
+          file: new File(['resume'], 'resume.pdf'),
+        },
+      ],
+      false
+    )
+    await new Promise((r) => setTimeout(r, 10))
+    const stored = JSON.parse(
+      localStorage.getItem('formkit-local-storage-test-resumeForm') || '{}'
+    )
+    expect(stored.data).toEqual({ name: 'Ada' })
+    wrapper.unmount()
+  })
+
+  it('does not load stale cached file input values (#1363)', async () => {
+    localStorage.setItem(
+      'formkit-local-storage-test-uploadForm',
+      JSON.stringify({
+        maxAge: Date.now() + 1000,
+        data: {
+          name: 'Ada',
+          attachment: [{ name: 'resume.pdf' }],
+        },
+      })
+    )
+    const wrapper = mount(
+      {
+        template: `
+          <FormKit type="form" name="uploadForm" use-local-storage>
+            <FormKit type="text" name="name" />
+            <FormKit id="attachment-load" type="file" name="attachment" />
+          </FormKit>
+        `,
+      },
+      global
+    )
+    await new Promise((r) => setTimeout(r, 10))
+    expect(getNode('attachment-load')!.value).toEqual([])
+    expect(wrapper.find('.formkit-file-name').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/packages/addons/src/plugins/localStoragePlugin.ts
+++ b/packages/addons/src/plugins/localStoragePlugin.ts
@@ -1,4 +1,4 @@
-import { FormKitNode, FormKitPlugin } from '@formkit/core'
+import { FormKitNode, FormKitPlugin, isPlaceholder } from '@formkit/core'
 import { undefine } from '@formkit/utils'
 
 /**
@@ -24,6 +24,31 @@ export interface LocalStorageOptions {
   beforeSave?: (payload: any) => any
   beforeLoad?: (payload: any) => any
   clearOnSubmit?: boolean
+}
+
+function omitFileValues(value: unknown, node: FormKitNode): unknown {
+  if (!value || typeof value !== 'object') return value
+  const sanitized: Record<string | number, unknown> | unknown[] = Array.isArray(
+    value
+  )
+    ? [...value]
+    : { ...(value as Record<string | number, unknown>) }
+  node.children.forEach((child) => {
+    if (isPlaceholder(child)) return
+    const key = child.name as string | number
+    if (child.props.type === 'file') {
+      delete sanitized[key as keyof typeof sanitized]
+      return
+    }
+    const childValue = (value as Record<string | number, unknown>)[key]
+    if (childValue !== undefined) {
+      ;(sanitized as Record<string | number, unknown>)[key] = omitFileValues(
+        childValue,
+        child
+      )
+    }
+  })
+  return sanitized
 }
 
 /**
@@ -102,6 +127,9 @@ export function createLocalStoragePlugin(
         const value = forceValue || localStorage.getItem(storageKey)
         if (!value) return
         const loadValue = JSON.parse(value)
+        if (loadValue && typeof loadValue.data === 'object') {
+          loadValue.data = omitFileValues(loadValue.data, node)
+        }
         if (typeof localStorageOptions?.beforeLoad === 'function') {
           node.props.disabled = true
           try {
@@ -122,7 +150,7 @@ export function createLocalStoragePlugin(
       }
 
       const saveValue = async (payload: unknown) => {
-        let savePayload = payload
+        let savePayload = omitFileValues(payload, node)
         if (typeof localStorageOptions?.beforeSave === 'function') {
           try {
             savePayload = await localStorageOptions.beforeSave(payload)


### PR DESCRIPTION
## What changed

- Omits values for descendant `type="file"` nodes before the localStorage plugin saves default cached form data.
- Omits stale cached file values before default localStorage loads are applied, preventing false-positive hydrated file inputs that only contain file names/metadata.
- Adds localStorage plugin regressions for saving file inputs and loading stale cached file metadata.

## Verification

- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/localStorage.spec.ts --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__ --reporter verbose`
- `pnpm vitest --typecheck.only --run`
- `node scripts/cli.mjs --script build addons` reached successful CJS/ESM addon bundles, then failed during DTS on the existing `@formkit/auto-animate` package exports/type resolution issue in `autoAnimatePlugin.ts`.

## Security

- Prevents localStorage from persisting browser `File` objects or misleading file metadata by default. No new storage keys or data exposure paths were introduced.

Closes #1363
