### PR TITLE
Fix keyboard activation for clickable icons

### DIFF
--- a/packages/inputs/src/sections/icon.ts
+++ b/packages/inputs/src/sections/icon.ts
@@ -7,7 +7,7 @@ import { createSection, FormKitSchemaExtendableSection } from '../createSection'
  */
 export const icon = (
   sectionKey: string,
-  el?: string
+  el?: string,
 ): FormKitSchemaExtendableSection => {
   return createSection(`${sectionKey}Icon`, () => {
     const rawIconProp = `_raw${sectionKey
@@ -20,6 +20,7 @@ export const icon = (
         class: `$classes.${sectionKey}Icon + " " + $classes.icon`,
         innerHTML: `$${rawIconProp}`,
         onClick: `$handlers.iconClick(${sectionKey})`,
+        onKeydown: `$handlers.iconKeydown && $handlers.iconKeydown(${sectionKey})`,
         role: `$fns.iconRole(${sectionKey})`,
         tabindex: `$fns.iconRole(${sectionKey}) === "button" && "0" || undefined`,
         for: {

--- a/packages/react/__tests__/FormKitIcon.spec.ts
+++ b/packages/react/__tests__/FormKitIcon.spec.ts
@@ -1,6 +1,6 @@
 import { createElement, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { FormKitIcon, FormKitProvider, defaultConfig } from '../src'
 
 const chevronIcon =
@@ -18,8 +18,8 @@ describe('FormKitIcon component (react)', () => {
         createElement(FormKitIcon, {
           icon: chevronIcon,
           iconLoader: (iconName) => iconName,
-        })
-      )
+        }),
+      ),
     )
 
     await waitFor(() => {
@@ -40,8 +40,8 @@ describe('FormKitIcon component (react)', () => {
         },
         createElement(FormKitIcon, {
           icon: 'libraryIcon',
-        })
-      )
+        }),
+      ),
     )
 
     await waitFor(() => {
@@ -66,21 +66,66 @@ describe('FormKitIcon component (react)', () => {
           'div',
           null,
           createElement(FormKitIcon, { icon }),
-          createElement('button', { onClick: () => setIcon('circleIcon') }, 'swap')
-        )
+          createElement(
+            'button',
+            { onClick: () => setIcon('circleIcon') },
+            'swap',
+          ),
+        ),
       )
     }
 
     const { container } = render(createElement(Host))
 
     await waitFor(() => {
-      expect(container.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 16 7')
+      expect(container.querySelector('svg')?.getAttribute('viewBox')).toBe(
+        '0 0 16 7',
+      )
     })
 
     fireEvent.click(container.querySelector('button') as HTMLButtonElement)
 
     await waitFor(() => {
-      expect(container.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 32 32')
+      expect(container.querySelector('svg')?.getAttribute('viewBox')).toBe(
+        '0 0 32 32',
+      )
     })
+  })
+
+  it('triggers click handlers with keyboard activation', async () => {
+    const onClick = vi.fn()
+    const { container } = render(
+      createElement(
+        FormKitProvider,
+        {
+          config: defaultConfig({
+            icons: {
+              libraryIcon: chevronIcon,
+            },
+          }),
+        },
+        createElement(FormKitIcon, {
+          icon: 'libraryIcon',
+          onClick,
+        }),
+      ),
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.formkit-icon svg')).toBeTruthy()
+    })
+
+    const icon = container.querySelector('.formkit-icon') as HTMLElement
+    expect(icon.getAttribute('role')).toBe('button')
+    expect(icon.getAttribute('tabindex')).toBe('0')
+
+    fireEvent.keyDown(icon, { key: 'Enter' })
+    expect(onClick).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(icon, { key: ' ' })
+    expect(onClick).toHaveBeenCalledTimes(2)
+
+    fireEvent.keyDown(icon, { key: 'Escape' })
+    expect(onClick).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/react/__tests__/inputs/checkbox.spec.ts
+++ b/packages/react/__tests__/inputs/checkbox.spec.ts
@@ -277,6 +277,15 @@ describe('multiple checkboxes (react)', () => {
     fireEvent.click(icon as HTMLElement)
 
     expect(onDecoratorIconClick).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(icon as HTMLElement, { key: 'Enter' })
+    expect(onDecoratorIconClick).toHaveBeenCalledTimes(2)
+
+    fireEvent.keyDown(icon as HTMLElement, { key: ' ' })
+    expect(onDecoratorIconClick).toHaveBeenCalledTimes(3)
+
+    fireEvent.keyDown(icon as HTMLElement, { key: 'Escape' })
+    expect(onDecoratorIconClick).toHaveBeenCalledTimes(3)
   })
 
   it('multi-checkboxes set array values immediately', () => {

--- a/packages/react/src/FormKitIcon.ts
+++ b/packages/react/src/FormKitIcon.ts
@@ -1,11 +1,15 @@
 import { createElement, useContext, useEffect, useMemo, useState } from 'react'
+import type { HTMLAttributes, KeyboardEvent } from 'react'
 import { FormKitPlugin } from '@formkit/core'
 import { FormKitIconLoader, createIconHandler } from '@formkit/themes'
 import { optionsSymbol } from './plugin'
 import { parentSymbol } from './context'
 import { useReactiveStore } from './reactiveStore'
 
-export interface FormKitIconProps {
+export interface FormKitIconProps extends Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  'children' | 'dangerouslySetInnerHTML'
+> {
   icon: string
   iconLoader?: FormKitIconLoader | null
   iconLoaderUrl?: ((iconName: string) => string) | null
@@ -13,7 +17,7 @@ export interface FormKitIconProps {
 
 function resolveSyncIcon(
   iconHandler: FormKitIconLoader | undefined,
-  iconName: string
+  iconName: string,
 ) {
   if (!iconHandler || typeof iconHandler !== 'function' || !iconName) {
     return undefined
@@ -24,22 +28,33 @@ function resolveSyncIcon(
 }
 
 export function FormKitIcon(props: FormKitIconProps) {
+  const {
+    icon: iconName,
+    iconLoader,
+    iconLoaderUrl,
+    className,
+    onClick,
+    onKeyDown,
+    role,
+    tabIndex,
+    ...spanAttrs
+  } = props
   const config = useContext(optionsSymbol)
   const parent = useContext(parentSymbol)
 
   useReactiveStore(parent?.context)
 
   const iconHandler: FormKitIconLoader | undefined = useMemo(() => {
-    if (props.iconLoader && typeof props.iconLoader === 'function') {
-      return createIconHandler(props.iconLoader)
+    if (iconLoader && typeof iconLoader === 'function') {
+      return createIconHandler(iconLoader)
     }
 
     if (parent && parent.props?.iconLoader) {
       return createIconHandler(parent.props.iconLoader)
     }
 
-    if (props.iconLoaderUrl && typeof props.iconLoaderUrl === 'function') {
-      return createIconHandler(undefined, props.iconLoaderUrl)
+    if (iconLoaderUrl && typeof iconLoaderUrl === 'function') {
+      return createIconHandler(undefined, iconLoaderUrl)
     }
 
     const iconPlugin = config?.plugins?.find((plugin) => {
@@ -50,20 +65,20 @@ export function FormKitIcon(props: FormKitIconProps) {
     }) as (FormKitPlugin & { iconHandler: FormKitIconLoader }) | undefined
 
     return iconPlugin?.iconHandler
-  }, [config?.plugins, parent, props.iconLoader, props.iconLoaderUrl])
+  }, [config?.plugins, iconLoader, iconLoaderUrl, parent])
 
   const [icon, setIcon] = useState<undefined | string>(() =>
-    resolveSyncIcon(iconHandler, props.icon)
+    resolveSyncIcon(iconHandler, iconName),
   )
 
   useEffect(() => {
-    if (!iconHandler || typeof iconHandler !== 'function' || !props.icon) {
+    if (!iconHandler || typeof iconHandler !== 'function' || !iconName) {
       setIcon(undefined)
       return
     }
 
     let isActive = true
-    const iconOrPromise = iconHandler(props.icon)
+    const iconOrPromise = iconHandler(iconName)
     if (iconOrPromise instanceof Promise) {
       iconOrPromise.then((iconValue) => {
         if (isActive) {
@@ -77,16 +92,34 @@ export function FormKitIcon(props: FormKitIconProps) {
     return () => {
       isActive = false
     }
-  }, [iconHandler, props.icon])
+  }, [iconHandler, iconName])
 
-  if (!props.icon || !icon) {
+  if (!iconName || !icon) {
     return null
   }
 
+  const clickable = typeof onClick === 'function'
+  const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (onKeyDown) onKeyDown(event)
+    if (!event.defaultPrevented && clickable && isKeyboardClick(event)) {
+      event.preventDefault()
+      event.currentTarget.click()
+    }
+  }
+
   return createElement('span', {
-    className: 'formkit-icon',
+    ...spanAttrs,
+    className: ['formkit-icon', className].filter(Boolean).join(' '),
+    role: role ?? (clickable ? 'button' : undefined),
+    tabIndex: tabIndex ?? (clickable ? 0 : undefined),
+    onClick,
+    onKeyDown: clickable ? handleKeyDown : onKeyDown,
     dangerouslySetInnerHTML: { __html: icon },
   })
+}
+
+function isKeyboardClick(event: KeyboardEvent): boolean {
+  return event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar'
 }
 
 export default FormKitIcon

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -42,7 +42,7 @@ export interface FormKitIconLoaderUrl {
  * @public
  */
 export function generateClasses(
-  classes: Record<string, Record<string, string>>
+  classes: Record<string, Record<string, string>>,
 ): Record<string, string | FormKitClasses | Record<string, boolean>> {
   const classesBySectionKey: Record<string, Record<string, any>> = {}
   Object.keys(classes).forEach((type) => {
@@ -78,7 +78,7 @@ export function generateClasses(
 function addClassesBySection(
   node: FormKitNode,
   _sectionKey: string,
-  classesByType: Record<string, () => string>
+  classesByType: Record<string, () => string>,
 ): string {
   const type = node.props.type
   const family = node.props.family
@@ -152,7 +152,7 @@ export function createThemePlugin(
   theme?: string,
   icons?: Record<string, string | undefined>,
   iconLoaderUrl?: FormKitIconLoaderUrl,
-  iconLoader?: FormKitIconLoader
+  iconLoader?: FormKitIconLoader,
 ): (node: FormKitNode) => any {
   if (icons) {
     // add any user-provided icons to the registry
@@ -181,15 +181,15 @@ export function createThemePlugin(
     node.addProps(['iconLoader', 'iconLoaderUrl'])
     node.props.iconHandler = createIconHandler(
       node.props?.iconLoader ? node.props.iconLoader : iconLoader,
-      node.props?.iconLoaderUrl ? node.props.iconLoaderUrl : iconLoaderUrl
+      node.props?.iconLoaderUrl ? node.props.iconLoaderUrl : iconLoaderUrl,
     )
     loadIconPropIcons(node, node.props.iconHandler)
 
     node.on('created', () => {
       // set up the `-icon` click handlers
       if (node?.context?.handlers) {
-        node.context.handlers.iconClick = (
-          sectionKey: string
+        const iconClick = (
+          sectionKey: string,
         ): ((e: MouseEvent) => void) | void => {
           const clickHandlerProp = `on${sectionKey
             .charAt(0)
@@ -201,6 +201,20 @@ export function createThemePlugin(
             }
           }
           return undefined
+        }
+        node.context.handlers.iconClick = iconClick
+        node.context.handlers.iconKeydown = (
+          sectionKey: string,
+        ): ((e: KeyboardEvent) => void) | void => {
+          if (!iconClick(sectionKey)) return undefined
+          return (e: KeyboardEvent) => {
+            if (isKeyboardClick(e)) {
+              e.preventDefault()
+              if (e.currentTarget instanceof HTMLElement) {
+                e.currentTarget.click()
+              }
+            }
+          }
         }
       }
       if (node?.context?.fns) {
@@ -218,6 +232,10 @@ export function createThemePlugin(
 
   themePlugin.iconHandler = createIconHandler(iconLoader, iconLoaderUrl)
   return themePlugin
+}
+
+function isKeyboardClick(e: KeyboardEvent): boolean {
+  return e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar'
 }
 
 /**
@@ -280,10 +298,10 @@ function loadTheme(theme: string) {
  */
 export function createIconHandler(
   iconLoader?: FormKitIconLoader,
-  iconLoaderUrl?: FormKitIconLoaderUrl
+  iconLoaderUrl?: FormKitIconLoaderUrl,
 ): FormKitIconLoader {
   return (
-    iconName: string | boolean
+    iconName: string | boolean,
   ): string | undefined | Promise<string | undefined> => {
     // bail if we got something that wasn't string
     if (typeof iconName !== 'string') return
@@ -337,7 +355,7 @@ export function createIconHandler(
 }
 
 function getIconFromStylesheet(
-  iconName: string
+  iconName: string,
 ): string | undefined | Promise<string | undefined> {
   if (!isClient) return
   if (themeHasLoaded) {
@@ -369,7 +387,7 @@ function loadStylesheetIcon(iconName: string) {
  */
 function getRemoteIcon(
   iconName: string,
-  iconLoaderUrl?: FormKitIconLoaderUrl
+  iconLoaderUrl?: FormKitIconLoaderUrl,
 ): Promise<string | undefined> | undefined {
   const formkitVersion = FORMKIT_VERSION.startsWith('__')
     ? 'latest'
@@ -398,7 +416,7 @@ function getRemoteIcon(
  */
 function loadIconPropIcons(
   node: FormKitNode,
-  iconHandler: FormKitIconLoader
+  iconHandler: FormKitIconLoader,
 ): void {
   const iconRegex = /^[a-zA-Z-]+(?:-icon|Icon)$/
   const iconProps = Object.keys(node.props).filter((prop) => {
@@ -415,7 +433,7 @@ function loadIconPropIcons(
 function loadPropIcon(
   node: FormKitNode,
   iconHandler: FormKitIconLoader,
-  sectionKey: string
+  sectionKey: string,
 ): Promise<void> | void {
   const iconName = node.props[sectionKey]
   const loadedIcon = iconHandler(iconName)

--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -1674,9 +1674,19 @@ describe('icons', () => {
         ],
       },
     })
-    wrapper.find('.formkit-prefix-icon').trigger('click')
+    const icon = wrapper.find('.formkit-prefix-icon')
+    icon.trigger('click')
     await new Promise((r) => setTimeout(r, 10))
     expect(iconClick).toHaveBeenCalledTimes(1)
+
+    await icon.trigger('keydown', { key: 'Enter' })
+    expect(iconClick).toHaveBeenCalledTimes(2)
+
+    await icon.trigger('keydown', { key: ' ' })
+    expect(iconClick).toHaveBeenCalledTimes(3)
+
+    await icon.trigger('keydown', { key: 'Escape' })
+    expect(iconClick).toHaveBeenCalledTimes(3)
   })
 })
 

--- a/packages/vue/__tests__/FormKitIcon.spec.ts
+++ b/packages/vue/__tests__/FormKitIcon.spec.ts
@@ -2,7 +2,7 @@ import FormKitIcon from '../src/FormKitIcon'
 import { plugin } from '../src/plugin'
 import { defaultConfig } from '../src'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 // const wait = (delay?: number) => new Promise((r) => setTimeout(r, delay ? delay : 0))
 
@@ -17,7 +17,7 @@ describe('FormKitIcon component', () => {
       },
     })
     expect(wrapper.html()).toStrictEqual(
-      '<span class="formkit-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 7"><path d="M8,6.5c-.13,0-.26-.05-.35-.15L3.15,1.85c-.2-.2-.2-.51,0-.71,.2-.2,.51-.2,.71,0l4.15,4.15L12.15,1.15c.2-.2,.51-.2,.71,0,.2,.2,.2,.51,0,.71l-4.5,4.5c-.1,.1-.23,.15-.35,.15Z" fill="currentColor"></path></svg></span>'
+      '<span class="formkit-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 7"><path d="M8,6.5c-.13,0-.26-.05-.35-.15L3.15,1.85c-.2-.2-.2-.51,0-.71,.2-.2,.51-.2,.71,0l4.15,4.15L12.15,1.15c.2-.2,.51-.2,.71,0,.2,.2,.2,.51,0,.71l-4.5,4.5c-.1,.1-.23,.15-.35,.15Z" fill="currentColor"></path></svg></span>',
     )
   })
 
@@ -41,7 +41,7 @@ describe('FormKitIcon component', () => {
       },
     })
     expect(wrapper.html()).toStrictEqual(
-      '<span class="formkit-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 7"><path d="M8,6.5c-.13,0-.26-.05-.35-.15L3.15,1.85c-.2-.2-.2-.51,0-.71,.2-.2,.51-.2,.71,0l4.15,4.15L12.15,1.15c.2-.2,.51-.2,.71,0,.2,.2,.2,.51,0,.71l-4.5,4.5c-.1,.1-.23,.15-.35,.15Z" fill="currentColor"></path></svg></span>'
+      '<span class="formkit-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 7"><path d="M8,6.5c-.13,0-.26-.05-.35-.15L3.15,1.85c-.2-.2-.2-.51,0-.71,.2-.2,.51-.2,.71,0l4.15,4.15L12.15,1.15c.2-.2,.51-.2,.71,0,.2,.2,.2,.51,0,.71l-4.5,4.5c-.1,.1-.23,.15-.35,.15Z" fill="currentColor"></path></svg></span>',
     )
   })
 
@@ -67,11 +67,48 @@ describe('FormKitIcon component', () => {
       },
     })
     expect(wrapper.html()).toStrictEqual(
-      '<span class="formkit-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 7"><path d="M8,6.5c-.13,0-.26-.05-.35-.15L3.15,1.85c-.2-.2-.2-.51,0-.71,.2-.2,.51-.2,.71,0l4.15,4.15L12.15,1.15c.2-.2,.51-.2,.71,0,.2,.2,.2,.51,0,.71l-4.5,4.5c-.1,.1-.23,.15-.35,.15Z" fill="currentColor"></path></svg></span>'
+      '<span class="formkit-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 7"><path d="M8,6.5c-.13,0-.26-.05-.35-.15L3.15,1.85c-.2-.2-.2-.51,0-.71,.2-.2,.51-.2,.71,0l4.15,4.15L12.15,1.15c.2-.2,.51-.2,.71,0,.2,.2,.2,.51,0,.71l-4.5,4.5c-.1,.1-.23,.15-.35,.15Z" fill="currentColor"></path></svg></span>',
     )
     await wrapper.setProps({ icon: 'circleIcon' })
     expect(wrapper.html()).toStrictEqual(
-      '<span class="formkit-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle fill="currentColor" cx="16" cy="16" r="16"></circle></svg></span>'
+      '<span class="formkit-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle fill="currentColor" cx="16" cy="16" r="16"></circle></svg></span>',
     )
+  })
+
+  it('triggers click handlers with keyboard activation', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(FormKitIcon, {
+      props: {
+        icon: `libraryIcon`,
+      },
+      attrs: {
+        onClick,
+      },
+      global: {
+        plugins: [
+          [
+            plugin,
+            defaultConfig({
+              icons: {
+                libraryIcon:
+                  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 7"><path d="M8,6.5c-.13,0-.26-.05-.35-.15L3.15,1.85c-.2-.2-.2-.51,0-.71,.2-.2,.51-.2,.71,0l4.15,4.15L12.15,1.15c.2-.2,.51-.2,.71,0,.2,.2,.2,.51,0,.71l-4.5,4.5c-.1,.1-.23,.15-.35,.15Z" fill="currentColor"/></svg>',
+              },
+            }),
+          ],
+        ],
+      },
+    })
+
+    expect(wrapper.attributes('role')).toBe('button')
+    expect(wrapper.attributes('tabindex')).toBe('0')
+
+    await wrapper.trigger('keydown', { key: 'Enter' })
+    expect(onClick).toHaveBeenCalledTimes(1)
+
+    await wrapper.trigger('keydown', { key: ' ' })
+    expect(onClick).toHaveBeenCalledTimes(2)
+
+    await wrapper.trigger('keydown', { key: 'Escape' })
+    expect(onClick).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/vue/src/FormKitIcon.ts
+++ b/packages/vue/src/FormKitIcon.ts
@@ -1,4 +1,4 @@
-import { h, ref, watch, defineComponent, inject, PropType } from 'vue'
+import { h, ref, watch, defineComponent, inject, PropType, useAttrs } from 'vue'
 import { optionsSymbol } from './plugin'
 import { parentSymbol } from './FormKit'
 import { FormKitPlugin } from '@formkit/core'
@@ -11,6 +11,7 @@ import { FormKitIconLoader, createIconHandler } from '@formkit/themes'
  */
 export const FormKitIcon = /* #__PURE__ */ defineComponent({
   name: 'FormKitIcon',
+  inheritAttrs: false,
   props: {
     icon: {
       type: String,
@@ -27,6 +28,7 @@ export const FormKitIcon = /* #__PURE__ */ defineComponent({
   },
   setup(props) {
     const icon = ref<undefined | string>(undefined)
+    const attrs = useAttrs()
     const config = inject(optionsSymbol, {})
     const parent = inject(parentSymbol, null)
     let iconHandler: FormKitIconLoader | undefined = undefined
@@ -72,19 +74,60 @@ export const FormKitIcon = /* #__PURE__ */ defineComponent({
       () => {
         loadIcon()
       },
-      { immediate: true }
+      { immediate: true },
     )
 
     return () => {
       if (props.icon && icon.value) {
-        return h('span', {
-          class: 'formkit-icon',
+        const {
+          class: iconClass,
+          onKeydown: onKeydownAttr,
+          onKeyDown: onKeyDownAttr,
+          ...passThroughAttrs
+        } = attrs
+        const clickable = hasEventHandler(passThroughAttrs.onClick)
+        const onKeydown = onKeydownAttr || onKeyDownAttr
+        const iconAttrs: Record<string, unknown> = {
+          ...passThroughAttrs,
+          class: ['formkit-icon', iconClass],
           innerHTML: icon.value,
-        })
+        }
+        if (clickable) {
+          iconAttrs.role = attrs.role || 'button'
+          if (attrs.tabindex === undefined && attrs.tabIndex === undefined) {
+            iconAttrs.tabindex = '0'
+          }
+          iconAttrs.onKeydown = (e: KeyboardEvent) => {
+            callEventHandler(onKeydown, e)
+            if (!e.defaultPrevented && isKeyboardClick(e)) {
+              e.preventDefault()
+              if (e.currentTarget instanceof HTMLElement) {
+                e.currentTarget.click()
+              }
+            }
+          }
+        }
+        return h('span', iconAttrs)
       }
       return null
     }
   },
 })
+
+function hasEventHandler(handler: unknown): boolean {
+  return typeof handler === 'function' || Array.isArray(handler)
+}
+
+function callEventHandler(handler: unknown, event: Event) {
+  if (Array.isArray(handler)) {
+    handler.forEach((eventHandler) => callEventHandler(eventHandler, event))
+  } else if (typeof handler === 'function') {
+    handler(event)
+  }
+}
+
+function isKeyboardClick(e: KeyboardEvent): boolean {
+  return e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar'
+}
 
 export default FormKitIcon


### PR DESCRIPTION
What changed
- Adds Enter/Space keyboard activation for FormKit schema icons that already expose icon click handlers.
- Adds keyboard activation, default button semantics, and focusability for clickable Vue and React `FormKitIcon` components while preserving explicit role/tabindex/key handlers.
- Adds Vue and React regression coverage for input icon handlers and standalone `FormKitIcon` keyboard activation.

Verification
- `pnpm build icons` (local package entry prerequisite for the Vue FormKit spec)
- `pnpm vitest packages/vue/__tests__/FormKitIcon.spec.ts packages/vue/__tests__/FormKit.spec.ts packages/react/__tests__/FormKitIcon.spec.ts packages/react/__tests__/inputs/checkbox.spec.ts --run`
- `pnpm build inputs`
- `pnpm build themes`
- `pnpm build vue`
- `pnpm build react`
- `git diff --check`

Security
- No new dependencies, network calls, or HTML execution paths. Keyboard handlers only dispatch the existing click behavior for already-clickable icons.

Fixes #1479