### PR TITLE
Fix Regenesis dark disabled submit border

### DIFF
--- a/packages/cli/__tests__/themeNormalize.spec.ts
+++ b/packages/cli/__tests__/themeNormalize.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { createHash } from 'crypto'
+import { normalizeGeneratedTheme } from '../src/themeNormalize'
+
+describe('normalizeGeneratedTheme', () => {
+  it('keeps Regenesis dark disabled submit borders aligned with the disabled background', () => {
+    const source = `/**
+  * @checksum - old-checksum
+  * @variables -
+  * @theme - regenesis
+  **/
+const classes = {
+  "submit__input": {
+    "dark:disabled:border-neutral-100": true,
+    "dark:disabled:bg-neutral-500": true
+  }
+}
+`
+
+    const normalized = normalizeGeneratedTheme('regenesis', source)
+    expect(normalized).toContain('"dark:disabled:border-neutral-500": true')
+    expect(normalized).not.toContain('dark:disabled:border-neutral-100')
+
+    const checksum = normalized.substring(
+      normalized.indexOf('@checksum -') + 12,
+      normalized.indexOf('\n', normalized.indexOf('@checksum -'))
+    )
+    const codeWithoutChecksum = normalized.replace(
+      `* @checksum - ${checksum}`,
+      '* @checksum -'
+    )
+    expect(createHash('sha256').update(codeWithoutChecksum).digest('hex')).toBe(
+      checksum
+    )
+  })
+
+  it('does not alter non-Regenesis theme output', () => {
+    const source = `/**
+  * @checksum - old-checksum
+  * @variables -
+  * @theme - other
+  **/
+"dark:disabled:border-neutral-100": true
+`
+
+    expect(normalizeGeneratedTheme('other', source)).toBe(source)
+  })
+})

--- a/packages/cli/src/theme.ts
+++ b/packages/cli/src/theme.ts
@@ -13,6 +13,7 @@ import open from 'open'
 import { parse as parseUrl } from 'url'
 import { token } from '@formkit/utils'
 import { getPort } from 'get-port-please'
+import { normalizeGeneratedTheme } from './themeNormalize'
 
 interface BuildThemeOptions {
   semantic: boolean
@@ -565,7 +566,7 @@ async function apiTheme(
   })
   if (res.ok) {
     const code = await res.text()
-    return code
+    return normalizeGeneratedTheme(themeName, code)
   } else {
     error(`Could not generate theme — ${res.statusText}`)
   }

--- a/packages/cli/src/themeNormalize.ts
+++ b/packages/cli/src/themeNormalize.ts
@@ -1,0 +1,39 @@
+import { createHash } from 'crypto'
+
+export function normalizeGeneratedTheme(themeName: string, code: string): string {
+  if (themeName !== 'regenesis' && themeName !== 'regenesis-tw3') {
+    return code
+  }
+
+  const normalized = code.replace(
+    /"dark:disabled:border-neutral-100": true/g,
+    '"dark:disabled:border-neutral-500": true'
+  )
+
+  return normalized === code
+    ? code
+    : updateGeneratedThemeChecksum(normalized)
+}
+
+function updateGeneratedThemeChecksum(code: string): string {
+  const checksum = extractChecksum(code)
+  const codeWithoutChecksum = code.replace(
+    `* @checksum - ${checksum}`,
+    '* @checksum -'
+  )
+  const newChecksum = createHash('sha256')
+    .update(codeWithoutChecksum)
+    .digest('hex')
+  return code.replace(
+    `* @checksum - ${checksum}`,
+    `* @checksum - ${newChecksum}`
+  )
+}
+
+function extractChecksum(theme: string): string {
+  const checksumStart = theme.indexOf('@checksum -')
+  if (checksumStart === -1) {
+    throw new Error('Unable to find checksum in theme file.')
+  }
+  return theme.substring(checksumStart + 12, theme.indexOf('\n', checksumStart))
+}


### PR DESCRIPTION
Closes #1391

## What changed
- Normalizes generated Regenesis and Regenesis TW3 theme output so dark disabled submit buttons use a neutral-500 border to match their neutral-500 disabled background instead of the current near-white neutral-100 border.
- Recomputes the generated theme checksum after normalization so future CLI theme edits do not appear as manual local modifications.
- Adds focused coverage for the normalization behavior and checksum update.

## Verification
- Passed: `pnpm vitest --config /tmp/formkit-vitest-ci.mts packages/cli/__tests__/themeNormalize.spec.ts --run`
- Passed: `pnpm vitest --typecheck.only --run`
- Partial: `node scripts/cli.mjs --script build cli` produced CJS/ESM bundles successfully, then failed DTS on the existing local install gap: `Cannot find module 'commander'`.
- Attempted: `pnpm vitest --config /tmp/formkit-vitest-ci.mts packages/cli/__tests__/cli.spec.ts --run`; this local worktree cannot collect that suite because package-local CLI dependency symlinks for `@formkit/theme-creator/stylesheet` / `open` are missing.

## Security
- No new dependencies, network targets, or user-controlled execution paths. The change only post-processes trusted theme API output for first-party Regenesis theme names.