### PR TITLE
Load local TypeScript theme config files

### DIFF
--- a/packages/cli/src/theme.ts
+++ b/packages/cli/src/theme.ts
@@ -10,6 +10,7 @@ import prompts from 'prompts'
 import { createHash } from 'crypto'
 import ora, { Ora } from 'ora'
 import open from 'open'
+import createJiti from 'jiti'
 import { parse as parseUrl } from 'url'
 import { token } from '@formkit/utils'
 import { getPort } from 'get-port-please'
@@ -511,9 +512,13 @@ async function localTheme(
   const path = getPath(paths)
   if (!path) error(`Could not find ${themeName}.`)
 
-  const theme = (await import(path)) as { default: Theme<ThemeOptions> }
-  if (typeof theme !== 'object' || !theme.default) error('Invalid theme file.')
-  return theme.default
+  const jiti = createJiti(import.meta.url, { interopDefault: true })
+  const theme = (await jiti.import(path, {})) as
+    | Theme<ThemeOptions>
+    | { default?: Theme<ThemeOptions> }
+  const themeFunction = typeof theme === 'function' ? theme : theme.default
+  if (!themeFunction) error('Invalid theme file.')
+  return themeFunction
 }
 
 export function extractThemeData(


### PR DESCRIPTION
## What changed
- Uses `jiti` to load local theme files for the CLI theme command instead of native dynamic import.
- Preserves support for default-exported theme objects/functions while allowing `.ts` local config files to load under the published Node CLI.

Fixes #1534.

## Verification
- `pnpm vitest packages/cli/__tests__/cli.spec.ts --run`
- `pnpm vitest packages/cli/__tests__/cli.spec.ts packages/cli/__tests__/skill.spec.ts --run`
- `pnpm build cli`
- Built CLI smoke test from a temporary directory with `formkit.theme.config.ts` importing the local mock theme
- `git diff --check`

## Security
- No security-sensitive behavior changed; the CLI already executes user-provided local theme files, and this only restores TypeScript loading for that existing local-file path.