### PR TITLE
Fix select placeholder state for grouped options

### DIFF
--- a/packages/inputs/src/features/selects.ts
+++ b/packages/inputs/src/features/selects.ts
@@ -38,14 +38,22 @@ function isSelected(
  */
 function containsValue(
   options: FormKitOptionsListWithGroups,
-  value: unknown
+  value: unknown,
+  ignorePlaceholder = false
 ): boolean {
   return options.some((option) => {
     if (isGroupOption(option)) {
-      return containsValue(option.options, value)
+      return containsValue(option.options, value, ignorePlaceholder)
     } else {
-      return (
-        ('__original' in option ? option.__original : option.value) === value
+      if (
+        ignorePlaceholder &&
+        option.attrs &&
+        'data-is-placeholder' in option.attrs
+      )
+        return false
+      return eq(
+        '__original' in option ? option.__original : option.value,
+        value
       )
     }
   })
@@ -167,15 +175,7 @@ export default function select(node: FormKitNode): void {
       node.context.fns.isSelected = isSelected.bind(null, node)
       node.context.fns.showPlaceholder = (value: unknown, placeholder) => {
         if (!Array.isArray(node.props.options)) return false
-        const hasMatchingValue = node.props.options.some(
-          (option: FormKitOptionsItem) => {
-            if (option.attrs && 'data-is-placeholder' in option.attrs)
-              return false
-            const optionValue =
-              '__original' in option ? option.__original : option.value
-            return eq(value, optionValue)
-          }
-        )
+        const hasMatchingValue = containsValue(node.props.options, value, true)
         return placeholder && !hasMatchingValue ? true : undefined
       }
     }

--- a/packages/vue/__tests__/inputs/select.spec.ts
+++ b/packages/vue/__tests__/inputs/select.spec.ts
@@ -451,6 +451,39 @@ describe('select', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('removes placeholder state when selecting a grouped option', async () => {
+    const id = `a${token()}`
+    const wrapper = mount(FormKit, {
+      props: {
+        id,
+        type: 'select',
+        delay: 0,
+        placeholder: 'Select one',
+        options: [
+          {
+            group: 'Letters',
+            options: {
+              a: 'A',
+              b: 'B',
+            },
+          },
+        ],
+      },
+      global: {
+        plugins: [[plugin, defaultConfig]],
+      },
+    })
+
+    expect(wrapper.find('select').attributes('data-placeholder')).toBe('true')
+    await wrapper.find('select').setValue('b')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(getNode(id)?.value).toBe('b')
+    expect(wrapper.find('select').attributes('data-placeholder')).toBe(
+      undefined
+    )
+  })
+
   it('can render a group of options with masked values', async () => {
     const id = `a${token()}`
     const wrapper = mount(


### PR DESCRIPTION
## What changed
- Make select placeholder-state matching recurse through option groups instead of checking only top-level options.
- Ignore the injected placeholder option when deciding whether the current value matches a real option.
- Use FormKit equality matching for placeholder-state lookup, consistent with arbitrary option values.
- Add regression coverage for selecting an option inside an optgroup with a placeholder configured.

## Verification
- `pnpm vitest packages/vue/__tests__/inputs/select.spec.ts --run -t "grouped option"`
- `pnpm vitest packages/vue/__tests__/inputs/select.spec.ts --run`
- `pnpm build inputs`
- `pnpm build vue`
- `git diff --check`

## Security
- No dependency, network, or HTML execution changes. This only adjusts local select option-value matching for placeholder state.

Fixes #1453.