### PR TITLE
Emit childRemoved for synced list removals

### DIFF
--- a/packages/core/__tests__/lists.spec.ts
+++ b/packages/core/__tests__/lists.spec.ts
@@ -252,6 +252,28 @@ describe('synced lists', () => {
     expect(list.children[1]).toBe(nodes[2])
   })
 
+  it('emits childRemoved when removing a synced list node via value', async () => {
+    const nodes = [
+      createNode({ value: 'A' }),
+      createNode({ value: 'B' }),
+      createNode({ value: 'C' }),
+    ]
+    const list = createNode<string[]>({
+      type: 'list',
+      value: ['A', 'B', 'C'],
+      sync: true,
+      children: nodes,
+    })
+    const listener = vi.fn()
+    list.on('childRemoved', listener)
+
+    list.input(['A', 'C'], false)
+    await list.settled
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0].payload).toBe(nodes[1])
+  })
+
   it('can remove a node in synced list by splicing the value', async () => {
     const nodes = [
       createNode({

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -2129,6 +2129,7 @@ function syncListNodes(node: FormKitNode, context: FormKitContext) {
         if (!parent || isPlaceholder(parent)) return
         parent.ledger.unmerge(child)
         child._c.parent = null
+        node.emit('childRemoved', child)
         child.destroy()
       }
     })


### PR DESCRIPTION
## What changed
- Emit the parent `childRemoved` event when `syncListNodes` removes unused synced-list children during value hydration.
- Preserve the existing manual ledger detach/destroy behavior so list values are not mutated a second time.
- Add regression coverage for value-driven synced list removal.

## Verification
- `pnpm vitest packages/core/__tests__/lists.spec.ts --run`
- `pnpm vitest packages/core --run`
- `pnpm build core`
- `git diff --check`

## Security
- No dependency, network, or HTML execution changes. This only restores a lifecycle event during local node-tree updates.

Fixes #1473.