### PR TITLE
Treat null boolean props as absent

### DIFF
--- a/packages/react/__tests__/inputs/radio.spec.ts
+++ b/packages/react/__tests__/inputs/radio.spec.ts
@@ -176,9 +176,9 @@ describe('radios (react)', () => {
     })
   })
 
-  it('applies undefined to a false disabled prop', async () => {
+  it('applies undefined to a false or null disabled prop', async () => {
     function Host() {
-      const [disabled, setDisabled] = useState('false')
+      const [disabled, setDisabled] = useState<string | null>('false')
       return createElement(
         'div',
         null,
@@ -195,6 +195,14 @@ describe('radios (react)', () => {
           'button',
           {
             type: 'button',
+            onClick: () => setDisabled(null),
+          },
+          'null'
+        ),
+        createElement(
+          'button',
+          {
+            type: 'button',
             onClick: () => setDisabled('true'),
           },
           'disable'
@@ -207,6 +215,12 @@ describe('radios (react)', () => {
     expect(container.querySelector('.formkit-outer')?.getAttribute('data-disabled')).toBeNull()
 
     fireEvent.click(container.querySelector('button') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('.formkit-outer')?.getAttribute('data-disabled')).toBeNull()
+    })
+
+    fireEvent.click(container.querySelectorAll('button')[1] as HTMLButtonElement)
 
     await waitFor(() => {
       expect(container.querySelector('.formkit-outer')?.getAttribute('data-disabled')).toBe('true')

--- a/packages/utils/__tests__/utils.spec.ts
+++ b/packages/utils/__tests__/utils.spec.ts
@@ -554,6 +554,9 @@ describe('undefine', () => {
   it('undefines undefined', () => {
     expect(undefine(undefined)).toBe(undefined)
   })
+  it('undefines null', () => {
+    expect(undefine(null)).toBe(undefined)
+  })
   it('undefines the string false', () => {
     expect(undefine('false')).toBe(undefined)
   })

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -744,9 +744,12 @@ export function getAt(obj: any, addr: string): unknown {
  * @public
  */
 export function undefine(value: unknown): true | undefined {
-  return value !== undefined && value !== 'false' && value !== false
-    ? true
-    : undefined
+  const shouldDefine =
+    value !== undefined &&
+    value !== null &&
+    value !== 'false' &&
+    value !== false
+  return shouldDefine ? true : undefined
 }
 
 /**

--- a/packages/vue/__tests__/inputs/radio.spec.ts
+++ b/packages/vue/__tests__/inputs/radio.spec.ts
@@ -215,8 +215,8 @@ describe('radios', () => {
     expect(getNode(id)!.value).toEqual(null)
   })
 
-  it('applies undefined to a "false" disabled prop', async () => {
-    const disabled = ref('false')
+  it('applies undefined to a false or null disabled prop', async () => {
+    const disabled = ref<string | null>('false')
     const wrapper = mount(
       {
         setup() {
@@ -235,6 +235,11 @@ describe('radios', () => {
         ...global,
       }
     )
+    expect(wrapper.find('.formkit-outer').attributes('data-disabled')).toBe(
+      undefined
+    )
+    disabled.value = null
+    await new Promise((r) => setTimeout(r, 10))
     expect(wrapper.find('.formkit-outer').attributes('data-disabled')).toBe(
       undefined
     )


### PR DESCRIPTION
## What changed
- Update `undefine` so `null` is treated like `undefined`, `false`, and `'false'` for presence-style boolean props.
- Preserve existing behavior where empty-string boolean attributes still resolve to `true`.
- Add utility coverage plus Vue and React radio disabled-prop regressions for `null`.

## Verification
- `pnpm vitest packages/utils/__tests__/utils.spec.ts --run -t "undefine"`
- `pnpm vitest packages/vue/__tests__/inputs/radio.spec.ts --run -t "false or null disabled"`
- `pnpm vitest packages/react/__tests__/inputs/radio.spec.ts --run -t "false or null disabled"`
- `pnpm vitest packages/utils/__tests__/utils.spec.ts --run`
- `pnpm vitest packages/vue/__tests__/inputs/radio.spec.ts --run`
- `pnpm vitest packages/react/__tests__/inputs/radio.spec.ts --run`
- `pnpm build utils`
- `pnpm build inputs`
- `pnpm build react`
- `pnpm build vue`
- `git diff --check`

## Security
- No dependency, network, runtime execution, or HTML parsing changes. This only changes boolean-prop normalization for `null` values.

Fixes #1442.