### PR TITLE
fix: update multistep labels reactively

### DIFF
--- a/packages/addons/__tests__/multistep.spec.ts
+++ b/packages/addons/__tests__/multistep.spec.ts
@@ -316,6 +316,54 @@ describe('multistep', () => {
     wrapper.unmount()
   })
 
+  it('updates step tab labels when the label prop changes (#1377)', async () => {
+    const data = reactive({
+      firstLabel: 'First label',
+      secondLabel: 'Second label',
+    })
+    const wrapper = mount(FormKitSchema, {
+      props: {
+        data,
+        schema: [
+          {
+            $formkit: 'multi-step',
+            children: [
+              {
+                $formkit: 'step',
+                name: 'first',
+                label: '$firstLabel',
+              },
+              {
+                $formkit: 'step',
+                name: 'second',
+                label: '$secondLabel',
+              },
+            ],
+          },
+        ],
+      },
+      attachTo: document.body,
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              plugins: [createMultiStepPlugin()],
+            }),
+          ],
+        ],
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 15))
+    expect(wrapper.html()).toContain('First label')
+    data.firstLabel = 'Translated label'
+    await new Promise((r) => setTimeout(r, 15))
+    expect(wrapper.html()).toContain('Translated label')
+    expect(wrapper.html()).not.toContain('First label')
+    wrapper.unmount()
+  })
+
   it('preserves the order of steps even when a step is conditionally rendered', async () => {
     const data = reactive({
       showStepTwo: true,

--- a/packages/addons/src/plugins/multiStep/multiStepPlugin.ts
+++ b/packages/addons/src/plugins/multiStep/multiStepPlugin.ts
@@ -583,8 +583,12 @@ export function createMultiStepPlugin(
         node.props.steps = orderSteps(node, node.props.steps)
         setNodePositionProps(node.props.steps)
 
-        childNode.props.stepName =
-          childNode.props.label || camel2title(childNode.name)
+        const setStepName = () => {
+          childNode.props.stepName =
+            childNode.props.label || camel2title(childNode.name)
+        }
+        setStepName()
+        childNode.on('prop:label', setStepName)
         childNode.props.errorCount = 0
         childNode.props.blockingCount = 0
         childNode.props.isActiveStep = isFirstStep


### PR DESCRIPTION
## What changed

- Updates multi-step `stepName` whenever a child step’s `label` prop changes, instead of copying the label only once when the step is registered.
- Adds a regression that changes step labels after mount and verifies the tab label text updates, covering i18n/reactive label use cases.

## Verification

- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/multistep.spec.ts -t "#1377" --reporter verbose`
- `pnpm exec vitest run --config /tmp/formkit-vitest-ci.mts packages/addons/__tests__/multistep.spec.ts --reporter verbose`
- `pnpm vitest --typecheck.only --run`
- `node scripts/cli.mjs --script build addons` reached successful CJS/ESM addon bundles, then failed during DTS on the existing `@formkit/auto-animate` package exports/type resolution issue in `autoAnimatePlugin.ts`.

## Security

- No new inputs, storage, network, or data exposure paths. This only keeps existing display text in sync with reactive label props.

Closes #1377
