### PR TITLE
fix: preserve remounted same-name group values

### DIFF
--- a/packages/core/__tests__/node.spec.ts
+++ b/packages/core/__tests__/node.spec.ts
@@ -1260,6 +1260,34 @@ describe('value propagation in a node tree', () => {
     })
   })
 
+  it('preserves a replacement child value when removing another child with the same name', () => {
+    const redirect = createNode({
+      type: 'group',
+      name: 'en',
+      children: [createNode({ name: 'redirect_url', value: 'google.com.ua' })],
+    })
+    const message = createNode({
+      type: 'group',
+      name: 'en',
+      children: [
+        createNode({ name: 'success_message', value: 'Success message' }),
+      ],
+    })
+    const parent = createNode({
+      type: 'group',
+      children: [redirect],
+    })
+
+    parent.add(message)
+    parent.remove(redirect)
+
+    expect(parent.value).toStrictEqual({
+      en: {
+        success_message: 'Success message',
+      },
+    })
+  })
+
   it('can re-arrange the order of a list’s values', async () => {
     const food = createNode({
       type: 'list',

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -2002,8 +2002,22 @@ function hydrate(node: FormKitNode, context: FormKitContext): FormKitNode {
   // For "synced" lists the underlying nodes need to be synced to their values
   // before hydration.
   if (node.type === 'list' && node.sync) syncListNodes(node, context)
+  // Frameworks can briefly mount a same-name replacement before unmounting the
+  // old node. In that overlap, the children remain the source of truth.
+  const duplicateNames = new Set<PropertyKey>()
+  if (node.type !== 'list') {
+    const childNames = new Set<PropertyKey>()
+    context.children.forEach((child) => {
+      if (childNames.has(child.name)) duplicateNames.add(child.name)
+      childNames.add(child.name)
+    })
+  }
   context.children.forEach((child) => {
     if (typeof _value !== 'object') return
+    if (duplicateNames.has(child.name) && !child.props.mergeStrategy) {
+      partial(context, { name: child.name, value: child.value })
+      return
+    }
     if (child.name in _value) {
       // In this case, the parent has a value to give to the child, so we
       // perform a down-tree synchronous input which will cascade values down
@@ -2513,9 +2527,12 @@ function removeChild(
       parent = parent.parent
     }
     if (!preserve) {
+      const sibling = context.children.find(
+        (sibling) => sibling.name === child.name
+      )
       node.calm({
         name: node.type === 'list' ? childIndex : child.name,
-        value: valueRemoved,
+        value: sibling && node.type !== 'list' ? sibling.value : valueRemoved,
       })
     } else {
       node.calm()

--- a/packages/vue/__tests__/inputs/group.spec.ts
+++ b/packages/vue/__tests__/inputs/group.spec.ts
@@ -427,4 +427,99 @@ describe('clearing values', () => {
     await new Promise((r) => setTimeout(r, 25))
     expect(wrapper.find('pre').html()).toMatchSnapshot()
   })
+
+  it('re-initializes a remounted group in a child component (#1433)', async () => {
+    const formId = token()
+    const ChildComponent = defineComponent({
+      data() {
+        return {
+          action: 'message',
+          options: [
+            {
+              value: 'message',
+              label: 'Message',
+            },
+            {
+              value: 'redirect',
+              label: 'Redirect',
+            }
+          ],
+          success_message: 'Success message',
+          redirect_url: 'google.com.ua',
+        }
+      },
+      template: `
+        <div>
+          <FormKit
+            type="select"
+            name="action"
+            label="Action"
+            v-model="action"
+            :options="options"
+          />
+
+          <template v-if="action === 'message'">
+            <FormKit type="group" name="en" key="message-group">
+              <FormKit
+                key="message-field"
+                type="text"
+                name="success_message"
+                label="Success message"
+                :value="success_message"
+              />
+            </FormKit>
+          </template>
+
+          <template v-if="action === 'redirect'">
+            <FormKit type="group" name="en" key="redirect-group">
+              <FormKit
+                key="redirect-field"
+                type="text"
+                name="redirect_url"
+                label="Redirect URL"
+                :value="redirect_url"
+              />
+            </FormKit>
+          </template>
+        </div>`,
+    })
+    const wrapper = mount(
+      defineComponent({
+        components: { ChildComponent },
+        template: `
+          <FormKit type="form" id="${formId}">
+            <ChildComponent />
+          </FormKit>`,
+      }),
+      {
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+
+    await wrapper.find('select').setValue('redirect')
+    await new Promise((r) => setTimeout(r, 25))
+    expect(getNode(formId)!.value).toMatchObject({
+      action: 'redirect',
+      en: {
+        redirect_url: 'google.com.ua',
+      }
+    })
+    expect(
+      (getNode(formId)!.value as Record<string, any>).en
+    ).not.toHaveProperty('success_message')
+
+    await wrapper.find('select').setValue('message')
+    await new Promise((r) => setTimeout(r, 25))
+    expect(getNode(formId)!.value).toMatchObject({
+      action: 'message',
+      en: {
+        success_message: 'Success message',
+      }
+    })
+    expect(
+      (getNode(formId)!.value as Record<string, any>).en
+    ).not.toHaveProperty('redirect_url')
+  })
 })


### PR DESCRIPTION
## What changed
- Treat temporary same-name child overlap during hydration as child-owned state unless the field is using mergeStrategy sync.
- Preserve the replacement sibling value when removing the old same-name child, instead of deleting the parent key after the replacement has initialized.
- Add core and Vue regressions for the `#1433` conditional child-component remount case, including checks that inactive branch fields are not retained.

## Verification
- `pnpm vitest packages/core/__tests__/node.spec.ts --run`
- `pnpm vitest packages/vue/__tests__/inputs/group.spec.ts --run`
- `pnpm vitest packages/vue/__tests__/vModel.spec.ts --run`
- `pnpm vitest packages/vue/__tests__/FormKit.spec.ts --run`
- `pnpm build core`
- `pnpm build vue`
- `git diff --check`

## Security
- No dependency, network, runtime execution, or HTML parsing changes. This only changes FormKit node value reconciliation during same-name child replacement.

Fixes #1433
