### PR TITLE
Fix repeater infinite loop when toggling disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Co-located validation, self-structuring data, composability, and a compact single-component API<br>that makes it easy for coding agents to reason about complex forms without boilerplate or guesswork.
 
-**React** · **Vue** &nbsp;—&nbsp; Trusted by NBC, Nike, Bosch, Walmart, and thousands of teams that ship at scale.
+**React** · **Vue** &nbsp;—&nbsp; Trusted by NBC, Nike, Bosch, Anthem Blue Cross, and thousands of teams that ship at scale.
 
 [Documentation](https://formkit.com) &nbsp;&middot;&nbsp; [Get Started](https://formkit.com/getting-started/installation) &nbsp;&middot;&nbsp; [Discord](https://discord.gg/Vhu97pAC76)
 

--- a/packages/core/__tests__/lists.spec.ts
+++ b/packages/core/__tests__/lists.spec.ts
@@ -545,4 +545,63 @@ describe('synced lists', () => {
     expect(list.children[2]).toBe(nodes[2])
     expect(list.children[2].value).toBe('C')
   })
+
+  it('reuses the slot when a synced child re-mounts over an existing node (#1758)', async () => {
+    const list = createNode<Array<{ x: string }>>({
+      type: 'list',
+      value: [{ x: 'A' }],
+      sync: true,
+      children: [
+        createNode({
+          type: 'group',
+          children: [createNode({ name: 'x', value: 'A' })],
+        }),
+      ],
+    })
+    await list.settled
+    expect(list.children).toHaveLength(1)
+    const originalUid = list.children[0].uid
+
+    // Re-mount where the new node is added before the old one is removed.
+    const replacement = createNode({
+      type: 'group',
+      index: 0,
+      parent: list,
+      children: [createNode({ name: 'x', value: 'A' })],
+    })
+    await list.settled
+    expect(list.children).toHaveLength(1)
+    expect(list.value).toEqual([{ x: 'A' }])
+    expect(replacement.uid).toBe(originalUid)
+  })
+
+  it('reuses the uid of a just-removed synced child on re-mount (#1758)', async () => {
+    const list = createNode<Array<{ x: string }>>({
+      type: 'list',
+      value: [{ x: 'A' }],
+      sync: true,
+      children: [
+        createNode({
+          type: 'group',
+          children: [createNode({ name: 'x', value: 'A' })],
+        }),
+      ],
+    })
+    await list.settled
+    const originalUid = list.children[0].uid
+
+    // Re-mount the other way round: old node removed first, then replacement
+    // added back at the same index in the same tick.
+    list.children[0].destroy()
+    const replacement = createNode({
+      type: 'group',
+      index: 0,
+      parent: list,
+      children: [createNode({ name: 'x', value: 'A' })],
+    })
+    await list.settled
+    expect(list.children).toHaveLength(1)
+    expect(list.value).toEqual([{ x: 'A' }])
+    expect(replacement.uid).toBe(originalUid)
+  })
 })

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1637,6 +1637,11 @@ export const valueMoved = Symbol('moved')
  */
 export const valueInserted = Symbol('inserted')
 
+// uids of synced-list children removed this tick, by parent + old index. Lets
+// addChild hand the same uid to a re-mounted child so its render key doesn't
+// change (see #1758). Cleared next microtask.
+const recentlyRemovedSyncUids = new WeakMap<FormKitNode, Map<number, symbol>>()
+
 /**
  * A simple type guard to determine if the context being evaluated is a list
  * type.
@@ -2401,7 +2406,25 @@ function addChild(
         // remove that replace it with the real node (the current child).
         child._c.uid = existingNode.uid
         parentContext.children.splice(listIndex, 1, child)
+      } else if (existingNode && parent.sync) {
+        // Synced lists always have a placeholder waiting for a mounting child,
+        // so a real node sitting here means the framework re-mounted and put the
+        // new child in before pulling the old one out. Take over its slot and
+        // uid instead of inserting a duplicate, which would grow the value and
+        // spin up an endless re-mount loop (#1758).
+        child._c.uid = existingNode.uid
+        parentContext.children.splice(listIndex, 1, child)
       } else {
+        // Same re-mount, opposite order: the old child left first, so the slot's
+        // empty. Reuse its uid if we stashed one this tick so the key holds.
+        if (!existingNode && parent.sync) {
+          const removedUids = recentlyRemovedSyncUids.get(parent)
+          const reusableUid = removedUids?.get(listIndex)
+          if (reusableUid) {
+            child._c.uid = reusableUid
+            removedUids?.delete(listIndex)
+          }
+        }
         parentContext.children.splice(listIndex, 0, child)
       }
 
@@ -2502,6 +2525,17 @@ function removeChild(
 ) {
   const childIndex = context.children.indexOf(child)
   if (childIndex !== -1) {
+    if (node.sync && node.type === 'list') {
+      // Hang onto the uid in case this is a re-mount and addChild is about to
+      // add the replacement back at the same index (#1758).
+      let removedUids = recentlyRemovedSyncUids.get(node)
+      if (!removedUids) {
+        removedUids = new Map()
+        recentlyRemovedSyncUids.set(node, removedUids)
+      }
+      removedUids.set(childIndex, child.uid)
+      queueMicrotask(() => removedUids?.delete(childIndex))
+    }
     if (child.isSettled) node.disturb()
     context.children.splice(childIndex, 1)
     // If an ancestor uses the preserve prop, then we are expected to not remove


### PR DESCRIPTION
Closes #1758 

If a repeater has draggable + the up/down/remove controls all bound to something like `!disabled`, toggling disabled crashes the page with "Maximum recursive updates exceeded".

Cause: the controls and drag handle disappearing makes Vue re-mount the row. In a synced list each re-mount makes a brand new node with a new id, used as the render key. New key means another re-mount, which makes another new id... and round it goes.

Fix: keeps the id stable across a re-mount, so the key doesn't change and the loop never starts. Handles both orders Vue can do it in (new row added before the old one is removed, and the other way round).

* Added two tests covering both cases. Confirmed they fail without the fix and pass with it
* Tested by hand in the browser with the real Pro repeater from the issue: toggling back and forth a bunch of times no longer crashes, and adding/removing/reordering rows still works.