### PR TITLE
fix: default dynamic select options

### DIFF
--- a/packages/inputs/src/features/selects.ts
+++ b/packages/inputs/src/features/selects.ts
@@ -118,6 +118,21 @@ function firstValue(options: FormKitOptionsListWithGroups): unknown {
 }
 
 /**
+ * Determines if a select should default to its first option.
+ * @param node - A formkit node.
+ * @param value - The current value of the node.
+ */
+function shouldSelectFirstOption(node: FormKitNode, value: unknown): boolean {
+  return !!(
+    !node.props.placeholder &&
+    value === undefined &&
+    Array.isArray(node.props?.options) &&
+    node.props.options.length &&
+    !undefine(node.props?.attrs?.multiple)
+  )
+}
+
+/**
  * Converts the options prop to usable values.
  * @param node - A formkit node.
  * @public
@@ -181,14 +196,14 @@ export default function select(node: FormKitNode): void {
     }
   })
 
+  node.on('prop:options', () => {
+    if (shouldSelectFirstOption(node, node._value)) {
+      node.input(firstValue(node.props.options), false)
+    }
+  })
+
   node.hook.input((value, next) => {
-    if (
-      !node.props.placeholder &&
-      value === undefined &&
-      Array.isArray(node.props?.options) &&
-      node.props.options.length &&
-      !undefine(node.props?.attrs?.multiple)
-    ) {
+    if (shouldSelectFirstOption(node, value)) {
       value = firstValue(node.props.options)
     }
     return next(value)

--- a/packages/vue/__tests__/inputs/select.spec.ts
+++ b/packages/vue/__tests__/inputs/select.spec.ts
@@ -199,6 +199,40 @@ describe('select', () => {
     expect(wrapper.find('select').element.value).toBe('foo')
   })
 
+  it('selects the first dynamically loaded value when no value or placeholder is specified (#1432)', async () => {
+    const id = token()
+    const wrapper = mount(
+      {
+        data() {
+          return {
+            options: [] as Array<{ label: string; value: string }>,
+          }
+        },
+        template: `
+          <FormKit
+            id="${id}"
+            type="select"
+            name="country"
+            :options="options"
+          />`,
+      },
+      {
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+    const node = getNode(id)!
+    expect(node.value).toBeUndefined()
+
+    wrapper.vm.options = [{ label: 'First option', value: 'First value' }]
+    await nextTick()
+    await node.settled
+
+    expect(node.value).toBe('First value')
+    expect(wrapper.find('select').element.value).toBe('First value')
+  })
+
   it('does not select the first value when multiple', () => {
     const wrapper = mount(FormKit, {
       props: {


### PR DESCRIPTION
## What changed
- Reuse the select first-option defaulting predicate for both initial input normalization and later options updates.
- When a non-multiple select has no placeholder and no current value, default to the first option after dynamically loaded options are assigned.
- Add a Vue select regression for the dynamically loaded single-option case from `#1432`.

## Verification
- `pnpm vitest packages/vue/__tests__/inputs/select.spec.ts --run -t "dynamically loaded"`
- `pnpm vitest packages/vue/__tests__/inputs/select.spec.ts --run`
- `pnpm vitest packages/inputs/__tests__/features.spec.ts --run`
- `pnpm vitest packages/vue/__tests__/inputs/select.spec.ts --run -t "multiple|placeholder|v-model"`
- `pnpm build inputs`
- `pnpm build vue`
- `git diff --check`

## Security
- No dependency, network, runtime execution, or HTML parsing changes. This only updates select value defaulting when options props change.

Fixes #1432
