### PR TITLE
Fix schema date partial backspace clearing

### DIFF
--- a/packages/vue/__tests__/FormKitSchema.spec.ts
+++ b/packages/vue/__tests__/FormKitSchema.spec.ts
@@ -2,7 +2,7 @@ import { reactive, nextTick, defineComponent, markRaw, ref } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'
 import { FormKitSchemaNode, FormKitSchemaDOMNode } from '@formkit/core'
 import { FormKitSchema } from '../src/FormKitSchema'
-import { createNode, resetRegistry } from '@formkit/core'
+import { createNode, getNode, resetRegistry } from '@formkit/core'
 import corePlugin from '../src/bindings'
 import { plugin } from '../src/plugin'
 import { defaultConfig } from '../src'
@@ -656,6 +656,39 @@ describe('parsing dom elements', () => {
       },
     })
     expect(wrapper.text()).toBe('0: a1: b2: c')
+  })
+
+  it('preserves native date values during partial delete input events', async () => {
+    const id = 'date-partial-delete'
+    const wrapper = mount(FormKitSchema, {
+      props: {
+        schema: [
+          {
+            $formkit: 'date',
+            id,
+            name: 'birthDate',
+            value: '2024-02-10',
+          },
+        ],
+      },
+      attachTo: document.body,
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+    const input = wrapper.find('input').element as HTMLInputElement
+    input.focus()
+    input.value = ''
+    input.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        inputType: 'deleteContentBackward',
+      })
+    )
+    await nextTick()
+
+    expect(getNode(id)?.value).toBe('2024-02-10')
+    wrapper.unmount()
   })
 
   it('can render the loop data inside the default slot when nested in an $el', async () => {

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -30,6 +30,14 @@ import {
 import { createObserver } from '@formkit/observer'
 import { FormKitPseudoProps } from '@formkit/core'
 
+const nativeDateInputTypes = new Set([
+  'date',
+  'datetime-local',
+  'month',
+  'time',
+  'week',
+])
+
 /**
  * A plugin that creates Vue-specific context object on each given node.
  *
@@ -282,7 +290,10 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
         )
       },
       DOMInput: (e: Event) => {
-        node.input((e.target as HTMLInputElement).value)
+        const target = e.target as HTMLInputElement
+        if (!isPartialNativeDateDelete(e, target, node._value)) {
+          node.input(target.value)
+        }
         node.emit('dom-input-event', e)
       },
     },
@@ -537,6 +548,22 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
     /* @ts-ignore */ // eslint-disable-line
     node = null
   })
+}
+
+function isPartialNativeDateDelete(
+  e: Event,
+  target: HTMLInputElement,
+  currentValue: unknown
+): boolean {
+  const inputType =
+    'inputType' in e && typeof e.inputType === 'string' ? e.inputType : ''
+  return (
+    inputType.startsWith('delete') &&
+    nativeDateInputTypes.has(target.type) &&
+    target.value === '' &&
+    target.ownerDocument?.activeElement === target &&
+    !empty(currentValue)
+  )
 }
 
 export default vueBindings


### PR DESCRIPTION
## What changed
- Ignores focused native date/time delete input events that report an empty value while the node still has a value.
- This prevents Firefox partial date-part deletion from syncing an empty string back into FormKit and clearing the entire native date field.
- Adds a schema-generated date input regression for a `deleteContentBackward` event with an existing date value.

## Verification
- `pnpm vitest packages/vue/__tests__/FormKitSchema.spec.ts --run -t "preserves native date values"`
- `pnpm vitest packages/vue/__tests__/FormKitSchema.spec.ts --run`
- `pnpm vitest packages/vue/__tests__/FormKit.spec.ts packages/vue/__tests__/FormKitSchema.spec.ts --run` *(FormKitSchema passed; FormKit.spec collection is blocked locally by the existing `@formkit/icons` resolution issue)*
- `pnpm build vue`

## Security
- Client-side event handling only; no new dependencies, network calls, storage, or credential handling.

Fixes #1553.