### PR TITLE
Fix messages section schema override types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,7 @@ export type {
   FormKitSchemaFormKit,
   FormKitSchemaMeta,
   FormKitSchemaNode,
+  FormKitSchemaNodeExtension,
   FormKitSchemaProps,
   FormKitSchemaTextNode,
   FormKitSchemaDefinition,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -158,6 +158,28 @@ export type FormKitSchemaNode =
   | FormKitSchemaFormKit
 
 /**
+ * A partial schema node used to extend or unset section schema properties.
+ *
+ * @public
+ */
+export type FormKitSchemaNodeExtension =
+  | FormKitSchemaTextNode
+  | (Omit<Partial<FormKitSchemaDOMNode>, '$el'> & {
+      $el?: FormKitSchemaDOMNode['$el'] | undefined
+      $cmp?: undefined
+      $formkit?: undefined
+    })
+  | (Omit<Partial<FormKitSchemaComponent>, '$cmp'> & {
+      $cmp?: FormKitSchemaComponent['$cmp'] | undefined
+      $el?: undefined
+      $formkit?: undefined
+    })
+  | (Partial<FormKitSchemaFormKit> & {
+      $el?: undefined
+      $cmp?: undefined
+    })
+
+/**
  * An entire schema object or subtree from any entry point. Can be a single
  * node, an array of nodes, or a conditional. This is the type that is passed to
  * the FormKitSchema constructor.
@@ -176,7 +198,7 @@ export type FormKitSchemaDefinition =
  */
 export interface FormKitSchemaComposable {
   (
-    extendWith?: Partial<FormKitSchemaNode>,
+    extendWith?: FormKitSchemaNodeExtension,
     children?: string | FormKitSchemaNode[] | FormKitSchemaCondition,
     ...args: any[]
   ): FormKitSchemaNode
@@ -188,7 +210,7 @@ export interface FormKitSchemaComposable {
  */
 export type FormKitSectionsSchema = Record<
   string,
-  Partial<FormKitSchemaNode> | FormKitSchemaCondition | null
+  FormKitSchemaNodeExtension | FormKitSchemaCondition | null
 >
 
 /**

--- a/packages/inputs/src/compose.ts
+++ b/packages/inputs/src/compose.ts
@@ -12,6 +12,7 @@ import {
   warn,
   FormKitSchemaDOMNode,
   FormKitSectionsSchema,
+  FormKitSchemaNodeExtension,
 } from '@formkit/core'
 import {
   isSchemaObject,
@@ -381,7 +382,7 @@ export function $for(
 /*@__NO_SIDE_EFFECTS__*/
 export function $extend(
   section: FormKitSchemaExtendableSection,
-  extendWith: Partial<FormKitSchemaNode>
+  extendWith: FormKitSchemaNodeExtension
 ): FormKitSchemaExtendableSection {
   const extendable = (extensions: FormKitSectionsSchema) => {
     const node = section({})

--- a/packages/inputs/src/createSection.ts
+++ b/packages/inputs/src/createSection.ts
@@ -9,6 +9,7 @@ import {
   FormKitSchemaFormKit,
   FormKitSectionsSchema,
   FormKitSchemaCondition,
+  FormKitSchemaNodeExtension,
 } from '@formkit/core'
 
 /**
@@ -158,7 +159,7 @@ export function createRoot(
  * @public
  */
 export function isSchemaObject(
-  schema: Partial<FormKitSchemaNode> | null
+  schema: FormKitSchemaNodeExtension | FormKitSchemaCondition | null
 ): schema is
   | FormKitSchemaDOMNode
   | FormKitSchemaComponent
@@ -184,7 +185,7 @@ export function isSchemaObject(
 /*@__NO_SIDE_EFFECTS__*/
 export function extendSchema(
   schema: FormKitSchemaNode,
-  extension: Partial<FormKitSchemaNode> | null = {}
+  extension: FormKitSchemaNodeExtension | FormKitSchemaCondition | null = {}
 ): FormKitSchemaNode {
   if (typeof schema === 'string') {
     return isSchemaObject(extension) || typeof extension === 'string'

--- a/packages/react/src/FormKitMessages.ts
+++ b/packages/react/src/FormKitMessages.ts
@@ -2,8 +2,7 @@ import { ReactNode, createElement, useContext, useEffect, useMemo } from 'react'
 import { createSection } from '@formkit/inputs'
 import {
   FormKitNode,
-  FormKitSchemaNode,
-  FormKitSchemaCondition,
+  FormKitSectionsSchema,
 } from '@formkit/core'
 import { undefine } from '@formkit/utils'
 import FormKitSchema from './FormKitSchema'
@@ -29,10 +28,7 @@ const definition = messages(message('$message.value'))
 
 export interface FormKitMessagesProps {
   node?: FormKitNode
-  sectionsSchema?: Record<
-    string,
-    Partial<FormKitSchemaNode> | FormKitSchemaCondition
-  >
+  sectionsSchema?: FormKitSectionsSchema
   defaultPosition?: 'true' | 'false' | boolean | undefined
   library?: Record<string, any>
   children?: ReactNode

--- a/packages/react/src/FormKitSummary.ts
+++ b/packages/react/src/FormKitSummary.ts
@@ -9,8 +9,7 @@ import { createSection, localize } from '@formkit/inputs'
 import { token } from '@formkit/utils'
 import {
   FormKitNode,
-  FormKitSchemaNode,
-  FormKitSchemaCondition,
+  FormKitSectionsSchema,
   FormKitFrameworkContext,
 } from '@formkit/core'
 import FormKitSchema from './FormKitSchema'
@@ -76,10 +75,7 @@ export interface FormKitSummaryMessage {
 export interface FormKitSummaryProps {
   node?: FormKitNode
   forceShow?: boolean
-  sectionsSchema?: Record<
-    string,
-    Partial<FormKitSchemaNode> | FormKitSchemaCondition
-  >
+  sectionsSchema?: FormKitSectionsSchema
   onShow?: (summaries: Array<FormKitSummaryMessage>) => void
 }
 

--- a/packages/vue/__tests__/FormKitMessages.test-d.tsx
+++ b/packages/vue/__tests__/FormKitMessages.test-d.tsx
@@ -1,0 +1,25 @@
+import { describe, it, assertType } from 'vitest'
+import { defineComponent } from 'vue'
+import { FormKitMessages } from '../src/FormKitMessages'
+
+describe('FormKitMessages types', () => {
+  it('allows section schema extensions to unset $el when using $cmp', () => {
+    type Props = InstanceType<typeof FormKitMessages>['$props']
+
+    assertType<Props>({
+      library: {
+        Notification: defineComponent({}),
+      },
+      sectionsSchema: {
+        message: {
+          $el: undefined,
+          $cmp: 'Notification',
+          props: {
+            type: 'error',
+          },
+          children: '$message.value',
+        },
+      },
+    })
+  })
+})

--- a/packages/vue/src/FormKitMessages.ts
+++ b/packages/vue/src/FormKitMessages.ts
@@ -10,8 +10,7 @@ import {
 import { createSection } from '@formkit/inputs'
 import {
   FormKitNode,
-  FormKitSchemaNode,
-  FormKitSchemaCondition,
+  FormKitSectionsSchema,
 } from '@formkit/core'
 import { parentSymbol } from './FormKit'
 import FormKitSchema from './FormKitSchema'
@@ -54,9 +53,7 @@ export const FormKitMessages = /* #__PURE__ */ defineComponent({
       required: false,
     },
     sectionsSchema: {
-      type: Object as PropType<
-        Record<string, Partial<FormKitSchemaNode> | FormKitSchemaCondition>
-      >,
+      type: Object as PropType<FormKitSectionsSchema>,
       default: {},
     },
     defaultPosition: {

--- a/packages/vue/src/FormKitSummary.ts
+++ b/packages/vue/src/FormKitSummary.ts
@@ -3,8 +3,7 @@ import { createSection } from '@formkit/inputs'
 import { token } from '@formkit/utils'
 import {
   FormKitNode,
-  FormKitSchemaNode,
-  FormKitSchemaCondition,
+  FormKitSectionsSchema,
   FormKitFrameworkContext,
 } from '@formkit/core'
 import { parentSymbol } from './FormKit'
@@ -93,9 +92,7 @@ export const FormKitSummary = /* #__PURE__ */ defineComponent({
       default: false,
     },
     sectionsSchema: {
-      type: Object as PropType<
-        Record<string, Partial<FormKitSchemaNode> | FormKitSchemaCondition>
-      >,
+      type: Object as PropType<FormKitSectionsSchema>,
       default: {},
     },
   },


### PR DESCRIPTION
## What changed
- Add a public `FormKitSchemaNodeExtension` type for section-schema overrides so discriminator properties like `$el` can be explicitly unset.
- Use `FormKitSectionsSchema` for Vue/React `FormKitMessages` and `FormKitSummary` `sectionsSchema` props instead of narrower inline partial schema-node records.
- Keep normal schema node types strict while allowing section overrides such as `{ $el: undefined, $cmp: 'Notification' }`.
- Add a type regression for `FormKitMessages` custom message components.

## Verification
- `pnpm vitest packages/vue/__tests__/FormKitMessages.test-d.tsx --typecheck.only --run`
- `pnpm vitest packages/vue/__tests__/FormKitMessages.test-d.tsx packages/vue/__tests__/inputs/*.test-d.tsx --typecheck.only --run`
- `pnpm vitest packages/vue/__tests__/FormKit.spec.ts --run -t "library on FormKitMessages"`
- `pnpm vitest packages/inputs/__tests__/compose.spec.ts --run`
- `pnpm build core`
- `pnpm build inputs`
- `pnpm build vue`
- `pnpm build react`
- `git diff --check`

## Security
- No dependency, network, runtime execution, or HTML parsing changes. This is a TypeScript type-surface change plus type coverage.

Fixes #1450.