### PR TITLE
Fix stale Vue DOM input events after node destroy

### DIFF
--- a/packages/vue/__tests__/FormKit.spec.ts
+++ b/packages/vue/__tests__/FormKit.spec.ts
@@ -2072,6 +2072,30 @@ describe('exposures', () => {
     )
   })
 
+  it('ignores stale DOM input events after the node is destroyed (#1702)', () => {
+    const id = token()
+    const wrapper = mount(
+      {
+        template: `<FormKit id="${id}" />`,
+      },
+      {
+        global: {
+          plugins: [[plugin, defaultConfig]],
+        },
+      }
+    )
+    const node = getNode(id)
+    const handler = node?.context?.handlers.DOMInput
+    const input = document.createElement('input')
+    const event = new Event('input')
+    input.value = 'late input'
+    Object.defineProperty(event, 'target', { value: input })
+
+    wrapper.unmount()
+
+    expect(() => handler?.(event)).not.toThrow()
+  })
+
   it('debounces the input event (not fired on mount) and not the inputRaw event', async () => {
     const wrapper = mount(FormKit, {
       props: {

--- a/packages/vue/src/bindings.ts
+++ b/packages/vue/src/bindings.ts
@@ -282,6 +282,7 @@ const vueBindings: FormKitPlugin = function vueBindings(node) {
         )
       },
       DOMInput: (e: Event) => {
+        if (!node) return
         node.input((e.target as HTMLInputElement).value)
         node.emit('dom-input-event', e)
       },


### PR DESCRIPTION
Fixes #1702.

## What changed
- Added a null guard to the Vue DOM input handler so stale input events that arrive after node teardown are ignored.
- Added a regression test that captures the handler, unmounts the input, and verifies a late DOM input event does not throw.

## Verification
- pnpm test packages/vue/__tests__/FormKit.spec.ts --run -t "1702"
- pnpm test packages/vue/__tests__/FormKit.spec.ts packages/vue/__tests__/createInput.spec.ts packages/vue/__tests__/inputs/text.spec.ts --run
- pnpm build vue
- git diff --check

## Security
- No new dependencies, network access, or dynamic code execution paths were added. The change only guards a stale local event handler after teardown.
- GitHub Actions Tests workflow_dispatch passed on stacked head `3ececa1a`: https://github.com/formkit/formkit/actions/runs/25714824013